### PR TITLE
fix(pos): embed register gates in shell

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3987 nodes · 3559 edges · 1453 communities detected
+- 3992 nodes · 3566 edges · 1453 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1575,28 +1575,28 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 21 - "Community 21"
+Cohesion: 0.2
+Nodes (13): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionTransactionPatch() (+5 more)
+
+### Community 22 - "Community 22"
 Cohesion: 0.26
 Nodes (15): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername(), getStaffCredentialByStaffProfileIdWithCtx() (+7 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.13
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
-
-### Community 26 - "Community 26"
-Cohesion: 0.21
-Nodes (12): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionTransactionPatch() (+4 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.27
@@ -1663,20 +1663,20 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 43 - "Community 43"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 44 - "Community 44"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 46 - "Community 46"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 47 - "Community 47"
 Cohesion: 0.18
@@ -1764,27 +1764,27 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 68 - "Community 68"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 69 - "Community 69"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
-
-### Community 70 - "Community 70"
-Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
+
+### Community 71 - "Community 71"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 72 - "Community 72"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 73 - "Community 73"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 74 - "Community 74"
 Cohesion: 0.36
@@ -1979,20 +1979,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 122 - "Community 122"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 123 - "Community 123"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 124 - "Community 124"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 125 - "Community 125"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 126 - "Community 126"
 Cohesion: 0.33
@@ -2007,16 +2007,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 129 - "Community 129"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 130 - "Community 130"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 131 - "Community 131"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 132 - "Community 132"
 Cohesion: 0.33
@@ -2027,104 +2027,104 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 134 - "Community 134"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 135 - "Community 135"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 136 - "Community 136"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 146 - "Community 146"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.7
-Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 149 - "Community 149"
 Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
 ### Community 150 - "Community 150"
-Cohesion: 0.5
-Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 151 - "Community 151"
 Cohesion: 0.5
-Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
+Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
 ### Community 152 - "Community 152"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 154 - "Community 154"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 155 - "Community 155"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 158 - "Community 158"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 159 - "Community 159"
 Cohesion: 0.4
@@ -2132,7 +2132,7 @@ Nodes (0):
 
 ### Community 160 - "Community 160"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.4
@@ -2167,12 +2167,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 169 - "Community 169"
-Cohesion: 0.6
-Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
+Cohesion: 0.4
+Nodes (1): Header()
 
 ### Community 170 - "Community 170"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
 
 ### Community 171 - "Community 171"
 Cohesion: 0.4
@@ -2187,76 +2187,76 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 174 - "Community 174"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.4
-Nodes (1): MockImage
+Nodes (0):
 
 ### Community 176 - "Community 176"
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
+### Community 177 - "Community 177"
+Cohesion: 0.4
+Nodes (1): MockImage
+
+### Community 178 - "Community 178"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 179 - "Community 179"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 180 - "Community 180"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 181 - "Community 181"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 182 - "Community 182"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 183 - "Community 183"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 186 - "Community 186"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 187 - "Community 187"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 188 - "Community 188"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 190 - "Community 190"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 190 - "Community 190"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 191 - "Community 191"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 192 - "Community 192"
 Cohesion: 0.5
@@ -2267,104 +2267,104 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 194 - "Community 194"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 196 - "Community 196"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 198 - "Community 198"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 199 - "Community 199"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 201 - "Community 201"
-Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 204 - "Community 204"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 205 - "Community 205"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 206 - "Community 206"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 208 - "Community 208"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 207 - "Community 207"
+### Community 209 - "Community 209"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 208 - "Community 208"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 209 - "Community 209"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 210 - "Community 210"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 211 - "Community 211"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 212 - "Community 212"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 213 - "Community 213"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 213 - "Community 213"
+### Community 215 - "Community 215"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 214 - "Community 214"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 215 - "Community 215"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 216 - "Community 216"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 218 - "Community 218"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.5
@@ -2379,44 +2379,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 222 - "Community 222"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 224 - "Community 224"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 225 - "Community 225"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.67
-Nodes (2): getSummaryAmount(), getSummaryLabel()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 230 - "Community 230"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 231 - "Community 231"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getSummaryAmount(), getSummaryLabel()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.5
@@ -2439,24 +2439,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 237 - "Community 237"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 238 - "Community 238"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 238 - "Community 238"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 240 - "Community 240"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 241 - "Community 241"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 241 - "Community 241"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.5
@@ -2467,36 +2467,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 244 - "Community 244"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 245 - "Community 245"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 251 - "Community 251"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 252 - "Community 252"
 Cohesion: 0.5
@@ -2523,55 +2523,55 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 260 - "Community 260"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 262 - "Community 262"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 263 - "Community 263"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 265 - "Community 265"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 266 - "Community 266"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 267 - "Community 267"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 268 - "Community 268"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 269 - "Community 269"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 270 - "Community 270"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 271 - "Community 271"
@@ -2615,44 +2615,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 281 - "Community 281"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 282 - "Community 282"
 Cohesion: 1.0
 Nodes (2): buildRegisterState(), getRegisterState()
 
-### Community 282 - "Community 282"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 284 - "Community 284"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 287 - "Community 287"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 287 - "Community 287"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 290 - "Community 290"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 290 - "Community 290"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.67
@@ -2663,36 +2663,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 293 - "Community 293"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 298 - "Community 298"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 299 - "Community 299"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 299 - "Community 299"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 300 - "Community 300"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
@@ -2707,24 +2707,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
@@ -2732,19 +2732,19 @@ Nodes (0):
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 312 - "Community 312"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 313 - "Community 313"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 313 - "Community 313"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
@@ -2755,8 +2755,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -712,6 +712,18 @@
       "weight": 1
     },
     {
+      "_src": "cashierauthdialog_cashierauthdialog",
+      "_tgt": "cashierauthdialog_getstaffdisplayname",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cashierauthdialog_getstaffdisplayname",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L132",
+      "target": "cashierauthdialog_cashierauthdialog",
+      "weight": 1
+    },
+    {
       "_src": "cataloggateway_useconvexproductidlookup",
       "_tgt": "cataloggateway_mapproductbyidresult",
       "confidence": "EXTRACTED",
@@ -1067,7 +1079,7 @@
       "relation": "calls",
       "source": "closeouts_asboolean",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L212",
+      "source_location": "L233",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -1079,7 +1091,7 @@
       "relation": "calls",
       "source": "closeouts_asnumber",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L208",
+      "source_location": "L229",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -1091,7 +1103,7 @@
       "relation": "calls",
       "source": "closeouts_asrecord",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L206",
+      "source_location": "L227",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -7187,7 +7199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L170",
+      "source_location": "L191",
       "target": "closeouts_asboolean",
       "weight": 1
     },
@@ -7199,7 +7211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L174",
+      "source_location": "L195",
       "target": "closeouts_asnumber",
       "weight": 1
     },
@@ -7211,7 +7223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L162",
+      "source_location": "L183",
       "target": "closeouts_asrecord",
       "weight": 1
     },
@@ -7223,7 +7235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L224",
+      "source_location": "L245",
       "target": "closeouts_buildregistersessioncloseoutreview",
       "weight": 1
     },
@@ -7235,7 +7247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L360",
+      "source_location": "L381",
       "target": "closeouts_cancelpendingapprovalifneeded",
       "weight": 1
     },
@@ -7247,7 +7259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L205",
+      "source_location": "L226",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -7259,7 +7271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L278",
+      "source_location": "L299",
       "target": "closeouts_listregistersessionsforcloseout",
       "weight": 1
     },
@@ -7271,7 +7283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L308",
+      "source_location": "L329",
       "target": "closeouts_liststaffnames",
       "weight": 1
     },
@@ -7283,7 +7295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L183",
+      "source_location": "L204",
       "target": "closeouts_persistregistersessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -7295,7 +7307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L325",
+      "source_location": "L346",
       "target": "closeouts_staffprofilecanreviewcloseoutvariance",
       "weight": 1
     },
@@ -7307,7 +7319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L178",
+      "source_location": "L199",
       "target": "closeouts_trimoptional",
       "weight": 1
     },
@@ -10259,7 +10271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L243",
+      "source_location": "L256",
       "target": "registersessions_buildclosedregistersessionpatch",
       "weight": 1
     },
@@ -10295,7 +10307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L214",
+      "source_location": "L227",
       "target": "registersessions_buildregistersessiondepositpatch",
       "weight": 1
     },
@@ -10309,6 +10321,18 @@
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
       "source_location": "L147",
       "target": "registersessions_buildregistersessiontransactionpatch",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "_tgt": "registersessions_buildreopenedregistersessionpatch",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L214",
+      "target": "registersessions_buildreopenedregistersessionpatch",
       "weight": 1
     },
     {
@@ -10331,7 +10355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L269",
+      "source_location": "L282",
       "target": "registersessions_findconflictingregistersession",
       "weight": 1
     },
@@ -10367,7 +10391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L546",
+      "source_location": "L579",
       "target": "registersessions_recordregistersessiondepositwithctx",
       "weight": 1
     },
@@ -18335,7 +18359,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1415",
+      "source_location": "L1413",
       "target": "registersessionview_errormessage",
       "weight": 1
     },
@@ -18659,7 +18683,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L31",
+      "source_location": "L24",
       "target": "expensecompletion_expensecompletion",
       "weight": 1
     },
@@ -19973,14 +19997,14 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "_tgt": "cashierauthdialog_authenticatestaff",
+      "_tgt": "cashierauthdialog_cashierauthdialog",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L48",
-      "target": "cashierauthdialog_authenticatestaff",
+      "source_location": "L33",
+      "target": "cashierauthdialog_cashierauthdialog",
       "weight": 1
     },
     {
@@ -19991,7 +20015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L23",
+      "source_location": "L24",
       "target": "cashierauthdialog_getstaffdisplayname",
       "weight": 1
     },
@@ -20537,13 +20561,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "_tgt": "posregisterview_cashierauthworkspace",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L102",
+      "target": "posregisterview_cashierauthworkspace",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "_tgt": "posregisterview_handlecmdk",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L141",
+      "source_location": "L190",
       "target": "posregisterview_handlecmdk",
       "weight": 1
     },
@@ -20555,7 +20591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L60",
+      "source_location": "L61",
       "target": "posregisterview_productlookupemptystate",
       "weight": 1
     },
@@ -20567,7 +20603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L28",
+      "source_location": "L29",
       "target": "posregisterview_usecollapsesidebarforposflow",
       "weight": 1
     },
@@ -20723,8 +20759,44 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L12",
+      "source_location": "L17",
       "target": "registerdrawergate_cashcontrolsbutton",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "_tgt": "registerdrawergate_formatcurrency",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L45",
+      "target": "registerdrawergate_formatcurrency",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "_tgt": "registerdrawergate_getvariancetone",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L53",
+      "target": "registerdrawergate_getvariancetone",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "_tgt": "registerdrawergate_handlecloseoutsubmit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L70",
+      "target": "registerdrawergate_handlecloseoutsubmit",
       "weight": 1
     },
     {
@@ -20735,7 +20807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L45",
+      "source_location": "L66",
       "target": "registerdrawergate_handlesubmit",
       "weight": 1
     },
@@ -22163,7 +22235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L157",
+      "source_location": "L158",
       "target": "staffauthenticationdialog_handlekeydown",
       "weight": 1
     },
@@ -22175,7 +22247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L104",
+      "source_location": "L105",
       "target": "staffauthenticationdialog_handlesubmit",
       "weight": 1
     },
@@ -25799,7 +25871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L165",
+      "source_location": "L176",
       "target": "useregisterviewmodel_test_deferred",
       "weight": 1
     },
@@ -25811,7 +25883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L86",
+      "source_location": "L90",
       "target": "useregisterviewmodel_combinepaymentsbymethod",
       "weight": 1
     },
@@ -25823,7 +25895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L106",
+      "source_location": "L110",
       "target": "useregisterviewmodel_createpaymentid",
       "weight": 1
     },
@@ -25835,7 +25907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L58",
+      "source_location": "L62",
       "target": "useregisterviewmodel_hascustomerdetails",
       "weight": 1
     },
@@ -25847,7 +25919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L73",
+      "source_location": "L77",
       "target": "useregisterviewmodel_mapsessioncustomer",
       "weight": 1
     },
@@ -25859,7 +25931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L118",
+      "source_location": "L122",
       "target": "useregisterviewmodel_presentoperatorerror",
       "weight": 1
     },
@@ -25871,7 +25943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L113",
+      "source_location": "L117",
       "target": "useregisterviewmodel_trimoptional",
       "weight": 1
     },
@@ -25883,7 +25955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L122",
+      "source_location": "L126",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -34499,7 +34571,7 @@
       "relation": "calls",
       "source": "registersessions_assertvalidregistersessiontransition",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L256",
+      "source_location": "L269",
       "target": "registersessions_buildclosedregistersessionpatch",
       "weight": 1
     },
@@ -34511,7 +34583,7 @@
       "relation": "calls",
       "source": "registersessions_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L263",
+      "source_location": "L276",
       "target": "registersessions_buildclosedregistersessionpatch",
       "weight": 1
     },
@@ -34564,6 +34636,18 @@
       "weight": 1
     },
     {
+      "_src": "registersessions_buildreopenedregistersessionpatch",
+      "_tgt": "registersessions_assertvalidregistersessiontransition",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessions_assertvalidregistersessiontransition",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L217",
+      "target": "registersessions_buildreopenedregistersessionpatch",
+      "weight": 1
+    },
+    {
       "_src": "registersessions_normalizeregistersessionidentity",
       "_tgt": "registersessions_trimoptional",
       "confidence": "EXTRACTED",
@@ -34583,7 +34667,7 @@
       "relation": "calls",
       "source": "registersessions_buildregistersessiondepositpatch",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L566",
+      "source_location": "L599",
       "target": "registersessions_recordregistersessiondepositwithctx",
       "weight": 1
     },
@@ -40199,7 +40283,7 @@
       "relation": "calls",
       "source": "staffauthenticationdialog_handlesubmit",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L159",
+      "source_location": "L160",
       "target": "staffauthenticationdialog_handlekeydown",
       "weight": 1
     },
@@ -42527,7 +42611,7 @@
       "relation": "calls",
       "source": "useexpenseregisterviewmodel_getcashierdisplayname",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L591",
+      "source_location": "L585",
       "target": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "weight": 1
     },
@@ -42539,7 +42623,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L238",
+      "source_location": "L254",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -42551,7 +42635,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_trimoptional",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L129",
+      "source_location": "L134",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -47217,56 +47301,56 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "label": "RegisterDrawerGate.tsx",
+      "norm_label": "registerdrawergate.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
       "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
+      "id": "registerdrawergate_cashcontrolsbutton",
+      "label": "CashControlsButton()",
+      "norm_label": "cashcontrolsbutton()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L17"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
+      "id": "registerdrawergate_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L45"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
+      "id": "registerdrawergate_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L53"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
+      "id": "registerdrawergate_handlecloseoutsubmit",
+      "label": "handleCloseoutSubmit()",
+      "norm_label": "handlecloseoutsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L70"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
+      "id": "registerdrawergate_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1210,
@@ -47361,56 +47445,56 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
     },
     {
       "community": 1220,
@@ -47505,56 +47589,56 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1230,
@@ -47649,56 +47733,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1240,
@@ -47793,56 +47877,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1250,
@@ -47937,56 +48021,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1260,
@@ -48081,56 +48165,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
     },
     {
       "community": 1270,
@@ -48225,56 +48309,56 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
     },
     {
       "community": 1280,
@@ -48369,56 +48453,56 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
     },
     {
       "community": 1290,
@@ -48553,7 +48637,7 @@
       "label": "errorMessage()",
       "norm_label": "errormessage()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1415"
+      "source_location": "L1413"
     },
     {
       "community": 13,
@@ -48693,56 +48777,56 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
     },
     {
       "community": 1300,
@@ -48837,56 +48921,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L49"
     },
     {
       "community": 1310,
@@ -48981,56 +49065,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L28"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L37"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L12"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L6"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L49"
     },
     {
       "community": 1320,
@@ -49125,56 +49209,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1330,
@@ -49269,56 +49353,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1340,
@@ -49413,56 +49497,56 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
+      "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1350,
@@ -49557,56 +49641,56 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L83"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 1360,
@@ -49701,56 +49785,56 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1370,
@@ -49845,56 +49929,56 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1380,
@@ -49989,55 +50073,55 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -50313,55 +50397,55 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -50457,55 +50541,55 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -50601,55 +50685,55 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1"
     },
     {
@@ -50745,55 +50829,55 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1"
     },
     {
@@ -50889,55 +50973,55 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
       "source_location": "L1"
     },
     {
@@ -51033,47 +51117,56 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L81"
     },
     {
       "community": 1450,
@@ -51105,6 +51198,51 @@
     {
       "community": 146,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
       "norm_label": "validateexpenseitembelongstosession()",
@@ -51112,7 +51250,7 @@
       "source_location": "L135"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -51121,7 +51259,7 @@
       "source_location": "L39"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -51130,7 +51268,7 @@
       "source_location": "L19"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -51139,7 +51277,7 @@
       "source_location": "L92"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -51148,7 +51286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
       "label": "products.ts",
@@ -51157,7 +51295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "products_calculatetotalavailablecount",
       "label": "calculateTotalAvailableCount()",
@@ -51166,7 +51304,7 @@
       "source_location": "L70"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "products_calculatetotalinventorycount",
       "label": "calculateTotalInventoryCount()",
@@ -51175,7 +51313,7 @@
       "source_location": "L65"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "products_generatebarcode",
       "label": "generateBarcode()",
@@ -51184,7 +51322,7 @@
       "source_location": "L42"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "products_generatesku",
       "label": "generateSKU()",
@@ -51193,7 +51331,7 @@
       "source_location": "L18"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -51202,7 +51340,7 @@
       "source_location": "L77"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestascommandwithctx",
       "label": "decideApprovalRequestAsCommandWithCtx()",
@@ -51211,7 +51349,7 @@
       "source_location": "L158"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -51220,7 +51358,7 @@
       "source_location": "L27"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "approvalrequests_mapdecideapprovalrequesterror",
       "label": "mapDecideApprovalRequestError()",
@@ -51229,57 +51367,12 @@
       "source_location": "L106"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
       "norm_label": "approvalrequests.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
       "source_location": "L1"
     },
     {
@@ -51456,6 +51549,51 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "inventorymovements_buildinventorymovement",
       "label": "buildInventoryMovement()",
       "norm_label": "buildinventorymovement()",
@@ -51463,7 +51601,7 @@
       "source_location": "L25"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "inventorymovements_matchesexistingmovement",
       "label": "matchesExistingMovement()",
@@ -51472,7 +51610,7 @@
       "source_location": "L51"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "inventorymovements_recordinventorymovementwithctx",
       "label": "recordInventoryMovementWithCtx()",
@@ -51481,7 +51619,7 @@
       "source_location": "L70"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "inventorymovements_summarizeinventorymovements",
       "label": "summarizeInventoryMovements()",
@@ -51490,7 +51628,7 @@
       "source_location": "L36"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
       "label": "inventoryMovements.ts",
@@ -51499,7 +51637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
       "label": "paymentAllocations.ts",
@@ -51508,7 +51646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "paymentallocations_buildpaymentallocation",
       "label": "buildPaymentAllocation()",
@@ -51517,7 +51655,7 @@
       "source_location": "L27"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "paymentallocations_matchesexistingallocation",
       "label": "matchesExistingAllocation()",
@@ -51526,7 +51664,7 @@
       "source_location": "L57"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "paymentallocations_recordpaymentallocationwithctx",
       "label": "recordPaymentAllocationWithCtx()",
@@ -51535,7 +51673,7 @@
       "source_location": "L78"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "paymentallocations_summarizepaymentallocations",
       "label": "summarizePaymentAllocations()",
@@ -51544,7 +51682,7 @@
       "source_location": "L41"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -51553,7 +51691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -51562,7 +51700,7 @@
       "source_location": "L16"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -51571,7 +51709,7 @@
       "source_location": "L29"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -51580,7 +51718,7 @@
       "source_location": "L12"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -51589,7 +51727,7 @@
       "source_location": "L8"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -51598,7 +51736,7 @@
       "source_location": "L255"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -51607,7 +51745,7 @@
       "source_location": "L282"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -51616,7 +51754,7 @@
       "source_location": "L239"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -51625,7 +51763,7 @@
       "source_location": "L269"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -51634,7 +51772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -51643,7 +51781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -51652,7 +51790,7 @@
       "source_location": "L11"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -51661,7 +51799,7 @@
       "source_location": "L21"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -51670,7 +51808,7 @@
       "source_location": "L87"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -51679,7 +51817,7 @@
       "source_location": "L65"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -51688,7 +51826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -51697,7 +51835,7 @@
       "source_location": "L115"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -51706,7 +51844,7 @@
       "source_location": "L90"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -51715,7 +51853,7 @@
       "source_location": "L74"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -51724,7 +51862,7 @@
       "source_location": "L70"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -51733,7 +51871,7 @@
       "source_location": "L89"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -51742,7 +51880,7 @@
       "source_location": "L765"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -51751,7 +51889,7 @@
       "source_location": "L37"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -51760,7 +51898,7 @@
       "source_location": "L60"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -51769,7 +51907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -51778,7 +51916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -51787,7 +51925,7 @@
       "source_location": "L124"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -51796,7 +51934,7 @@
       "source_location": "L67"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -51805,7 +51943,7 @@
       "source_location": "L106"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -51814,7 +51952,7 @@
       "source_location": "L73"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -51823,7 +51961,7 @@
       "source_location": "L61"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -51832,7 +51970,7 @@
       "source_location": "L75"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -51841,7 +51979,7 @@
       "source_location": "L116"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -51850,58 +51988,13 @@
       "source_location": "L20"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
       "norm_label": "navbar.tsx",
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L287"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L230"
     },
     {
       "community": 16,
@@ -52077,47 +52170,47 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L287"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L230"
     },
     {
       "community": 161,
@@ -52482,47 +52575,47 @@
     {
       "community": 169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "label": "ProductEntry.tsx",
-      "norm_label": "productentry.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productentry_handleclearsearch",
-      "label": "handleClearSearch()",
-      "norm_label": "handleclearsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L270"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "productentry_handleopenquickadd",
-      "label": "handleOpenQuickAdd()",
-      "norm_label": "handleopenquickadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L275"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "productentry_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L304"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "productentry_resetquickaddform",
-      "label": "resetQuickAddForm()",
-      "norm_label": "resetquickaddform()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L295"
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 17,
@@ -52689,6 +52782,96 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "label": "ProductEntry.tsx",
+      "norm_label": "productentry.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productentry_handleclearsearch",
+      "label": "handleClearSearch()",
+      "norm_label": "handleclearsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L270"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productentry_handleopenquickadd",
+      "label": "handleOpenQuickAdd()",
+      "norm_label": "handleopenquickadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L275"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productentry_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L304"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productentry_resetquickaddform",
+      "label": "resetQuickAddForm()",
+      "norm_label": "resetquickaddform()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L295"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L190"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
       "norm_label": "receivingview.tsx",
@@ -52696,7 +52879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -52705,7 +52888,7 @@
       "source_location": "L37"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -52714,7 +52897,7 @@
       "source_location": "L46"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -52723,7 +52906,7 @@
       "source_location": "L33"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -52732,7 +52915,7 @@
       "source_location": "L72"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -52741,7 +52924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -52750,7 +52933,7 @@
       "source_location": "L157"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -52759,7 +52942,7 @@
       "source_location": "L230"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -52768,7 +52951,7 @@
       "source_location": "L322"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -52777,7 +52960,7 @@
       "source_location": "L377"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -52786,7 +52969,7 @@
       "source_location": "L99"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -52795,7 +52978,7 @@
       "source_location": "L53"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -52804,7 +52987,7 @@
       "source_location": "L75"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -52813,7 +52996,7 @@
       "source_location": "L63"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -52822,7 +53005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -52831,7 +53014,7 @@
       "source_location": "L7"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -52840,7 +53023,7 @@
       "source_location": "L69"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -52849,7 +53032,7 @@
       "source_location": "L44"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -52858,7 +53041,7 @@
       "source_location": "L103"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -52867,7 +53050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -52876,7 +53059,7 @@
       "source_location": "L18"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -52885,7 +53068,7 @@
       "source_location": "L23"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -52894,7 +53077,7 @@
       "source_location": "L65"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -52903,7 +53086,7 @@
       "source_location": "L45"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -52912,7 +53095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -52921,7 +53104,7 @@
       "source_location": "L78"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -52930,7 +53113,7 @@
       "source_location": "L74"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -52939,7 +53122,7 @@
       "source_location": "L103"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -52948,7 +53131,7 @@
       "source_location": "L109"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -52957,7 +53140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -52966,7 +53149,7 @@
       "source_location": "L75"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -52975,7 +53158,7 @@
       "source_location": "L26"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -52984,7 +53167,7 @@
       "source_location": "L38"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -52993,7 +53176,7 @@
       "source_location": "L4"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -53002,7 +53185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -53011,7 +53194,7 @@
       "source_location": "L3"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -53020,7 +53203,7 @@
       "source_location": "L29"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -53029,7 +53212,7 @@
       "source_location": "L33"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -53038,103 +53221,13 @@
       "source_location": "L40"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
       "norm_label": "cart.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
-      "label": "registerGateway.ts",
-      "norm_label": "registergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "registergateway_mapregisterstatedto",
-      "label": "mapRegisterStateDto()",
-      "norm_label": "mapregisterstatedto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "registergateway_mapterminaldto",
-      "label": "mapTerminalDto()",
-      "norm_label": "mapterminaldto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "registergateway_useconvexregisterstate",
-      "label": "useConvexRegisterState()",
-      "norm_label": "useconvexregisterstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "registergateway_useconvexterminalbyfingerprint",
-      "label": "useConvexTerminalByFingerprint()",
-      "norm_label": "useconvexterminalbyfingerprint()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
-      "label": "transactionUtils.ts",
-      "norm_label": "transactionutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "transactionutils_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "transactionutils_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "transactionutils_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "transactionutils_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L14"
     },
     {
       "community": 18,
@@ -53301,6 +53394,96 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
+      "label": "registerGateway.ts",
+      "norm_label": "registergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "registergateway_mapregisterstatedto",
+      "label": "mapRegisterStateDto()",
+      "norm_label": "mapregisterstatedto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "registergateway_mapterminaldto",
+      "label": "mapTerminalDto()",
+      "norm_label": "mapterminaldto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "registergateway_useconvexregisterstate",
+      "label": "useConvexRegisterState()",
+      "norm_label": "useconvexregisterstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "registergateway_useconvexterminalbyfingerprint",
+      "label": "useConvexTerminalByFingerprint()",
+      "norm_label": "useconvexterminalbyfingerprint()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
+      "label": "transactionUtils.ts",
+      "norm_label": "transactionutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "transactionutils_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "transactionutils_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "transactionutils_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "transactionutils_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
       "norm_label": "timelineutils.ts",
@@ -53308,7 +53491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -53317,7 +53500,7 @@
       "source_location": "L184"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -53326,7 +53509,7 @@
       "source_location": "L200"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -53335,7 +53518,7 @@
       "source_location": "L244"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -53344,7 +53527,7 @@
       "source_location": "L206"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -53353,7 +53536,7 @@
       "source_location": "L114"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -53362,7 +53545,7 @@
       "source_location": "L81"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -53371,7 +53554,7 @@
       "source_location": "L23"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -53380,7 +53563,7 @@
       "source_location": "L27"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -53389,7 +53572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -53398,7 +53581,7 @@
       "source_location": "L93"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -53407,7 +53590,7 @@
       "source_location": "L75"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -53416,7 +53599,7 @@
       "source_location": "L4"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -53425,7 +53608,7 @@
       "source_location": "L47"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -53434,7 +53617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -53443,7 +53626,7 @@
       "source_location": "L11"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -53452,7 +53635,7 @@
       "source_location": "L25"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -53461,7 +53644,7 @@
       "source_location": "L9"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -53470,7 +53653,7 @@
       "source_location": "L39"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -53479,7 +53662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -53488,7 +53671,7 @@
       "source_location": "L4"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -53497,7 +53680,7 @@
       "source_location": "L24"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -53506,7 +53689,7 @@
       "source_location": "L6"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -53515,7 +53698,7 @@
       "source_location": "L42"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -53524,7 +53707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -53533,7 +53716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -53542,7 +53725,7 @@
       "source_location": "L28"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -53551,7 +53734,7 @@
       "source_location": "L5"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -53560,7 +53743,7 @@
       "source_location": "L7"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -53569,7 +53752,7 @@
       "source_location": "L46"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -53578,7 +53761,7 @@
       "source_location": "L147"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -53587,7 +53770,7 @@
       "source_location": "L185"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -53596,7 +53779,7 @@
       "source_location": "L115"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -53605,7 +53788,7 @@
       "source_location": "L31"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -53614,7 +53797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -53623,7 +53806,7 @@
       "source_location": "L14"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -53632,7 +53815,7 @@
       "source_location": "L22"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -53641,7 +53824,7 @@
       "source_location": "L30"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -53650,102 +53833,12 @@
       "source_location": "L3"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
       "norm_label": "inventorylevelbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
-      "label": "storefrontFailureObservability.ts",
-      "norm_label": "storefrontfailureobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "label": "createStorefrontFailureEvent()",
-      "norm_label": "createstorefrontfailureevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "label": "emitStorefrontFailure()",
-      "norm_label": "emitstorefrontfailure()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "label": "inferStorefrontJourneyFromRoute()",
-      "norm_label": "inferstorefrontjourneyfromroute()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_normalizestorefronterror",
-      "label": "normalizeStorefrontError()",
-      "norm_label": "normalizestorefronterror()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "harness_repo_validation_collectharnessrepovalidationselection",
-      "label": "collectHarnessRepoValidationSelection()",
-      "norm_label": "collectharnessrepovalidationselection()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
-      "label": "matchesHarnessRepoValidationPath()",
-      "norm_label": "matchesharnessrepovalidationpath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "harness_repo_validation_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "harness_repo_validation_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_ts",
-      "label": "harness-repo-validation.ts",
-      "norm_label": "harness-repo-validation.ts",
-      "source_file": "scripts/harness-repo-validation.ts",
       "source_location": "L1"
     },
     {
@@ -53913,6 +54006,96 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
+      "label": "storefrontFailureObservability.ts",
+      "norm_label": "storefrontfailureobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_createstorefrontfailureevent",
+      "label": "createStorefrontFailureEvent()",
+      "norm_label": "createstorefrontfailureevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_emitstorefrontfailure",
+      "label": "emitStorefrontFailure()",
+      "norm_label": "emitstorefrontfailure()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
+      "label": "inferStorefrontJourneyFromRoute()",
+      "norm_label": "inferstorefrontjourneyfromroute()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_normalizestorefronterror",
+      "label": "normalizeStorefrontError()",
+      "norm_label": "normalizestorefronterror()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "harness_repo_validation_collectharnessrepovalidationselection",
+      "label": "collectHarnessRepoValidationSelection()",
+      "norm_label": "collectharnessrepovalidationselection()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
+      "label": "matchesHarnessRepoValidationPath()",
+      "norm_label": "matchesharnessrepovalidationpath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "harness_repo_validation_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "harness_repo_validation_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "scripts_harness_repo_validation_ts",
+      "label": "harness-repo-validation.ts",
+      "norm_label": "harness-repo-validation.ts",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
       "norm_label": "registersessiontracelifecycle.test.ts",
@@ -53920,7 +54103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -53929,7 +54112,7 @@
       "source_location": "L79"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -53938,7 +54121,7 @@
       "source_location": "L95"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -53947,7 +54130,7 @@
       "source_location": "L263"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -53956,7 +54139,7 @@
       "source_location": "L12"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -53965,7 +54148,7 @@
       "source_location": "L26"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -53974,7 +54157,7 @@
       "source_location": "L20"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -53983,7 +54166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -53992,7 +54175,7 @@
       "source_location": "L109"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -54001,7 +54184,7 @@
       "source_location": "L84"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -54010,7 +54193,7 @@
       "source_location": "L95"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -54019,7 +54202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -54028,7 +54211,7 @@
       "source_location": "L145"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -54037,7 +54220,7 @@
       "source_location": "L35"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -54046,7 +54229,7 @@
       "source_location": "L160"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -54055,7 +54238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -54064,7 +54247,7 @@
       "source_location": "L50"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -54073,7 +54256,7 @@
       "source_location": "L23"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -54082,7 +54265,7 @@
       "source_location": "L37"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -54091,7 +54274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -54100,7 +54283,7 @@
       "source_location": "L21"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -54109,7 +54292,7 @@
       "source_location": "L35"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -54118,7 +54301,7 @@
       "source_location": "L45"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -54127,7 +54310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -54136,7 +54319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -54145,7 +54328,7 @@
       "source_location": "L21"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -54154,7 +54337,7 @@
       "source_location": "L35"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -54163,7 +54346,7 @@
       "source_location": "L45"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -54172,7 +54355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -54181,7 +54364,7 @@
       "source_location": "L227"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -54190,85 +54373,13 @@
       "source_location": "L90"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
       "source_location": "L244"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L1"
     },
     {
       "community": 2,
@@ -54732,6 +54843,78 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
       "norm_label": "maskmtnpartyid()",
@@ -54739,7 +54922,7 @@
       "source_location": "L10"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -54748,7 +54931,7 @@
       "source_location": "L18"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -54757,7 +54940,7 @@
       "source_location": "L52"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -54766,7 +54949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -54775,7 +54958,7 @@
       "source_location": "L28"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -54784,7 +54967,7 @@
       "source_location": "L42"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -54793,7 +54976,7 @@
       "source_location": "L73"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -54802,7 +54985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -54811,7 +54994,7 @@
       "source_location": "L8"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -54820,7 +55003,7 @@
       "source_location": "L32"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -54829,7 +55012,7 @@
       "source_location": "L64"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -54838,7 +55021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -54847,7 +55030,7 @@
       "source_location": "L18"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -54856,7 +55039,7 @@
       "source_location": "L25"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -54865,7 +55048,7 @@
       "source_location": "L11"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -54874,7 +55057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -54883,7 +55066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -54892,7 +55075,7 @@
       "source_location": "L33"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -54901,7 +55084,7 @@
       "source_location": "L19"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -54910,7 +55093,7 @@
       "source_location": "L42"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -54919,7 +55102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -54928,7 +55111,7 @@
       "source_location": "L31"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -54937,7 +55120,7 @@
       "source_location": "L48"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -54946,7 +55129,7 @@
       "source_location": "L131"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -54955,7 +55138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -54964,7 +55147,7 @@
       "source_location": "L37"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -54973,7 +55156,7 @@
       "source_location": "L24"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -54982,7 +55165,7 @@
       "source_location": "L19"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -54991,7 +55174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -55000,7 +55183,7 @@
       "source_location": "L29"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -55009,7 +55192,7 @@
       "source_location": "L24"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -55018,2635 +55201,7 @@
       "source_location": "L51"
     },
     {
-      "community": 208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
-      "label": "searchCatalog.ts",
-      "norm_label": "searchcatalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "searchcatalog_lookupbybarcode",
-      "label": "lookupByBarcode()",
-      "norm_label": "lookupbybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "searchcatalog_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "searchcatalog_searchproducts",
-      "label": "searchProducts()",
-      "norm_label": "searchproducts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
-      "label": "sessionCommandRepository.ts",
-      "norm_label": "sessioncommandrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "sessioncommandrepository_collectsessionitemsfrompages",
-      "label": "collectSessionItemsFromPages()",
-      "norm_label": "collectsessionitemsfrompages()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "sessioncommandrepository_createsessioncommandrepository",
-      "label": "createSessionCommandRepository()",
-      "norm_label": "createsessioncommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "sessioncommandrepository_findsessionitembyskuinpages",
-      "label": "findSessionItemBySkuInPages()",
-      "norm_label": "findsessionitembyskuinpages()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L180"
-    },
-    {
       "community": 21,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
-      "label": "staffCredentials.ts",
-      "norm_label": "staffcredentials.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_assertstaffprofilereadyforcredential",
-      "label": "assertStaffProfileReadyForCredential()",
-      "norm_label": "assertstaffprofilereadyforcredential()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
-      "label": "authenticateStaffCredentialForTerminalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L496"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialwithctx",
-      "label": "authenticateStaffCredentialWithCtx()",
-      "norm_label": "authenticatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L406"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_createstaffcredentialwithctx",
-      "label": "createStaffCredentialWithCtx()",
-      "norm_label": "createstaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_getactiverolesforstaffprofile",
-      "label": "getActiveRolesForStaffProfile()",
-      "norm_label": "getactiverolesforstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyid",
-      "label": "getCredentialById()",
-      "norm_label": "getcredentialbyid()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyusername",
-      "label": "getCredentialByUsername()",
-      "norm_label": "getcredentialbyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
-      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
-      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
-      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
-      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_invalidstaffcredentialsresult",
-      "label": "invalidStaffCredentialsResult()",
-      "norm_label": "invalidstaffcredentialsresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
-      "label": "listStaffCredentialsByStoreWithCtx()",
-      "norm_label": "liststaffcredentialsbystorewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_normalizeusername",
-      "label": "normalizeUsername()",
-      "norm_label": "normalizeusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_requirenonemptyusername",
-      "label": "requireNonEmptyUsername()",
-      "norm_label": "requirenonemptyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_staffauthorizationfailedresult",
-      "label": "staffAuthorizationFailedResult()",
-      "norm_label": "staffauthorizationfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_staffpreconditionfailedresult",
-      "label": "staffPreconditionFailedResult()",
-      "norm_label": "staffpreconditionfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "staffcredentials_updatestaffcredentialwithctx",
-      "label": "updateStaffCredentialWithCtx()",
-      "norm_label": "updatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "adjustments_test_createapprovaldecisionmutationctx",
-      "label": "createApprovalDecisionMutationCtx()",
-      "norm_label": "createapprovaldecisionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "adjustments_test_createsubmissionmutationctx",
-      "label": "createSubmissionMutationCtx()",
-      "norm_label": "createsubmissionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "adjustments_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
-      "label": "adjustments.test.ts",
-      "norm_label": "adjustments.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
-      "label": "replenishment.test.ts",
-      "norm_label": "replenishment.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
-      "id": "replenishment_test_createreplenishmentqueryctx",
-      "label": "createReplenishmentQueryCtx()",
-      "norm_label": "createreplenishmentqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
-      "id": "replenishment_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
-      "id": "replenishment_test_toasynciterable",
-      "label": "toAsyncIterable()",
-      "norm_label": "toasynciterable()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 212,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 212,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 212,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 212,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
-      "label": "commerceQueryIndexes.test.ts",
-      "norm_label": "commercequeryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 213,
-      "file_type": "code",
-      "id": "customerengagementevents_findexistingcustomerprofileid",
-      "label": "findExistingCustomerProfileId()",
-      "norm_label": "findexistingcustomerprofileid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 213,
-      "file_type": "code",
-      "id": "customerengagementevents_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 213,
-      "file_type": "code",
-      "id": "customerengagementevents_recordstorefrontcustomermilestone",
-      "label": "recordStoreFrontCustomerMilestone()",
-      "norm_label": "recordstorefrontcustomermilestone()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 213,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
-      "label": "customerEngagementEvents.ts",
-      "norm_label": "customerengagementevents.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 214,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 214,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 214,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 214,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 215,
-      "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 215,
-      "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 215,
-      "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 215,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
-      "label": "staffDisplayName.ts",
-      "norm_label": "staffdisplayname.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplayname",
-      "label": "formatStaffDisplayName()",
-      "norm_label": "formatstaffdisplayname()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
-      "label": "formatStaffDisplayNameOrFallback()",
-      "norm_label": "formatstaffdisplaynameorfallback()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "staffdisplayname_normalizenamepart",
-      "label": "normalizeNamePart()",
-      "norm_label": "normalizenamepart()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "attributesmanager_attributesmanager",
-      "label": "AttributesManager()",
-      "norm_label": "attributesmanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L227"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "attributesmanager_colormanager",
-      "label": "ColorManager()",
-      "norm_label": "colormanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "attributesmanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "label": "AttributesManager.tsx",
-      "norm_label": "attributesmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "attributestable_getproductattribute",
-      "label": "getProductAttribute()",
-      "norm_label": "getproductattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "attributestable_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "attributestable_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L211"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "label": "AttributesTable.tsx",
-      "norm_label": "attributestable.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_categorymanager",
-      "label": "CategoryManager()",
-      "norm_label": "categorymanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_subcategorymanager",
-      "label": "SubcategoryManager()",
-      "norm_label": "subcategorymanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L288"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
-      "label": "CategorySubcategoryManager.tsx",
-      "norm_label": "categorysubcategorymanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "analyticsview_activecheckoutsessions",
-      "label": "ActiveCheckoutSessions()",
-      "norm_label": "activecheckoutsessions()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "analyticsview_analyticsview",
-      "label": "AnalyticsView()",
-      "norm_label": "analyticsview()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "analyticsview_storevisitors",
-      "label": "StoreVisitors()",
-      "norm_label": "storevisitors()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "label": "AnalyticsView.tsx",
-      "norm_label": "analyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 221,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "label": "StorefrontObservabilityPanel.tsx",
-      "norm_label": "storefrontobservabilitypanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 221,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_formatlabel",
-      "label": "formatLabel()",
-      "norm_label": "formatlabel()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 221,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
-      "label": "getTrafficSourceBadge()",
-      "norm_label": "gettrafficsourcebadge()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 221,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "utils_countgroupedanalytics",
-      "label": "countGroupedAnalytics()",
-      "norm_label": "countgroupedanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "utils_groupanalytics",
-      "label": "groupAnalytics()",
-      "norm_label": "groupanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "utils_groupproductviewsbyday",
-      "label": "groupProductViewsByDay()",
-      "norm_label": "groupproductviewsbyday()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "label": "MaintenanceMessageEditor.tsx",
-      "norm_label": "maintenancemessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "label": "ShopLook.tsx",
-      "norm_label": "shoplook.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "shoplook_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "shoplook_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "shoplook_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
-      "label": "ReturnExchangeView.tsx",
-      "norm_label": "returnexchangeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "returnexchangeview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "returnexchangeview_resetreplacementfields",
-      "label": "resetReplacementFields()",
-      "norm_label": "resetreplacementfields()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "returnexchangeview_toggleitem",
-      "label": "toggleItem()",
-      "norm_label": "toggleitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalancedueamount",
-      "label": "getBalanceDueAmount()",
-      "norm_label": "getbalancedueamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduelabel",
-      "label": "getBalanceDueLabel()",
-      "norm_label": "getbalanceduelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "ordersummary_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
-      "label": "OrderSummary.test.tsx",
-      "norm_label": "ordersummary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "ordersummary_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L377"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L259"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "ordersummary_handlestartnewtransaction",
-      "label": "handleStartNewTransaction()",
-      "norm_label": "handlestartnewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L276"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
-      "label": "PaymentsAddedList.test.tsx",
-      "norm_label": "paymentsaddedlist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummaryamount",
-      "label": "getSummaryAmount()",
-      "norm_label": "getsummaryamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarylabel",
-      "label": "getSummaryLabel()",
-      "norm_label": "getsummarylabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L60"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 231,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "label": "POSSettingsView.tsx",
-      "norm_label": "possettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 231,
-      "file_type": "code",
-      "id": "possettingsview_handleregisterterminal",
-      "label": "handleRegisterTerminal()",
-      "norm_label": "handleregisterterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L312"
-    },
-    {
-      "community": 231,
-      "file_type": "code",
-      "id": "possettingsview_handleupdateexistingterminal",
-      "label": "handleUpdateExistingTerminal()",
-      "norm_label": "handleupdateexistingterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L364"
-    },
-    {
-      "community": 231,
-      "file_type": "code",
-      "id": "possettingsview_loadfingerprint",
-      "label": "loadFingerprint()",
-      "norm_label": "loadfingerprint()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L219"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "label": "TransactionsView.tsx",
-      "norm_label": "transactionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "transactionsview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "transactionsview_formatregisterfilterlabel",
-      "label": "formatRegisterFilterLabel()",
-      "norm_label": "formatregisterfilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "transactionsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
-      "label": "ProcurementView.tsx",
-      "norm_label": "procurementview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "procurementview_formatoptionaldate",
-      "label": "formatOptionalDate()",
-      "norm_label": "formatoptionaldate()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L78"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "procurementview_getfilteremptystatecopy",
-      "label": "getFilterEmptyStateCopy()",
-      "norm_label": "getfilteremptystatecopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L118"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "procurementview_getrecommendationstatuscopy",
-      "label": "getRecommendationStatusCopy()",
-      "norm_label": "getrecommendationstatuscopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstock_tsx",
-      "label": "ProductStock.tsx",
-      "norm_label": "productstock.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "productstock_lowstockstatus",
-      "label": "LowStockStatus()",
-      "norm_label": "lowstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "productstock_outofstockstatus",
-      "label": "OutOfStockStatus()",
-      "norm_label": "outofstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "productstock_productstockstatus",
-      "label": "ProductStockStatus()",
-      "norm_label": "productstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 236,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
-      "label": "promoCodeMoney.ts",
-      "norm_label": "promocodemoney.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 236,
-      "file_type": "code",
-      "id": "promocodemoney_parsepromodiscountinput",
-      "label": "parsePromoDiscountInput()",
-      "norm_label": "parsepromodiscountinput()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 236,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountdisplaytext",
-      "label": "promoDiscountDisplayText()",
-      "norm_label": "promodiscountdisplaytext()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 236,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountinputvalue",
-      "label": "promoDiscountInputValue()",
-      "norm_label": "promodiscountinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
-      "label": "ServiceCasesView.tsx",
-      "norm_label": "servicecasesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "servicecasesview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L178"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "servicecasesview_handlecreatecase",
-      "label": "handleCreateCase()",
-      "norm_label": "handlecreatecase()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L205"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "servicecasesview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L806"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "label": "WorkflowTraceView.tsx",
-      "norm_label": "workflowtraceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "workflowtraceview_formattracelabel",
-      "label": "formatTraceLabel()",
-      "norm_label": "formattracelabel()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "workflowtraceview_getstatustone",
-      "label": "getStatusTone()",
-      "norm_label": "getstatustone()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "workflowtraceview_workflowtraceheader",
-      "label": "WorkflowTraceHeader()",
-      "norm_label": "workflowtraceheader()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "engagementmetrics_formatlastactivity",
-      "label": "formatLastActivity()",
-      "norm_label": "formatlastactivity()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "engagementmetrics_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "engagementmetrics_getdevicelabel",
-      "label": "getDeviceLabel()",
-      "norm_label": "getdevicelabel()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "label": "EngagementMetrics.tsx",
-      "norm_label": "engagementmetrics.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "label": "RiskIndicators.tsx",
-      "norm_label": "riskindicators.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "riskindicators_getriskicon",
-      "label": "getRiskIcon()",
-      "norm_label": "getriskicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "riskindicators_getriskstyles",
-      "label": "getRiskStyles()",
-      "norm_label": "getriskstyles()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "riskindicators_riskindicators",
-      "label": "RiskIndicators()",
-      "norm_label": "riskindicators()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "label": "getObservabilityStatusStyles()",
-      "norm_label": "getobservabilitystatusstyles()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
-      "label": "customerObservabilityTimeline.ts",
-      "norm_label": "customerobservabilitytimeline.ts",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "barcodeutils_extractbarcodefrominput",
-      "label": "extractBarcodeFromInput()",
-      "norm_label": "extractbarcodefrominput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "barcodeutils_isurlorbarcode",
-      "label": "isUrlOrBarcode()",
-      "norm_label": "isurlorbarcode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "barcodeutils_isvalidconvexid",
-      "label": "isValidConvexId()",
-      "norm_label": "isvalidconvexid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
-      "label": "barcodeUtils.ts",
-      "norm_label": "barcodeutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "customergateway_useconvexposcustomercreate",
-      "label": "useConvexPosCustomerCreate()",
-      "norm_label": "useconvexposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "customergateway_useconvexposcustomersearch",
-      "label": "useConvexPosCustomerSearch()",
-      "norm_label": "useconvexposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "customergateway_useconvexposcustomerupdate",
-      "label": "useConvexPosCustomerUpdate()",
-      "norm_label": "useconvexposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
-      "label": "customerGateway.ts",
-      "norm_label": "customergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
-      "label": "sessionGateway.ts",
-      "norm_label": "sessiongateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexactivesession",
-      "label": "useConvexActiveSession()",
-      "norm_label": "useconvexactivesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexheldsessions",
-      "label": "useConvexHeldSessions()",
-      "norm_label": "useconvexheldsessions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexsessionactions",
-      "label": "useConvexSessionActions()",
-      "norm_label": "useconvexsessionactions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "fingerprint_isbrowserfingerprintresult",
-      "label": "isBrowserFingerprintResult()",
-      "norm_label": "isbrowserfingerprintresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "fingerprint_readstoredterminalfingerprint",
-      "label": "readStoredTerminalFingerprint()",
-      "norm_label": "readstoredterminalfingerprint()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "fingerprint_readstoredterminalfingerprinthash",
-      "label": "readStoredTerminalFingerprintHash()",
-      "norm_label": "readstoredterminalfingerprinthash()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
-      "label": "fingerprint.ts",
-      "norm_label": "fingerprint.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
-      "label": "useExpenseRegisterViewModel.ts",
-      "norm_label": "useexpenseregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
-      "label": "getExpenseSessionLoadKey()",
-      "norm_label": "getexpensesessionloadkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
-      "label": "useExpenseRegisterViewModel()",
-      "norm_label": "useexpenseregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_buildcashcontrolsdashboardsnapshot",
-      "label": "buildCashControlsDashboardSnapshot()",
-      "norm_label": "buildcashcontrolsdashboardsnapshot()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_buildregistersessiondeposittargetid",
-      "label": "buildRegisterSessionDepositTargetId()",
-      "norm_label": "buildregistersessiondeposittargetid()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_buildregistersessionsummary",
-      "label": "buildRegisterSessionSummary()",
-      "norm_label": "buildregistersessionsummary()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_collectstaffprofileids",
-      "label": "collectStaffProfileIds()",
-      "norm_label": "collectstaffprofileids()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_iscashcontroldepositallocation",
-      "label": "isCashControlDepositAllocation()",
-      "norm_label": "iscashcontroldepositallocation()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listregistersessionsfordashboard",
-      "label": "listRegisterSessionsForDashboard()",
-      "norm_label": "listregistersessionsfordashboard()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listregistersessiontimeline",
-      "label": "listRegisterSessionTimeline()",
-      "norm_label": "listregistersessiontimeline()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L345"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listregistersessiontransactions",
-      "label": "listRegisterSessionTransactions()",
-      "norm_label": "listregistersessiontransactions()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listsessiondeposits",
-      "label": "listSessionDeposits()",
-      "norm_label": "listsessiondeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L331"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_liststoredeposits",
-      "label": "listStoreDeposits()",
-      "norm_label": "liststoredeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L317"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listterminalnames",
-      "label": "listTerminalNames()",
-      "norm_label": "listterminalnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L300"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_sumdepositsbysession",
-      "label": "sumDepositsBySession()",
-      "norm_label": "sumdepositsbysession()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
-      "label": "deposits.ts",
-      "norm_label": "deposits.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "subcategory_getallsubcategories",
-      "label": "getAllSubcategories()",
-      "norm_label": "getallsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "subcategory_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "subcategory_getsubategory",
-      "label": "getSubategory()",
-      "norm_label": "getsubategory()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
-      "label": "ProductActionBar.tsx",
-      "norm_label": "productactionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "productactionbar_checkscroll",
-      "label": "checkScroll()",
-      "norm_label": "checkscroll()",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "productactionbar_handleaction",
-      "label": "handleAction()",
-      "norm_label": "handleaction()",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "productactionbar_handledismiss",
-      "label": "handleDismiss()",
-      "norm_label": "handledismiss()",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
-      "label": "ProductReminderBar.tsx",
-      "norm_label": "productreminderbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "productreminderbar_checkscroll",
-      "label": "checkScroll()",
-      "norm_label": "checkscroll()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "productreminderbar_handleaddtobag",
-      "label": "handleAddToBag()",
-      "norm_label": "handleaddtobag()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "productreminderbar_handledismiss",
-      "label": "handleDismiss()",
-      "norm_label": "handledismiss()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "billingdetailssection_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "billingdetailssection_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "billingdetailssection_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
-      "label": "BillingDetailsSection.tsx",
-      "norm_label": "billingdetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "productattribute_optionclassname",
-      "label": "optionClassName()",
-      "norm_label": "optionclassname()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
-      "label": "ProductDetails.tsx",
-      "norm_label": "productdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "productdetails_bagproduct",
-      "label": "BagProduct()",
-      "norm_label": "bagproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "productdetails_pickupdetails",
-      "label": "PickupDetails()",
-      "norm_label": "pickupdetails()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "productdetails_shippingpolicy",
-      "label": "ShippingPolicy()",
-      "norm_label": "shippingpolicy()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "label": "UpsellModal.tsx",
-      "norm_label": "upsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "upsellmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L111"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "upsellmodal_handlescroll",
-      "label": "handleScroll()",
-      "norm_label": "handlescroll()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "upsellmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "label": "StoreContext.tsx",
-      "norm_label": "storecontext.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "storecontext_storeprovider",
-      "label": "StoreProvider()",
-      "norm_label": "storeprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "storecontext_useoptionalstorecontext",
-      "label": "useOptionalStoreContext()",
-      "norm_label": "useoptionalstorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "storecontext_usestorecontext",
-      "label": "useStoreContext()",
-      "norm_label": "usestorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "label": "_shopLayout.tsx",
-      "norm_label": "_shoplayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "shoplayout_clearfilters",
-      "label": "clearFilters()",
-      "norm_label": "clearfilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "shoplayout_onclickonmobilefilters",
-      "label": "onClickOnMobileFilters()",
-      "norm_label": "onclickonmobilefilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "shoplayout_onmobilefilterscloseclick",
-      "label": "onMobileFiltersCloseClick()",
-      "norm_label": "onmobilefilterscloseclick()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_ts",
       "label": "registerSessions.ts",
@@ -57655,7 +55210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_assertregistersessionidentity",
       "label": "assertRegisterSessionIdentity()",
@@ -57664,7 +55219,7 @@
       "source_location": "L61"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_assertregistersessionmatchestransaction",
       "label": "assertRegisterSessionMatchesTransaction()",
@@ -57673,7 +55228,7 @@
       "source_location": "L71"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_assertvalidregistersessiontransition",
       "label": "assertValidRegisterSessionTransition()",
@@ -57682,16 +55237,16 @@
       "source_location": "L128"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_buildclosedregistersessionpatch",
       "label": "buildClosedRegisterSessionPatch()",
       "norm_label": "buildclosedregistersessionpatch()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L243"
+      "source_location": "L256"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_buildregistersession",
       "label": "buildRegisterSession()",
@@ -57700,7 +55255,7 @@
       "source_location": "L93"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_buildregistersessioncloseoutpatch",
       "label": "buildRegisterSessionCloseoutPatch()",
@@ -57709,16 +55264,16 @@
       "source_location": "L188"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_buildregistersessiondepositpatch",
       "label": "buildRegisterSessionDepositPatch()",
       "norm_label": "buildregistersessiondepositpatch()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L214"
+      "source_location": "L227"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_buildregistersessiontransactionpatch",
       "label": "buildRegisterSessionTransactionPatch()",
@@ -57727,7 +55282,16 @@
       "source_location": "L147"
     },
     {
-      "community": 26,
+      "community": 21,
+      "file_type": "code",
+      "id": "registersessions_buildreopenedregistersessionpatch",
+      "label": "buildReopenedRegisterSessionPatch()",
+      "norm_label": "buildreopenedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_calculateregistersessioncashdelta",
       "label": "calculateRegisterSessionCashDelta()",
@@ -57736,16 +55300,16 @@
       "source_location": "L115"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_findconflictingregistersession",
       "label": "findConflictingRegisterSession()",
       "norm_label": "findconflictingregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L269"
+      "source_location": "L282"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_normalizeregistersessionidentity",
       "label": "normalizeRegisterSessionIdentity()",
@@ -57754,7 +55318,7 @@
       "source_location": "L54"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
       "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
@@ -57763,16 +55327,16 @@
       "source_location": "L32"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_recordregistersessiondepositwithctx",
       "label": "recordRegisterSessionDepositWithCtx()",
       "norm_label": "recordregistersessiondepositwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L546"
+      "source_location": "L579"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_registersessionstatusset",
       "label": "registerSessionStatusSet()",
@@ -57781,7 +55345,7 @@
       "source_location": "L11"
     },
     {
-      "community": 26,
+      "community": 21,
       "file_type": "code",
       "id": "registersessions_trimoptional",
       "label": "trimOptional()",
@@ -57790,7 +55354,2599 @@
       "source_location": "L27"
     },
     {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
+      "label": "searchCatalog.ts",
+      "norm_label": "searchcatalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "searchcatalog_lookupbybarcode",
+      "label": "lookupByBarcode()",
+      "norm_label": "lookupbybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "searchcatalog_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "searchcatalog_searchproducts",
+      "label": "searchProducts()",
+      "norm_label": "searchproducts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
+      "label": "sessionCommandRepository.ts",
+      "norm_label": "sessioncommandrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "sessioncommandrepository_collectsessionitemsfrompages",
+      "label": "collectSessionItemsFromPages()",
+      "norm_label": "collectsessionitemsfrompages()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "sessioncommandrepository_createsessioncommandrepository",
+      "label": "createSessionCommandRepository()",
+      "norm_label": "createsessioncommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "sessioncommandrepository_findsessionitembyskuinpages",
+      "label": "findSessionItemBySkuInPages()",
+      "norm_label": "findsessionitembyskuinpages()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L180"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "adjustments_test_createapprovaldecisionmutationctx",
+      "label": "createApprovalDecisionMutationCtx()",
+      "norm_label": "createapprovaldecisionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "adjustments_test_createsubmissionmutationctx",
+      "label": "createSubmissionMutationCtx()",
+      "norm_label": "createsubmissionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "adjustments_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "label": "adjustments.test.ts",
+      "norm_label": "adjustments.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
+      "label": "replenishment.test.ts",
+      "norm_label": "replenishment.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "replenishment_test_createreplenishmentqueryctx",
+      "label": "createReplenishmentQueryCtx()",
+      "norm_label": "createreplenishmentqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "replenishment_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "replenishment_test_toasynciterable",
+      "label": "toAsyncIterable()",
+      "norm_label": "toasynciterable()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
+      "label": "commerceQueryIndexes.test.ts",
+      "norm_label": "commercequeryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 215,
+      "file_type": "code",
+      "id": "customerengagementevents_findexistingcustomerprofileid",
+      "label": "findExistingCustomerProfileId()",
+      "norm_label": "findexistingcustomerprofileid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 215,
+      "file_type": "code",
+      "id": "customerengagementevents_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 215,
+      "file_type": "code",
+      "id": "customerengagementevents_recordstorefrontcustomermilestone",
+      "label": "recordStoreFrontCustomerMilestone()",
+      "norm_label": "recordstorefrontcustomermilestone()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 215,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "label": "customerEngagementEvents.ts",
+      "norm_label": "customerengagementevents.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
+      "label": "staffDisplayName.ts",
+      "norm_label": "staffdisplayname.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplayname",
+      "label": "formatStaffDisplayName()",
+      "norm_label": "formatstaffdisplayname()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
+      "label": "formatStaffDisplayNameOrFallback()",
+      "norm_label": "formatstaffdisplaynameorfallback()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "staffdisplayname_normalizenamepart",
+      "label": "normalizeNamePart()",
+      "norm_label": "normalizenamepart()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "attributesmanager_attributesmanager",
+      "label": "AttributesManager()",
+      "norm_label": "attributesmanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L227"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "attributesmanager_colormanager",
+      "label": "ColorManager()",
+      "norm_label": "colormanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "attributesmanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
+      "label": "AttributesManager.tsx",
+      "norm_label": "attributesmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
+      "label": "staffCredentials.ts",
+      "norm_label": "staffcredentials.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_assertstaffprofilereadyforcredential",
+      "label": "assertStaffProfileReadyForCredential()",
+      "norm_label": "assertstaffprofilereadyforcredential()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
+      "label": "authenticateStaffCredentialForTerminalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L496"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialwithctx",
+      "label": "authenticateStaffCredentialWithCtx()",
+      "norm_label": "authenticatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L406"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_createstaffcredentialwithctx",
+      "label": "createStaffCredentialWithCtx()",
+      "norm_label": "createstaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_getactiverolesforstaffprofile",
+      "label": "getActiveRolesForStaffProfile()",
+      "norm_label": "getactiverolesforstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyid",
+      "label": "getCredentialById()",
+      "norm_label": "getcredentialbyid()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyusername",
+      "label": "getCredentialByUsername()",
+      "norm_label": "getcredentialbyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
+      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
+      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
+      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
+      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_invalidstaffcredentialsresult",
+      "label": "invalidStaffCredentialsResult()",
+      "norm_label": "invalidstaffcredentialsresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
+      "label": "listStaffCredentialsByStoreWithCtx()",
+      "norm_label": "liststaffcredentialsbystorewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_normalizeusername",
+      "label": "normalizeUsername()",
+      "norm_label": "normalizeusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_requirenonemptyusername",
+      "label": "requireNonEmptyUsername()",
+      "norm_label": "requirenonemptyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_staffauthorizationfailedresult",
+      "label": "staffAuthorizationFailedResult()",
+      "norm_label": "staffauthorizationfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_staffpreconditionfailedresult",
+      "label": "staffPreconditionFailedResult()",
+      "norm_label": "staffpreconditionfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "staffcredentials_updatestaffcredentialwithctx",
+      "label": "updateStaffCredentialWithCtx()",
+      "norm_label": "updatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "attributestable_getproductattribute",
+      "label": "getProductAttribute()",
+      "norm_label": "getproductattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "attributestable_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "attributestable_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L211"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
+      "label": "AttributesTable.tsx",
+      "norm_label": "attributestable.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_categorymanager",
+      "label": "CategoryManager()",
+      "norm_label": "categorymanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_subcategorymanager",
+      "label": "SubcategoryManager()",
+      "norm_label": "subcategorymanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L288"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
+      "label": "CategorySubcategoryManager.tsx",
+      "norm_label": "categorysubcategorymanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "analyticsview_activecheckoutsessions",
+      "label": "ActiveCheckoutSessions()",
+      "norm_label": "activecheckoutsessions()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "analyticsview_analyticsview",
+      "label": "AnalyticsView()",
+      "norm_label": "analyticsview()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "analyticsview_storevisitors",
+      "label": "StoreVisitors()",
+      "norm_label": "storevisitors()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
+      "label": "AnalyticsView.tsx",
+      "norm_label": "analyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
+      "label": "StorefrontObservabilityPanel.tsx",
+      "norm_label": "storefrontobservabilitypanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_formatlabel",
+      "label": "formatLabel()",
+      "norm_label": "formatlabel()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
+      "label": "getTrafficSourceBadge()",
+      "norm_label": "gettrafficsourcebadge()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "utils_countgroupedanalytics",
+      "label": "countGroupedAnalytics()",
+      "norm_label": "countgroupedanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "utils_groupanalytics",
+      "label": "groupAnalytics()",
+      "norm_label": "groupanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "utils_groupproductviewsbyday",
+      "label": "groupProductViewsByDay()",
+      "norm_label": "groupproductviewsbyday()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
+      "label": "MaintenanceMessageEditor.tsx",
+      "norm_label": "maintenancemessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
+      "label": "ShopLook.tsx",
+      "norm_label": "shoplook.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "shoplook_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "shoplook_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "shoplook_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "label": "ReturnExchangeView.tsx",
+      "norm_label": "returnexchangeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "returnexchangeview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "returnexchangeview_resetreplacementfields",
+      "label": "resetReplacementFields()",
+      "norm_label": "resetreplacementfields()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "returnexchangeview_toggleitem",
+      "label": "toggleItem()",
+      "norm_label": "toggleitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalancedueamount",
+      "label": "getBalanceDueAmount()",
+      "norm_label": "getbalancedueamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduelabel",
+      "label": "getBalanceDueLabel()",
+      "norm_label": "getbalanceduelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "ordersummary_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
+      "label": "OrderSummary.test.tsx",
+      "norm_label": "ordersummary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L377"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L259"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "ordersummary_handlestartnewtransaction",
+      "label": "handleStartNewTransaction()",
+      "norm_label": "handlestartnewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L276"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
+      "label": "PaymentsAddedList.test.tsx",
+      "norm_label": "paymentsaddedlist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummaryamount",
+      "label": "getSummaryAmount()",
+      "norm_label": "getsummaryamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarylabel",
+      "label": "getSummaryLabel()",
+      "norm_label": "getsummarylabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
+      "label": "POSSettingsView.tsx",
+      "norm_label": "possettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "possettingsview_handleregisterterminal",
+      "label": "handleRegisterTerminal()",
+      "norm_label": "handleregisterterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L312"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "possettingsview_handleupdateexistingterminal",
+      "label": "handleUpdateExistingTerminal()",
+      "norm_label": "handleupdateexistingterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L364"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "possettingsview_loadfingerprint",
+      "label": "loadFingerprint()",
+      "norm_label": "loadfingerprint()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L219"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "label": "TransactionsView.tsx",
+      "norm_label": "transactionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "transactionsview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "transactionsview_formatregisterfilterlabel",
+      "label": "formatRegisterFilterLabel()",
+      "norm_label": "formatregisterfilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "transactionsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "label": "ProcurementView.tsx",
+      "norm_label": "procurementview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "procurementview_formatoptionaldate",
+      "label": "formatOptionalDate()",
+      "norm_label": "formatoptionaldate()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "procurementview_getfilteremptystatecopy",
+      "label": "getFilterEmptyStateCopy()",
+      "norm_label": "getfilteremptystatecopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L118"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "procurementview_getrecommendationstatuscopy",
+      "label": "getRecommendationStatusCopy()",
+      "norm_label": "getrecommendationstatuscopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstock_tsx",
+      "label": "ProductStock.tsx",
+      "norm_label": "productstock.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "productstock_lowstockstatus",
+      "label": "LowStockStatus()",
+      "norm_label": "lowstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "productstock_outofstockstatus",
+      "label": "OutOfStockStatus()",
+      "norm_label": "outofstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "productstock_productstockstatus",
+      "label": "ProductStockStatus()",
+      "norm_label": "productstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 236,
+      "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 236,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 236,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 236,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 237,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
+      "label": "promoCodeMoney.ts",
+      "norm_label": "promocodemoney.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 237,
+      "file_type": "code",
+      "id": "promocodemoney_parsepromodiscountinput",
+      "label": "parsePromoDiscountInput()",
+      "norm_label": "parsepromodiscountinput()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 237,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountdisplaytext",
+      "label": "promoDiscountDisplayText()",
+      "norm_label": "promodiscountdisplaytext()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 237,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountinputvalue",
+      "label": "promoDiscountInputValue()",
+      "norm_label": "promodiscountinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "label": "ServiceCasesView.tsx",
+      "norm_label": "servicecasesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "servicecasesview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L178"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "servicecasesview_handlecreatecase",
+      "label": "handleCreateCase()",
+      "norm_label": "handlecreatecase()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "servicecasesview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L806"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
+      "label": "WorkflowTraceView.tsx",
+      "norm_label": "workflowtraceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "workflowtraceview_formattracelabel",
+      "label": "formatTraceLabel()",
+      "norm_label": "formattracelabel()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "workflowtraceview_getstatustone",
+      "label": "getStatusTone()",
+      "norm_label": "getstatustone()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "workflowtraceview_workflowtraceheader",
+      "label": "WorkflowTraceHeader()",
+      "norm_label": "workflowtraceheader()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "engagementmetrics_formatlastactivity",
+      "label": "formatLastActivity()",
+      "norm_label": "formatlastactivity()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "engagementmetrics_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "engagementmetrics_getdevicelabel",
+      "label": "getDeviceLabel()",
+      "norm_label": "getdevicelabel()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
+      "label": "EngagementMetrics.tsx",
+      "norm_label": "engagementmetrics.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
+      "label": "RiskIndicators.tsx",
+      "norm_label": "riskindicators.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "riskindicators_getriskicon",
+      "label": "getRiskIcon()",
+      "norm_label": "getriskicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "riskindicators_getriskstyles",
+      "label": "getRiskStyles()",
+      "norm_label": "getriskstyles()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "riskindicators_riskindicators",
+      "label": "RiskIndicators()",
+      "norm_label": "riskindicators()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
+      "label": "getObservabilityStatusStyles()",
+      "norm_label": "getobservabilitystatusstyles()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
+      "label": "customerObservabilityTimeline.ts",
+      "norm_label": "customerobservabilitytimeline.ts",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "barcodeutils_extractbarcodefrominput",
+      "label": "extractBarcodeFromInput()",
+      "norm_label": "extractbarcodefrominput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "barcodeutils_isurlorbarcode",
+      "label": "isUrlOrBarcode()",
+      "norm_label": "isurlorbarcode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "barcodeutils_isvalidconvexid",
+      "label": "isValidConvexId()",
+      "norm_label": "isvalidconvexid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
+      "label": "barcodeUtils.ts",
+      "norm_label": "barcodeutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "customergateway_useconvexposcustomercreate",
+      "label": "useConvexPosCustomerCreate()",
+      "norm_label": "useconvexposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "customergateway_useconvexposcustomersearch",
+      "label": "useConvexPosCustomerSearch()",
+      "norm_label": "useconvexposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "customergateway_useconvexposcustomerupdate",
+      "label": "useConvexPosCustomerUpdate()",
+      "norm_label": "useconvexposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
+      "label": "customerGateway.ts",
+      "norm_label": "customergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
+      "label": "sessionGateway.ts",
+      "norm_label": "sessiongateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexactivesession",
+      "label": "useConvexActiveSession()",
+      "norm_label": "useconvexactivesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexheldsessions",
+      "label": "useConvexHeldSessions()",
+      "norm_label": "useconvexheldsessions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexsessionactions",
+      "label": "useConvexSessionActions()",
+      "norm_label": "useconvexsessionactions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "fingerprint_isbrowserfingerprintresult",
+      "label": "isBrowserFingerprintResult()",
+      "norm_label": "isbrowserfingerprintresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "fingerprint_readstoredterminalfingerprint",
+      "label": "readStoredTerminalFingerprint()",
+      "norm_label": "readstoredterminalfingerprint()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "fingerprint_readstoredterminalfingerprinthash",
+      "label": "readStoredTerminalFingerprintHash()",
+      "norm_label": "readstoredterminalfingerprinthash()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
+      "label": "fingerprint.ts",
+      "norm_label": "fingerprint.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
+      "label": "useExpenseRegisterViewModel.ts",
+      "norm_label": "useexpenseregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
+      "label": "getExpenseSessionLoadKey()",
+      "norm_label": "getexpensesessionloadkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
+      "label": "useExpenseRegisterViewModel()",
+      "norm_label": "useexpenseregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "subcategory_getallsubcategories",
+      "label": "getAllSubcategories()",
+      "norm_label": "getallsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "subcategory_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "subcategory_getsubategory",
+      "label": "getSubategory()",
+      "norm_label": "getsubategory()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
+      "label": "ProductActionBar.tsx",
+      "norm_label": "productactionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "productactionbar_checkscroll",
+      "label": "checkScroll()",
+      "norm_label": "checkscroll()",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "productactionbar_handleaction",
+      "label": "handleAction()",
+      "norm_label": "handleaction()",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "productactionbar_handledismiss",
+      "label": "handleDismiss()",
+      "norm_label": "handledismiss()",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
+      "label": "ProductReminderBar.tsx",
+      "norm_label": "productreminderbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "productreminderbar_checkscroll",
+      "label": "checkScroll()",
+      "norm_label": "checkscroll()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "productreminderbar_handleaddtobag",
+      "label": "handleAddToBag()",
+      "norm_label": "handleaddtobag()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "productreminderbar_handledismiss",
+      "label": "handleDismiss()",
+      "norm_label": "handledismiss()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "billingdetailssection_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "billingdetailssection_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "billingdetailssection_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
+      "label": "BillingDetailsSection.tsx",
+      "norm_label": "billingdetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "productattribute_optionclassname",
+      "label": "optionClassName()",
+      "norm_label": "optionclassname()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
+      "label": "ProductDetails.tsx",
+      "norm_label": "productdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "productdetails_bagproduct",
+      "label": "BagProduct()",
+      "norm_label": "bagproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "productdetails_pickupdetails",
+      "label": "PickupDetails()",
+      "norm_label": "pickupdetails()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "productdetails_shippingpolicy",
+      "label": "ShippingPolicy()",
+      "norm_label": "shippingpolicy()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
+      "label": "UpsellModal.tsx",
+      "norm_label": "upsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "upsellmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L111"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "upsellmodal_handlescroll",
+      "label": "handleScroll()",
+      "norm_label": "handlescroll()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "upsellmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
+      "label": "StoreContext.tsx",
+      "norm_label": "storecontext.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "storecontext_storeprovider",
+      "label": "StoreProvider()",
+      "norm_label": "storeprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "storecontext_useoptionalstorecontext",
+      "label": "useOptionalStoreContext()",
+      "norm_label": "useoptionalstorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "storecontext_usestorecontext",
+      "label": "useStoreContext()",
+      "norm_label": "usestorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_buildcashcontrolsdashboardsnapshot",
+      "label": "buildCashControlsDashboardSnapshot()",
+      "norm_label": "buildcashcontrolsdashboardsnapshot()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_buildregistersessiondeposittargetid",
+      "label": "buildRegisterSessionDepositTargetId()",
+      "norm_label": "buildregistersessiondeposittargetid()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_buildregistersessionsummary",
+      "label": "buildRegisterSessionSummary()",
+      "norm_label": "buildregistersessionsummary()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_collectstaffprofileids",
+      "label": "collectStaffProfileIds()",
+      "norm_label": "collectstaffprofileids()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_iscashcontroldepositallocation",
+      "label": "isCashControlDepositAllocation()",
+      "norm_label": "iscashcontroldepositallocation()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listregistersessionsfordashboard",
+      "label": "listRegisterSessionsForDashboard()",
+      "norm_label": "listregistersessionsfordashboard()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listregistersessiontimeline",
+      "label": "listRegisterSessionTimeline()",
+      "norm_label": "listregistersessiontimeline()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L345"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listregistersessiontransactions",
+      "label": "listRegisterSessionTransactions()",
+      "norm_label": "listregistersessiontransactions()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listsessiondeposits",
+      "label": "listSessionDeposits()",
+      "norm_label": "listsessiondeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L331"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_liststoredeposits",
+      "label": "listStoreDeposits()",
+      "norm_label": "liststoredeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listterminalnames",
+      "label": "listTerminalNames()",
+      "norm_label": "listterminalnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L300"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_sumdepositsbysession",
+      "label": "sumDepositsBySession()",
+      "norm_label": "sumdepositsbysession()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
+      "label": "deposits.ts",
+      "norm_label": "deposits.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
+      "label": "_shopLayout.tsx",
+      "norm_label": "_shoplayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "shoplayout_clearfilters",
+      "label": "clearFilters()",
+      "norm_label": "clearfilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "shoplayout_onclickonmobilefilters",
+      "label": "onClickOnMobileFilters()",
+      "norm_label": "onclickonmobilefilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "shoplayout_onmobilefilterscloseclick",
+      "label": "onMobileFiltersCloseClick()",
+      "norm_label": "onmobilefilterscloseclick()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 261,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -57799,7 +57955,7 @@
       "source_location": "L121"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -57808,7 +57964,7 @@
       "source_location": "L26"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -57817,7 +57973,7 @@
       "source_location": "L71"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -57826,7 +57982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -57835,7 +57991,7 @@
       "source_location": "L46"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -57844,7 +58000,7 @@
       "source_location": "L24"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -57853,7 +58009,7 @@
       "source_location": "L20"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -57862,7 +58018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -57871,7 +58027,7 @@
       "source_location": "L33"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -57880,7 +58036,7 @@
       "source_location": "L6"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -57889,7 +58045,7 @@
       "source_location": "L25"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -57898,7 +58054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -57907,7 +58063,7 @@
       "source_location": "L17"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -57916,7 +58072,7 @@
       "source_location": "L11"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -57925,7 +58081,7 @@
       "source_location": "L24"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -57934,7 +58090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -57943,7 +58099,7 @@
       "source_location": "L20"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -57952,7 +58108,7 @@
       "source_location": "L65"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -57961,7 +58117,7 @@
       "source_location": "L14"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -57970,7 +58126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -57979,7 +58135,7 @@
       "source_location": "L126"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -57988,7 +58144,7 @@
       "source_location": "L130"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -57997,7 +58153,7 @@
       "source_location": "L875"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -58006,7 +58162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -58015,7 +58171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -58024,7 +58180,7 @@
       "source_location": "L8"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -58033,7 +58189,7 @@
       "source_location": "L79"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -58042,7 +58198,7 @@
       "source_location": "L61"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -58051,7 +58207,7 @@
       "source_location": "L49"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -58060,7 +58216,7 @@
       "source_location": "L17"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -58069,7 +58225,7 @@
       "source_location": "L11"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -58078,7 +58234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -58087,7 +58243,7 @@
       "source_location": "L26"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -58096,7 +58252,7 @@
       "source_location": "L72"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -58105,48 +58261,12 @@
       "source_location": "L36"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
       "norm_label": "harness-test.ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "pre_push_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "pre_push_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "pre_push_review_test_warn",
-      "label": "warn()",
-      "norm_label": "warn()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_test_ts",
-      "label": "pre-push-review.test.ts",
-      "norm_label": "pre-push-review.test.ts",
-      "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -58296,6 +58416,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "pre_push_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pre_push_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pre_push_review_test_warn",
+      "label": "warn()",
+      "norm_label": "warn()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_test_ts",
+      "label": "pre-push-review.test.ts",
+      "norm_label": "pre-push-review.test.ts",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -58303,7 +58459,7 @@
       "source_location": "L98"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -58312,7 +58468,7 @@
       "source_location": "L33"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -58321,7 +58477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -58330,7 +58486,7 @@
       "source_location": "L85"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -58339,7 +58495,7 @@
       "source_location": "L31"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -58348,7 +58504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -58357,7 +58513,7 @@
       "source_location": "L12"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -58366,7 +58522,7 @@
       "source_location": "L21"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -58375,7 +58531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -58384,7 +58540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -58393,7 +58549,7 @@
       "source_location": "L5"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -58402,7 +58558,7 @@
       "source_location": "L12"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -58411,7 +58567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -58420,7 +58576,7 @@
       "source_location": "L14"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -58429,7 +58585,7 @@
       "source_location": "L10"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -58438,7 +58594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58447,7 +58603,7 @@
       "source_location": "L6"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -58456,7 +58612,7 @@
       "source_location": "L9"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -58465,7 +58621,7 @@
       "source_location": "L43"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -58474,7 +58630,7 @@
       "source_location": "L11"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -58483,7 +58639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -58492,7 +58648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -58501,7 +58657,7 @@
       "source_location": "L23"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -58510,7 +58666,7 @@
       "source_location": "L105"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -58519,7 +58675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -58528,40 +58684,13 @@
       "source_location": "L16"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
       "source_location": "L92"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
-      "label": "staffRoles.ts",
-      "norm_label": "staffroles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "staffroles_derivedefaultoperationalroles",
-      "label": "deriveDefaultOperationalRoles()",
-      "norm_label": "derivedefaultoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "staffroles_uniqueoperationalroles",
-      "label": "uniqueOperationalRoles()",
-      "norm_label": "uniqueoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L31"
     },
     {
       "community": 28,
@@ -58710,6 +58839,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
+      "label": "staffRoles.ts",
+      "norm_label": "staffroles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "staffroles_derivedefaultoperationalroles",
+      "label": "deriveDefaultOperationalRoles()",
+      "norm_label": "derivedefaultoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "staffroles_uniqueoperationalroles",
+      "label": "uniqueOperationalRoles()",
+      "norm_label": "uniqueoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
       "norm_label": "listtransactions()",
@@ -58717,7 +58873,7 @@
       "source_location": "L7"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -58726,7 +58882,7 @@
       "source_location": "L109"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -58735,7 +58891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -58744,7 +58900,7 @@
       "source_location": "L17"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -58753,7 +58909,7 @@
       "source_location": "L37"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -58762,7 +58918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -58771,7 +58927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -58780,7 +58936,7 @@
       "source_location": "L18"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -58789,7 +58945,7 @@
       "source_location": "L9"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -58798,7 +58954,7 @@
       "source_location": "L8"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -58807,7 +58963,7 @@
       "source_location": "L9"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -58816,7 +58972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -58825,7 +58981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -58834,7 +58990,7 @@
       "source_location": "L7"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -58843,7 +58999,7 @@
       "source_location": "L29"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -58852,7 +59008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -58861,7 +59017,7 @@
       "source_location": "L13"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -58870,7 +59026,7 @@
       "source_location": "L45"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -58879,7 +59035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -58888,7 +59044,7 @@
       "source_location": "L33"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -58897,7 +59053,7 @@
       "source_location": "L13"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -58906,7 +59062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -58915,7 +59071,7 @@
       "source_location": "L13"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -58924,7 +59080,7 @@
       "source_location": "L17"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -58933,7 +59089,7 @@
       "source_location": "L17"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -58942,40 +59098,13 @@
       "source_location": "L61"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
       "norm_label": "appointments.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
     },
     {
       "community": 29,
@@ -59115,6 +59244,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
       "norm_label": "receiving.test.ts",
@@ -59122,7 +59278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -59131,7 +59287,7 @@
       "source_location": "L20"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -59140,7 +59296,7 @@
       "source_location": "L16"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -59149,7 +59305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -59158,7 +59314,7 @@
       "source_location": "L12"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -59167,7 +59323,7 @@
       "source_location": "L7"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -59176,7 +59332,7 @@
       "source_location": "L25"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -59185,7 +59341,7 @@
       "source_location": "L21"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -59194,7 +59350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -59203,7 +59359,7 @@
       "source_location": "L7"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -59212,7 +59368,7 @@
       "source_location": "L14"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -59221,7 +59377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -59230,7 +59386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -59239,7 +59395,7 @@
       "source_location": "L45"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -59248,7 +59404,7 @@
       "source_location": "L37"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -59257,7 +59413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -59266,7 +59422,7 @@
       "source_location": "L10"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -59275,7 +59431,7 @@
       "source_location": "L44"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -59284,7 +59440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -59293,7 +59449,7 @@
       "source_location": "L84"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -59302,7 +59458,7 @@
       "source_location": "L100"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -59311,7 +59467,7 @@
       "source_location": "L5"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -59320,7 +59476,7 @@
       "source_location": "L25"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -59329,7 +59485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -59338,7 +59494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -59347,40 +59503,13 @@
       "source_location": "L35"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
       "norm_label": "normalizeworkflowtracelookupvalue()",
       "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
       "source_location": "L25"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_view_tsx",
-      "label": "View.tsx",
-      "norm_label": "view.tsx",
-      "source_file": "packages/athena-webapp/src/components/View.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_view_tsx",
-      "label": "View.tsx",
-      "norm_label": "view.tsx",
-      "source_file": "packages/storefront-webapp/src/components/View.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "view_view",
-      "label": "View()",
-      "norm_label": "view()",
-      "source_file": "packages/storefront-webapp/src/components/View.tsx",
-      "source_location": "L4"
     },
     {
       "community": 3,
@@ -59799,6 +59928,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_view_tsx",
+      "label": "View.tsx",
+      "norm_label": "view.tsx",
+      "source_file": "packages/athena-webapp/src/components/View.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_view_tsx",
+      "label": "View.tsx",
+      "norm_label": "view.tsx",
+      "source_file": "packages/storefront-webapp/src/components/View.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "view_view",
+      "label": "View()",
+      "norm_label": "view()",
+      "source_file": "packages/storefront-webapp/src/components/View.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
       "norm_label": "productavailability.tsx",
@@ -59806,7 +59962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -59815,7 +59971,7 @@
       "source_location": "L19"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -59824,7 +59980,7 @@
       "source_location": "L5"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -59833,7 +59989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -59842,7 +59998,7 @@
       "source_location": "L19"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -59851,7 +60007,7 @@
       "source_location": "L11"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -59860,7 +60016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -59869,7 +60025,7 @@
       "source_location": "L22"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -59878,7 +60034,7 @@
       "source_location": "L8"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -59887,7 +60043,7 @@
       "source_location": "L21"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -59896,7 +60052,7 @@
       "source_location": "L13"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -59905,7 +60061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -59914,7 +60070,7 @@
       "source_location": "L100"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -59923,7 +60079,7 @@
       "source_location": "L10"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -59932,7 +60088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -59941,7 +60097,7 @@
       "source_location": "L100"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -59950,7 +60106,7 @@
       "source_location": "L10"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -59959,7 +60115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -59968,7 +60124,7 @@
       "source_location": "L15"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -59977,7 +60133,7 @@
       "source_location": "L39"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -59986,7 +60142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -59995,7 +60151,7 @@
       "source_location": "L3"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -60004,7 +60160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -60013,7 +60169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -60022,7 +60178,7 @@
       "source_location": "L53"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -60031,39 +60187,12 @@
       "source_location": "L65"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
       "norm_label": "bestsellers.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
     },
     {
@@ -60195,6 +60324,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
       "norm_label": "videoplayer.tsx",
@@ -60202,7 +60358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -60211,7 +60367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -60220,7 +60376,7 @@
       "source_location": "L9"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -60229,7 +60385,7 @@
       "source_location": "L295"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -60238,7 +60394,7 @@
       "source_location": "L285"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -60247,7 +60403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -60256,7 +60412,7 @@
       "source_location": "L70"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -60265,7 +60421,7 @@
       "source_location": "L227"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -60274,7 +60430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -60283,7 +60439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -60292,7 +60448,7 @@
       "source_location": "L71"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -60301,7 +60457,7 @@
       "source_location": "L9"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -60310,7 +60466,7 @@
       "source_location": "L100"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -60319,7 +60475,7 @@
       "source_location": "L95"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -60328,25 +60484,25 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
-      "id": "cashierauthdialog_authenticatestaff",
-      "label": "authenticateStaff()",
-      "norm_label": "authenticatestaff()",
+      "id": "cashierauthdialog_cashierauthdialog",
+      "label": "CashierAuthDialog()",
+      "norm_label": "cashierauthdialog()",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L48"
+      "source_location": "L33"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
       "norm_label": "getstaffdisplayname()",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L23"
+      "source_location": "L24"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -60355,7 +60511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -60364,7 +60520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -60373,7 +60529,7 @@
       "source_location": "L115"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -60382,7 +60538,7 @@
       "source_location": "L82"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -60391,7 +60547,7 @@
       "source_location": "L28"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -60400,40 +60556,13 @@
       "source_location": "L34"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
       "norm_label": "expensereportsview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "label": "RegisterDrawerGate.tsx",
-      "norm_label": "registerdrawergate.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "registerdrawergate_cashcontrolsbutton",
-      "label": "CashControlsButton()",
-      "norm_label": "cashcontrolsbutton()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "registerdrawergate_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L45"
     },
     {
       "community": 319,
@@ -61000,7 +61129,7 @@
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L157"
+      "source_location": "L158"
     },
     {
       "community": 330,
@@ -61009,7 +61138,7 @@
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L104"
+      "source_location": "L105"
     },
     {
       "community": 331,
@@ -63835,7 +63964,7 @@
       "label": "asBoolean()",
       "norm_label": "asboolean()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L170"
+      "source_location": "L191"
     },
     {
       "community": 40,
@@ -63844,7 +63973,7 @@
       "label": "asNumber()",
       "norm_label": "asnumber()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L174"
+      "source_location": "L195"
     },
     {
       "community": 40,
@@ -63853,7 +63982,7 @@
       "label": "asRecord()",
       "norm_label": "asrecord()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L162"
+      "source_location": "L183"
     },
     {
       "community": 40,
@@ -63862,7 +63991,7 @@
       "label": "buildRegisterSessionCloseoutReview()",
       "norm_label": "buildregistersessioncloseoutreview()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L224"
+      "source_location": "L245"
     },
     {
       "community": 40,
@@ -63871,7 +64000,7 @@
       "label": "cancelPendingApprovalIfNeeded()",
       "norm_label": "cancelpendingapprovalifneeded()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L360"
+      "source_location": "L381"
     },
     {
       "community": 40,
@@ -63880,7 +64009,7 @@
       "label": "getCashControlsConfig()",
       "norm_label": "getcashcontrolsconfig()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L205"
+      "source_location": "L226"
     },
     {
       "community": 40,
@@ -63889,7 +64018,7 @@
       "label": "listRegisterSessionsForCloseout()",
       "norm_label": "listregistersessionsforcloseout()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L278"
+      "source_location": "L299"
     },
     {
       "community": 40,
@@ -63898,7 +64027,7 @@
       "label": "listStaffNames()",
       "norm_label": "liststaffnames()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L308"
+      "source_location": "L329"
     },
     {
       "community": 40,
@@ -63907,7 +64036,7 @@
       "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
       "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L183"
+      "source_location": "L204"
     },
     {
       "community": 40,
@@ -63916,7 +64045,7 @@
       "label": "staffProfileCanReviewCloseoutVariance()",
       "norm_label": "staffprofilecanreviewcloseoutvariance()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L325"
+      "source_location": "L346"
     },
     {
       "community": 40,
@@ -63925,7 +64054,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L178"
+      "source_location": "L199"
     },
     {
       "community": 40,
@@ -64857,101 +64986,101 @@
     {
       "community": 43,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 430,
@@ -65136,101 +65265,101 @@
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 440,
@@ -65415,101 +65544,101 @@
     {
       "community": 45,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 450,
@@ -65694,101 +65823,101 @@
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 460,
@@ -67462,7 +67591,7 @@
       "label": "ExpenseCompletion()",
       "norm_label": "expensecompletion()",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L31"
+      "source_location": "L24"
     },
     {
       "community": 513,
@@ -71107,7 +71236,7 @@
       "label": "deferred()",
       "norm_label": "deferred()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L165"
+      "source_location": "L176"
     },
     {
       "community": 642,
@@ -72021,73 +72150,73 @@
     {
       "community": 68,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -72273,74 +72402,74 @@
     {
       "community": 69,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 690,
@@ -72750,74 +72879,74 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 700,
@@ -73002,74 +73131,74 @@
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
     },
     {
       "community": 710,
@@ -73254,74 +73383,74 @@
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2348"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
+      "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2342"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
+      "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2338"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
+      "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2358"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
+      "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2104"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
+      "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2194"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
+      "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2086"
     },
     {
       "community": 720,
@@ -73506,74 +73635,74 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2348"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2342"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2338"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2358"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2104"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2194"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2086"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 730,
@@ -75310,7 +75439,7 @@
       "label": "combinePaymentsByMethod()",
       "norm_label": "combinepaymentsbymethod()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L86"
+      "source_location": "L90"
     },
     {
       "community": 80,
@@ -75319,7 +75448,7 @@
       "label": "createPaymentId()",
       "norm_label": "createpaymentid()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L106"
+      "source_location": "L110"
     },
     {
       "community": 80,
@@ -75328,7 +75457,7 @@
       "label": "hasCustomerDetails()",
       "norm_label": "hascustomerdetails()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L58"
+      "source_location": "L62"
     },
     {
       "community": 80,
@@ -75337,7 +75466,7 @@
       "label": "mapSessionCustomer()",
       "norm_label": "mapsessioncustomer()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L73"
+      "source_location": "L77"
     },
     {
       "community": 80,
@@ -75346,7 +75475,7 @@
       "label": "presentOperatorError()",
       "norm_label": "presentoperatorerror()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L118"
+      "source_location": "L122"
     },
     {
       "community": 80,
@@ -75355,7 +75484,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L113"
+      "source_location": "L117"
     },
     {
       "community": 80,
@@ -75364,7 +75493,7 @@
       "label": "useRegisterViewModel()",
       "norm_label": "useregisterviewmodel()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L122"
+      "source_location": "L126"
     },
     {
       "community": 800,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1525
-- Graph nodes: 3987
-- Graph edges: 3559
+- Graph nodes: 3992
+- Graph edges: 3566
 - Communities: 1453
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 262) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 263) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -107,6 +107,12 @@ type ReviewRegisterSessionCloseoutResult =
       registerSession: Doc<"registerSession"> | null;
     };
 
+type ReopenRegisterSessionResult = {
+  action: "reopened";
+  approvalRequest: Doc<"approvalRequest"> | null;
+  registerSession: Doc<"registerSession"> | null;
+};
+
 const closeoutReviewValidator = v.object({
   hasVariance: v.boolean(),
   reason: v.optional(v.string()),
@@ -152,6 +158,21 @@ const reviewRegisterSessionCloseoutResultValidator = v.union(
         registerSession: v.union(v.null(), v.any()),
       }),
     ),
+  }),
+  v.object({
+    kind: v.literal("user_error"),
+    error: userErrorValidator,
+  }),
+);
+
+const reopenRegisterSessionResultValidator = v.union(
+  v.object({
+    kind: v.literal("ok"),
+    data: v.object({
+      action: v.literal("reopened"),
+      approvalRequest: v.union(v.null(), v.any()),
+      registerSession: v.union(v.null(), v.any()),
+    }),
   }),
   v.object({
     kind: v.literal("user_error"),
@@ -360,6 +381,7 @@ async function staffProfileCanReviewCloseoutVariance(
 async function cancelPendingApprovalIfNeeded(args: {
   ctx: Pick<MutationCtx, "db" | "runMutation">;
   approvalRequestId?: Id<"approvalRequest">;
+  decisionNotes?: string;
   reviewedByUserId?: Id<"athenaUser">;
   reviewedByStaffProfileId?: Id<"staffProfile">;
 }): Promise<Doc<"approvalRequest"> | null> {
@@ -381,7 +403,8 @@ async function cancelPendingApprovalIfNeeded(args: {
     decision: "cancelled",
     reviewedByStaffProfileId: args.reviewedByStaffProfileId,
     reviewedByUserId: args.reviewedByUserId,
-    decisionNotes: "Superseded by a new register closeout submission.",
+    decisionNotes:
+      args.decisionNotes ?? "Superseded by a new register closeout submission.",
   });
 }
 
@@ -718,6 +741,70 @@ export const submitRegisterSessionCloseout = mutation({
       action: "closed" as const,
       closeoutReview,
       registerSession: closedSession,
+    });
+  },
+});
+
+export const reopenRegisterSessionCloseout = mutation({
+  args: {
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
+    actorUserId: v.optional(v.id("athenaUser")),
+    registerSessionId: v.id("registerSession"),
+    storeId: v.id("store"),
+  },
+  returns: reopenRegisterSessionResultValidator,
+  handler: async (
+    ctx: MutationCtx,
+    args
+  ): Promise<CommandResult<ReopenRegisterSessionResult>> => {
+    const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
+
+    if (!registerSession || registerSession.storeId !== args.storeId) {
+      return userError({
+        code: "not_found",
+        message: "Register session not found for this store.",
+      });
+    }
+
+    if (registerSession.status !== "closing") {
+      return userError({
+        code: "precondition_failed",
+        message: "Register session is not in closeout.",
+      });
+    }
+
+    const approvalRequest = await cancelPendingApprovalIfNeeded({
+      approvalRequestId: registerSession.managerApprovalRequestId,
+      ctx,
+      decisionNotes: "Register closeout reopened from POS.",
+      reviewedByStaffProfileId: args.actorStaffProfileId,
+      reviewedByUserId: args.actorUserId,
+    });
+
+    const reopenedSession = await ctx.runMutation(
+      internal.operations.registerSessions.reopenRegisterSession,
+      {
+        registerSessionId: args.registerSessionId,
+      }
+    );
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorStaffProfileId: args.actorStaffProfileId,
+      actorUserId: args.actorUserId,
+      eventType: "register_session_closeout_reopened",
+      message: "Register closeout reopened from POS.",
+      organizationId: registerSession.organizationId,
+      registerSessionId: registerSession._id,
+      storeId: args.storeId,
+      subjectId: registerSession._id,
+      subjectLabel: registerSession.registerNumber,
+      subjectType: "register_session",
+    });
+
+    return ok({
+      action: "reopened",
+      approvalRequest,
+      registerSession: reopenedSession,
     });
   },
 });

--- a/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
@@ -7,6 +7,7 @@ import {
   buildClosedRegisterSessionPatch,
   buildRegisterSessionDepositPatch,
   buildRegisterSessionCloseoutPatch,
+  buildReopenedRegisterSessionPatch,
   buildRegisterSession,
   buildRegisterSessionTransactionPatch,
   calculateRegisterSessionCashDelta,
@@ -66,6 +67,10 @@ describe("cash controls register sessions", () => {
 
     expect(() =>
       assertValidRegisterSessionTransition("closing", "closed")
+    ).not.toThrow();
+
+    expect(() =>
+      assertValidRegisterSessionTransition("closing", "active")
     ).not.toThrow();
 
     expect(() =>
@@ -192,6 +197,19 @@ describe("cash controls register sessions", () => {
       variance: 200,
     });
     expect(closedPatch.closedAt).toEqual(expect.any(Number));
+  });
+
+  it("reopens closeout sessions by clearing closeout draft fields", () => {
+    expect(
+      buildReopenedRegisterSessionPatch({
+        status: "closing",
+      })
+    ).toEqual({
+      countedCash: undefined,
+      managerApprovalRequestId: undefined,
+      status: "active",
+      variance: undefined,
+    });
   });
 
   it("subtracts recorded deposits from expected cash without letting the drawer go negative", () => {

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -15,7 +15,7 @@ const registerSessionStatusSet = (
 const REGISTER_SESSION_TRANSITIONS = {
   active: registerSessionStatusSet("closing"),
   closed: registerSessionStatusSet(),
-  closing: registerSessionStatusSet("closed"),
+  closing: registerSessionStatusSet("active", "closed"),
   open: registerSessionStatusSet("active", "closing"),
 } satisfies Record<RegisterSessionStatus, ReadonlySet<RegisterSessionStatus>>;
 type RegisterSessionIdentity = {
@@ -208,6 +208,19 @@ export function buildRegisterSessionCloseoutPatch(
       args.countedCash !== undefined
         ? args.countedCash - session.expectedCash
         : session.variance,
+  };
+}
+
+export function buildReopenedRegisterSessionPatch(session: {
+  status: RegisterSessionStatus;
+}) {
+  assertValidRegisterSessionTransition(session.status, "active");
+
+  return {
+    countedCash: undefined,
+    managerApprovalRequestId: undefined,
+    status: "active" as const,
+    variance: undefined,
   };
 }
 
@@ -537,6 +550,26 @@ export const beginRegisterSessionCloseout = internalMutation({
       "registerSession",
       args.registerSessionId,
       buildRegisterSessionCloseoutPatch(session, args)
+    );
+
+    return ctx.db.get("registerSession", args.registerSessionId);
+  },
+});
+
+export const reopenRegisterSession = internalMutation({
+  args: {
+    registerSessionId: v.id("registerSession"),
+  },
+  handler: async (ctx, args) => {
+    const session = await ctx.db.get("registerSession", args.registerSessionId);
+    if (!session) {
+      throw new Error("Register session not found.");
+    }
+
+    await ctx.db.patch(
+      "registerSession",
+      args.registerSessionId,
+      buildReopenedRegisterSessionPatch(session)
     );
 
     return ctx.db.get("registerSession", args.registerSessionId);

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -516,21 +516,19 @@ export function RegisterSessionViewContent({
   const closeoutStaffAuthCopy =
     closeoutStaffAuthIntent?.kind === "review"
       ? {
-          title:
-            closeoutStaffAuthIntent.decision === "approved"
-              ? "Approve variance"
-              : "Reject variance",
+          title: "Manager sign-in required",
           description:
-            "Confirm manager credentials so this variance decision is attributed correctly.",
+            closeoutStaffAuthIntent.decision === "approved"
+              ? "Enter username and PIN to approve variance."
+              : "Enter username and PIN to reject variance.",
           submitLabel:
             closeoutStaffAuthIntent.decision === "approved"
               ? "Approve variance"
               : "Reject variance",
         }
       : {
-          title: "Submit closeout",
-          description:
-            "Confirm staff credentials so the closeout and any variance request are attributed correctly.",
+          title: "Closeout sign-in required",
+          description: "Enter username and PIN to submit closeout.",
           submitLabel: "Submit closeout",
         };
 

--- a/packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx
+++ b/packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx
@@ -1,14 +1,7 @@
-import { useQuery } from "convex/react";
-
-import { api } from "~/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { CartItem } from "../pos/types";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { currencyFormatter } from "~/convex/utils";
-import { CashierView } from "../pos/CashierView";
-import { useExpenseStore } from "~/src/stores/expenseStore";
-import { useExpenseActiveSession } from "~/src/hooks/useExpenseSessions";
-import { useSessionManagementExpense } from "~/src/hooks/useSessionManagementExpense";
 import { toDisplayAmount } from "~/convex/lib/currency";
 
 interface ExpenseCompletionProps {
@@ -41,36 +34,6 @@ export function ExpenseCompletion({
 }: ExpenseCompletionProps) {
   const { activeStore } = useGetActiveStore();
   const formatter = currencyFormatter(activeStore?.currency || "GHS");
-
-  const staffProfileId = useExpenseStore((state) => state.cashier.id);
-  const terminalId = useExpenseStore((state) => state.terminalId);
-  const storeId = useExpenseStore((state) => state.storeId);
-  const clearCashier = useExpenseStore((state) => state.clearCashier);
-  const activeSession = useExpenseActiveSession(
-    storeId,
-    terminalId,
-    staffProfileId || undefined,
-  );
-  const { voidSession } = useSessionManagementExpense();
-  const staffProfile = useQuery(
-    api.operations.staffProfiles.getStaffProfileById,
-    staffProfileId ? { staffProfileId } : "skip",
-  );
-  const cashierName = staffProfile
-    ? staffProfile.fullName ||
-      [staffProfile.firstName, staffProfile.lastName].filter(Boolean).join(" ")
-    : "Unassigned";
-
-  const handleCashierSignOut = async () => {
-    if (activeSession) {
-      const result = await voidSession();
-      if (!result.success) {
-        return;
-      }
-    }
-
-    clearCashier();
-  };
 
   //   if (isCompleted && completedTransactionData) {
   //     return (
@@ -147,20 +110,18 @@ export function ExpenseCompletion({
 
         <Button
           onClick={onComplete}
-          disabled={isCompleting || cartItems.length === 0}
+          disabled={!isCompleted && (isCompleting || cartItems.length === 0)}
           className="w-full p-8 bg-green-500 text-white hover:text-white hover:bg-green-600"
           variant="outline"
           size="lg"
         >
-          {isCompleting ? "Recording Expense..." : "Complete Expense"}
+          {isCompleted
+            ? "Start new expense"
+            : isCompleting
+              ? "Recording expense..."
+              : "Complete expense"}
         </Button>
 
-        {storeId && terminalId && staffProfileId && (
-          <CashierView
-            cashierName={cashierName}
-            onSignOut={handleCashierSignOut}
-          />
-        )}
       </div>
     </div>
   );

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -193,7 +193,7 @@ describe("CashierAuthDialog", () => {
     renderDialog({ authenticateMutation, workflowMode: "expense" });
 
     expect(
-      screen.getByRole("heading", { name: "Start expense session" }),
+      screen.getByRole("heading", { name: "Expense sign-in required" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Sign out from other sessions" }),
@@ -277,7 +277,7 @@ describe("CashierAuthDialog", () => {
       screen.getByRole("heading", { name: "Sign out from other registers" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Start register session" }),
+      screen.getByRole("button", { name: "Return to sign in" }),
     ).toBeInTheDocument();
 
     await submitCredentials(user);

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -15,6 +15,7 @@ interface CashierAuthDialogProps {
   onAuthenticated: (staffProfileId: Id<"staffProfile">) => void;
   onDismiss: () => void;
   open: boolean;
+  presentation?: "dialog" | "inline";
   storeId: Id<"store">;
   terminalId: Id<"posTerminal">;
   workflowMode?: RegisterWorkflowMode;
@@ -33,6 +34,7 @@ export function CashierAuthDialog({
   onAuthenticated,
   onDismiss,
   open,
+  presentation = "dialog",
   storeId,
   terminalId,
   workflowMode = "pos",
@@ -85,7 +87,15 @@ export function CashierAuthDialog({
     return authenticationResult;
   }
 
-  const sessionLabel = isExpenseWorkflow ? "expense session" : "register session";
+  const primaryCopy = isExpenseWorkflow
+    ? {
+        title: "Expense sign-in required",
+        description: "Enter username and PIN before recording expenses.",
+      }
+    : {
+        title: "Register sign-in required",
+        description: "Enter username and PIN before adding items.",
+      };
   const recoveryLabel = isExpenseWorkflow
     ? "Sign out from other sessions"
     : "Sign out from other registers";
@@ -93,10 +103,11 @@ export function CashierAuthDialog({
   return (
     <StaffAuthenticationDialog
       open={open}
+      presentation={presentation}
       onDismiss={onDismiss}
       copy={{
-        title: `Start ${sessionLabel}`,
-        description: `Sign in with staff credentials before this ${sessionLabel} can continue.`,
+        title: primaryCopy.title,
+        description: primaryCopy.description,
         submitLabel: "Sign in",
       }}
       alternateCopy={{
@@ -109,7 +120,7 @@ export function CashierAuthDialog({
           : "Sign out from all registers",
       }}
       alternateTriggerLabel={recoveryLabel}
-      returnTriggerLabel={`Start ${sessionLabel}`}
+      returnTriggerLabel="Return to sign in"
       onAuthenticate={authenticateStaff}
       getSuccessMessage={(result, mode) => {
         if (mode === "recover") {

--- a/packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx
@@ -22,8 +22,21 @@ export function ExpenseCompletionPanel({
       totalValue: checkout.completedTransactionData.total,
     };
   }, [checkout.completedTransactionData]);
+  const displayCartItems =
+    checkout.isTransactionCompleted && completedTransactionData
+      ? completedTransactionData.cartItems
+      : checkout.cartItems;
+  const displayTotal =
+    checkout.isTransactionCompleted && completedTransactionData
+      ? completedTransactionData.totalValue
+      : checkout.total;
 
   const handleComplete = async () => {
+    if (checkout.isTransactionCompleted) {
+      checkout.onStartNewTransaction();
+      return;
+    }
+
     if (!checkout.onCompleteTransaction) {
       return;
     }
@@ -38,8 +51,8 @@ export function ExpenseCompletionPanel({
 
   return (
     <ExpenseCompletion
-      cartItems={checkout.cartItems}
-      totalValue={checkout.total}
+      cartItems={displayCartItems}
+      totalValue={displayTotal}
       notes=""
       onNotesChange={() => {}}
       onComplete={handleComplete}

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -86,7 +86,26 @@ vi.mock("@/components/pos/CashierAuthDialog", () => ({
 }));
 
 vi.mock("./RegisterActionBar", () => ({
-  RegisterActionBar: () => <div>register-action-bar</div>,
+  RegisterActionBar: ({
+    closeoutControl,
+  }: {
+    closeoutControl?: {
+      canCloseout: boolean;
+      onRequestCloseout: () => void;
+    } | null;
+  }) => (
+    <div>
+      register-action-bar
+      {closeoutControl ? (
+        <button
+          disabled={!closeoutControl.canCloseout}
+          onClick={closeoutControl.onRequestCloseout}
+        >
+          closeout-control
+        </button>
+      ) : null}
+    </div>
+  ),
 }));
 
 vi.mock("./RegisterCustomerPanel", () => ({
@@ -160,6 +179,10 @@ describe("POSRegisterView", () => {
       },
       sessionPanel: {},
       cashierCard: {},
+      closeoutControl: {
+        canCloseout: true,
+        onRequestCloseout: vi.fn(),
+      },
       authDialog: {
         open: false,
       },
@@ -171,6 +194,7 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("register-action-bar")).toBeInTheDocument();
+    expect(screen.getByText("closeout-control")).toBeInTheDocument();
     expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.getByText("product-search-input")).toBeInTheDocument();
     expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
@@ -180,7 +204,7 @@ describe("POSRegisterView", () => {
     expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
   });
 
-  it("hides selling controls while cashier authentication is missing", async () => {
+  it("renders cashier authentication in the product lookup space while keeping POS controls visible", async () => {
     mockUseRegisterViewModel.mockReturnValue({
       hasActiveStore: true,
       header: {
@@ -218,11 +242,10 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
-    expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-customer-panel")).not.toBeInTheDocument();
+    expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
-    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
   });
 
   it("renders expense completion UI in expense workflow without POS checkout controls", async () => {
@@ -330,6 +353,110 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
     expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
+  });
+
+  it("shows the expense entry state after an expense session completes", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "Expense Products",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        customerName: "Ama Serwa",
+        registerLabel: "Expenses",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        showProductLookup: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+        onAddProduct: vi.fn(),
+        setShowProductLookup: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: true,
+      },
+      workflowMode: "expense",
+      sessionPanel: null,
+      cashierCard: null,
+      drawerGate: null,
+      authDialog: {
+        open: false,
+      },
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByText("Ready for expense entry")).toBeInTheDocument();
+    expect(
+      screen.getByText("Search or scan products to add expense items"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
+    expect(screen.getByText("Cashier")).toBeInTheDocument();
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
+    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+  });
+
+  it("keeps the register shell around expense authentication", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "Expense Products",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        customerName: "Ama Serwa",
+        registerLabel: "Expenses",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        showProductLookup: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+        onAddProduct: vi.fn(),
+        setShowProductLookup: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: true,
+      },
+      workflowMode: "expense",
+      sessionPanel: null,
+      cashierCard: null,
+      drawerGate: null,
+      authDialog: {
+        open: true,
+      },
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    const authDialog = screen.getByText("cashier-auth-dialog");
+
+    expect(authDialog).toBeInTheDocument();
+    expect(authDialog.parentElement).not.toHaveClass("lg:col-span-2");
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
+    expect(screen.getByText("Cashier")).toBeInTheDocument();
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
+    expect(screen.queryByText("Ready for expense entry")).not.toBeInTheDocument();
   });
 
   it("keeps POS workflow behavior when expense completion data is present but mode is not set to expense", async () => {
@@ -445,7 +572,7 @@ describe("POSRegisterView", () => {
     expect(setProductSearchQuery).toHaveBeenCalledWith("");
   });
 
-  it("renders the drawer gate instead of the selling surface while drawer setup is pending", async () => {
+  it("renders the drawer gate in the product lookup space while drawer setup is pending", async () => {
     mockUseRegisterViewModel.mockReturnValue({
       hasActiveStore: true,
       header: {
@@ -498,15 +625,14 @@ describe("POSRegisterView", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Opening float (GH₵)")).toBeInTheDocument();
+    expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
-    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("register-checkout-panel"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
   });
 
-  it("renders recovery copy, inline errors, and escape actions while hiding sale controls", async () => {
+  it("renders recovery copy, inline errors, and escape actions in the product lookup space", async () => {
     const onSignOut = vi.fn();
     mockUseRegisterViewModel.mockReturnValue({
       hasActiveStore: true,
@@ -563,11 +689,10 @@ describe("POSRegisterView", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
     );
+    expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
-    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("register-checkout-panel"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
@@ -607,7 +732,18 @@ describe("POSRegisterView", () => {
         isRecovery: false,
         registerLabel: "Front Counter",
         registerNumber: "1",
+        currency: "GHS",
+        closeoutCountedCash: "",
+        closeoutDraftVariance: undefined,
+        closeoutNotes: "",
+        expectedCash: 5000,
         errorMessage: null,
+        isCloseoutSubmitting: false,
+        isReopeningCloseout: false,
+        onCloseoutCountedCashChange: vi.fn(),
+        onCloseoutNotesChange: vi.fn(),
+        onReopenRegister: vi.fn(),
+        onSubmitCloseout: vi.fn(),
         onSignOut,
       },
       sessionPanel: null,
@@ -621,28 +757,38 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Closeout in progress")).toBeInTheDocument();
+    expect(
+      screen.getByText("Register 1 closeout in progress"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Front Counter is already in closeout. Finish it in Cash Controls before selling here again./i,
+        /Finish this register closeout in Cash Controls before selling here./i,
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Expected")).toBeInTheDocument();
+    expect(screen.getByText("GH₵50")).toBeInTheDocument();
+    expect(screen.getByLabelText(/counted cash/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/closeout notes/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /submit closeout/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /reopen register/i }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /sign out/i }),
     ).toBeInTheDocument();
     expect(screen.queryByLabelText(/opening float/i)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /open drawer/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
-    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("register-checkout-panel"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /sign out/i }));

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -1,6 +1,7 @@
 import { ComposedPageHeader } from "@/components/common/PageHeader";
 import { FadeIn } from "@/components/common/FadeIn";
 import { CashierAuthDialog } from "@/components/pos/CashierAuthDialog";
+import { CashierView } from "@/components/pos/CashierView";
 import { CartItems } from "@/components/pos/CartItems";
 import {
   ProductEntry,
@@ -57,7 +58,13 @@ function useCollapseSidebarForPosFlow() {
   }, []);
 }
 
-function ProductLookupEmptyState() {
+function ProductLookupEmptyState({
+  workflowMode,
+}: {
+  workflowMode: RegisterWorkflowMode;
+}) {
+  const isExpenseWorkflow = workflowMode === "expense";
+
   return (
     <div className="flex h-full min-h-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gradient-to-br from-gray-50/50 to-gray-100/30 p-8 text-center">
       <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-white text-muted-foreground shadow-sm ">
@@ -65,10 +72,14 @@ function ProductLookupEmptyState() {
       </div>
       <div className="space-y-1">
         <p className="text-sm font-medium text-gray-900">
-          Ready for product lookup
+          {isExpenseWorkflow
+            ? "Ready for expense entry"
+            : "Ready for product lookup"}
         </p>
         <p className="text-sm text-muted-foreground">
-          Scan a barcode or search products to add items to this sale
+          {isExpenseWorkflow
+            ? "Search or scan products to add expense items"
+            : "Scan a barcode or search products to add items to this sale"}
         </p>
       </div>
       <div className="mt-5 flex items-center gap-2 text-xs text-muted-foreground">
@@ -83,6 +94,38 @@ function ProductLookupEmptyState() {
             ⌘+K
           </kbd>
         </span>
+      </div>
+    </div>
+  );
+}
+
+function CashierAuthWorkspace({
+  authDialog,
+}: {
+  authDialog: NonNullable<RegisterViewModel["authDialog"]>;
+}) {
+  return (
+    <CashierAuthDialog
+      open={authDialog.open}
+      presentation="inline"
+      storeId={authDialog.storeId}
+      terminalId={authDialog.terminalId}
+      workflowMode={authDialog.workflowMode}
+      onAuthenticated={authDialog.onAuthenticated}
+      onDismiss={authDialog.onDismiss}
+    />
+  );
+}
+
+function DrawerGateWorkspace({
+  drawerGate,
+}: {
+  drawerGate: NonNullable<RegisterViewModel["drawerGate"]>;
+}) {
+  return (
+    <div className="flex h-full min-h-0 items-start justify-center overflow-y-auto rounded-lg border border-gray-200 bg-gradient-to-br from-gray-50/50 to-gray-100/30 px-6 py-10 sm:px-8 sm:pt-20">
+      <div className="w-[min(100%,40rem)]">
+        <RegisterDrawerGate drawerGate={drawerGate} />
       </div>
     </div>
   );
@@ -126,10 +169,16 @@ export function POSRegisterView({
   const isHeaderProductSearchSupported =
     isSessionActive && canSearchProducts && !viewModel.productEntry.disabled;
   const shouldRenderSaleSurface =
-    !viewModel.checkout.isTransactionCompleted && !isAwaitingCashierAuth;
+    isPosWorkflow ? !viewModel.checkout.isTransactionCompleted : true;
+  const shouldRenderExpenseCompletionPanel = !isPosWorkflow;
   const shouldRenderCheckoutPanel =
-    !isAwaitingCashierAuth &&
-    (isPosWorkflow || !viewModel.checkout.isTransactionCompleted);
+    isPosWorkflow || shouldRenderExpenseCompletionPanel;
+  const shouldRenderCartSidebar =
+    shouldRenderSaleSurface && !shouldShowPaymentWorkspace;
+  const shouldRenderWorkspaceSidebar =
+    shouldRenderCartSidebar ||
+    shouldRenderCheckoutPanel ||
+    isAwaitingCashierAuth;
 
   useEffect(() => {
     if (hasProductSearchIntent && isPaymentInputActive) {
@@ -264,6 +313,7 @@ export function POSRegisterView({
           trailingContent={
             canSearchProducts && isPosWorkflow ? (
               <RegisterActionBar
+                closeoutControl={viewModel.closeoutControl}
                 registerInfo={viewModel.registerInfo}
                 sessionPanel={viewModel.sessionPanel}
               />
@@ -273,69 +323,70 @@ export function POSRegisterView({
       }
     >
       <FadeIn className={registerContentClassName}>
-        {isPosWorkflow && viewModel.drawerGate ? (
-          <div className="flex h-full min-h-0 w-full items-center justify-center overflow-y-auto py-6">
-            <div className="w-full -translate-y-1/4">
-              <RegisterDrawerGate drawerGate={viewModel.drawerGate} />
-            </div>
-          </div>
-        ) : (
-          <div className="flex h-full min-h-0 flex-col gap-6 overflow-hidden">
-            {isPosWorkflow && shouldRenderSaleSurface ? (
-              <RegisterCustomerPanel
-                customerPanel={viewModel.customerPanel}
-                disabled={!isSessionActive}
-              />
+        <div className="flex h-full min-h-0 flex-col gap-6 overflow-hidden">
+          {isPosWorkflow && shouldRenderSaleSurface ? (
+            <RegisterCustomerPanel
+              customerPanel={viewModel.customerPanel}
+              disabled={!isSessionActive}
+            />
+          ) : null}
+
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-[minmax(0,2fr)_minmax(340px,1fr)]">
+            {shouldRenderSaleSurface ? (
+              <div
+                className={cn(
+                  "flex min-h-0 flex-col overflow-hidden pr-1",
+                  !shouldRenderWorkspaceSidebar && "lg:col-span-2",
+                )}
+              >
+                {isPosWorkflow && viewModel.drawerGate ? (
+                  <DrawerGateWorkspace drawerGate={viewModel.drawerGate} />
+                ) : isAwaitingCashierAuth && viewModel.authDialog ? (
+                  <CashierAuthWorkspace authDialog={viewModel.authDialog} />
+                ) : shouldShowPaymentWorkspace ? (
+                  <CartItems
+                    cartItems={viewModel.cart.items}
+                    onUpdateQuantity={viewModel.cart.onUpdateQuantity}
+                    onRemoveItem={viewModel.cart.onRemoveItem}
+                    clearCart={viewModel.cart.onClearCart}
+                    density="comfortable"
+                  />
+                ) : hasProductSearchIntent ? (
+                  <div className="min-h-0 flex-1">
+                    <ProductEntry
+                      ref={productEntryRef}
+                      disabled={viewModel.productEntry.disabled}
+                      showProductLookup={viewModel.productEntry.showProductLookup}
+                      setShowProductLookup={
+                        viewModel.productEntry.setShowProductLookup
+                      }
+                      productSearchQuery={viewModel.productEntry.productSearchQuery}
+                      setProductSearchQuery={
+                        viewModel.productEntry.setProductSearchQuery
+                      }
+                      onBarcodeSubmit={viewModel.productEntry.onBarcodeSubmit}
+                      onAddProduct={viewModel.productEntry.onAddProduct}
+                      barcodeSearchResult={
+                        viewModel.productEntry.barcodeSearchResult
+                      }
+                      productIdSearchResults={
+                        viewModel.productEntry.productIdSearchResults
+                      }
+                      showSearchInput={false}
+                      containerClassName="h-full min-h-0"
+                      lookupPanelClassName="flex h-full min-h-0 flex-col overflow-hidden"
+                      resultsClassName="max-h-none min-h-0 flex-1 pr-1"
+                    />
+                  </div>
+                ) : (
+                  <ProductLookupEmptyState
+                    workflowMode={effectiveWorkflowMode}
+                  />
+                )}
+              </div>
             ) : null}
 
-            <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-[minmax(0,2fr)_minmax(340px,1fr)]">
-              {shouldRenderSaleSurface ? (
-                <div className="flex min-h-0 flex-col overflow-hidden pr-1">
-                  {shouldShowPaymentWorkspace ? (
-                    <CartItems
-                      cartItems={viewModel.cart.items}
-                      onUpdateQuantity={viewModel.cart.onUpdateQuantity}
-                      onRemoveItem={viewModel.cart.onRemoveItem}
-                      clearCart={viewModel.cart.onClearCart}
-                      density="comfortable"
-                    />
-                  ) : hasProductSearchIntent ? (
-                    <div className="min-h-0 flex-1">
-                      <ProductEntry
-                        ref={productEntryRef}
-                        disabled={viewModel.productEntry.disabled}
-                        showProductLookup={
-                          viewModel.productEntry.showProductLookup
-                        }
-                        setShowProductLookup={
-                          viewModel.productEntry.setShowProductLookup
-                        }
-                        productSearchQuery={
-                          viewModel.productEntry.productSearchQuery
-                        }
-                        setProductSearchQuery={
-                          viewModel.productEntry.setProductSearchQuery
-                        }
-                        onBarcodeSubmit={viewModel.productEntry.onBarcodeSubmit}
-                        onAddProduct={viewModel.productEntry.onAddProduct}
-                        barcodeSearchResult={
-                          viewModel.productEntry.barcodeSearchResult
-                        }
-                        productIdSearchResults={
-                          viewModel.productEntry.productIdSearchResults
-                        }
-                        showSearchInput={false}
-                        containerClassName="h-full min-h-0"
-                        lookupPanelClassName="flex h-full min-h-0 flex-col overflow-hidden"
-                        resultsClassName="max-h-none min-h-0 flex-1 pr-1"
-                      />
-                    </div>
-                  ) : (
-                    <ProductLookupEmptyState />
-                  )}
-                </div>
-              ) : null}
-
+            {shouldRenderWorkspaceSidebar ? (
               <div
                 className={cn(
                   "flex h-full min-h-0 overflow-hidden",
@@ -343,7 +394,7 @@ export function POSRegisterView({
                 )}
               >
                 <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
-                  {shouldRenderSaleSurface && !shouldShowPaymentWorkspace ? (
+                  {shouldRenderCartSidebar ? (
                     <CartItems
                       cartItems={viewModel.cart.items}
                       onUpdateQuantity={viewModel.cart.onUpdateQuantity}
@@ -375,14 +426,28 @@ export function POSRegisterView({
                       )}
                     </div>
                   ) : null}
+
+                  {!isPosWorkflow ? (
+                    <div className="shrink-0">
+                      <CashierView
+                        cashierName={
+                          viewModel.cashierCard?.cashierName ?? "Unassigned"
+                        }
+                        isSignInRequired={
+                          isAwaitingCashierAuth || !viewModel.cashierCard
+                        }
+                        onSignOut={viewModel.cashierCard?.onSignOut}
+                      />
+                    </div>
+                  ) : null}
                 </div>
               </div>
+            ) : null}
             </div>
           </div>
-        )}
       </FadeIn>
 
-      {viewModel.authDialog && (
+      {viewModel.authDialog && !isAwaitingCashierAuth && (
         <CashierAuthDialog
           open={viewModel.authDialog.open}
           storeId={viewModel.authDialog.storeId}

--- a/packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx
@@ -1,23 +1,26 @@
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, LockKeyhole } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import type {
+  RegisterCloseoutControlState,
   RegisterInfoState,
   RegisterSessionPanelState,
 } from "@/lib/pos/presentation/register/registerUiState";
+import { Button } from "@/components/ui/button";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { cn } from "~/src/lib/utils";
 
 import { RegisterActions } from "../RegisterActions";
 import { RegisterSessionPanel } from "./RegisterSessionPanel";
-import { FadeIn } from "../../common/FadeIn";
 
 interface RegisterActionBarProps {
+  closeoutControl: RegisterCloseoutControlState | null;
   registerInfo: RegisterInfoState;
   sessionPanel: RegisterSessionPanelState | null;
 }
 
 export function RegisterActionBar({
+  closeoutControl,
   registerInfo,
   sessionPanel,
 }: RegisterActionBarProps) {
@@ -36,6 +39,18 @@ export function RegisterActionBar({
           registerNumber={registerInfo.registerLabel}
           hasTerminal={registerInfo.hasTerminal}
         />
+        {closeoutControl ? (
+          <Button
+            className="h-10"
+            disabled={!closeoutControl.canCloseout}
+            onClick={closeoutControl.onRequestCloseout}
+            type="button"
+            variant="outline"
+          >
+            <LockKeyhole className="mr-2 h-4 w-4" />
+            Closeout
+          </Button>
+        ) : null}
         {!registerInfo.hasTerminal && (
           <Link
             params={(params) => ({

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -4,10 +4,15 @@ import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { Textarea } from "@/components/ui/textarea";
+import { formatStoredAmount } from "@/lib/pos/displayAmounts";
 import type { RegisterDrawerGateState } from "@/lib/pos/presentation/register/registerUiState";
 import { getOrigin } from "~/src/lib/navigationUtils";
-import { currencyDisplaySymbol } from "~/shared/currencyFormatter";
+import {
+  currencyDisplaySymbol,
+  currencyFormatter,
+} from "~/shared/currencyFormatter";
 
 function CashControlsButton({
   className,
@@ -37,6 +42,22 @@ function CashControlsButton({
   );
 }
 
+function formatCurrency(currency: string, amount?: number | null) {
+  if (amount === undefined || amount === null) {
+    return "Pending";
+  }
+
+  return formatStoredAmount(currencyFormatter(currency), amount);
+}
+
+function getVarianceTone(variance?: number) {
+  if (variance === undefined || variance === 0) {
+    return "text-stone-900";
+  }
+
+  return variance > 0 ? "text-emerald-700" : "text-red-700";
+}
+
 export function RegisterDrawerGate({
   drawerGate,
 }: {
@@ -46,49 +67,131 @@ export function RegisterDrawerGate({
     event.preventDefault();
     void drawerGate.onSubmit?.();
   };
+  const handleCloseoutSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void drawerGate.onSubmitCloseout?.();
+  };
   const isCloseoutBlocked = drawerGate.mode === "closeoutBlocked";
   const isRecovery = drawerGate.mode === "recovery";
 
   if (isCloseoutBlocked) {
+    const currency = drawerGate.currency ?? "GHS";
+
     return (
       <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
-        <div className="space-y-3">
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-stone-500">
-            Register closeout
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-stone-900">
+            Register {drawerGate.registerNumber} closeout in progress
+          </h2>
+          <p className="text-sm text-stone-600">
+            Finish this register closeout in Cash Controls before selling here.
           </p>
-          <div className="space-y-1">
-            <h2 className="text-2xl font-semibold text-stone-900">
-              Closeout in progress
-            </h2>
-            <p className="text-sm text-stone-600">
-              {drawerGate.registerLabel} is already in closeout. Finish it in
-              Cash Controls before selling here again.
-            </p>
-            <p className="text-sm text-stone-500">
-              Register {drawerGate.registerNumber}
-            </p>
+        </div>
+
+        <form className="mt-8 space-y-5" onSubmit={handleCloseoutSubmit}>
+          <div className="rounded-lg border border-stone-200 bg-stone-50/70 p-4">
+            <dl className="grid grid-cols-2 gap-3 text-sm">
+              <div className="space-y-1">
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  Expected
+                </dt>
+                <dd className="font-mono text-stone-900">
+                  {formatCurrency(currency, drawerGate.expectedCash)}
+                </dd>
+              </div>
+              <div className="space-y-1">
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  Draft variance
+                </dt>
+                <dd
+                  className={`font-mono ${getVarianceTone(drawerGate.closeoutDraftVariance)}`}
+                >
+                  {drawerGate.closeoutDraftVariance === undefined
+                    ? "Pending count"
+                    : formatCurrency(currency, drawerGate.closeoutDraftVariance)}
+                </dd>
+              </div>
+            </dl>
           </div>
-        </div>
 
-        {drawerGate.errorMessage ? (
-          <p className="mt-6 text-sm text-red-600" role="alert">
-            {drawerGate.errorMessage}
-          </p>
-        ) : null}
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-stone-700">
+              Counted cash ({currencyDisplaySymbol(currency)})
+            </span>
+            <Input
+              autoFocus
+              disabled={drawerGate.isCloseoutSubmitting}
+              inputMode="decimal"
+              onChange={(event) =>
+                drawerGate.onCloseoutCountedCashChange?.(event.target.value)
+              }
+              placeholder="0.00"
+              value={drawerGate.closeoutCountedCash ?? ""}
+            />
+          </label>
 
-        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <CashControlsButton className="w-full sm:w-auto" variant="default" />
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-stone-700">
+              Closeout notes
+            </span>
+            <Textarea
+              disabled={drawerGate.isCloseoutSubmitting}
+              onChange={(event) =>
+                drawerGate.onCloseoutNotesChange?.(event.target.value)
+              }
+              placeholder="Add drawer notes if anything needs follow-up."
+              rows={3}
+              value={drawerGate.closeoutNotes ?? ""}
+            />
+          </label>
 
-          <Button
-            className="w-full sm:w-auto"
-            onClick={() => void drawerGate.onSignOut()}
-            type="button"
-            variant="outline"
-          >
-            <LogOutIcon className="mr-2 h-4 w-4" />
-            Sign out
-          </Button>
-        </div>
+          {drawerGate.errorMessage ? (
+            <p className="text-sm text-red-600" role="alert">
+              {drawerGate.errorMessage}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <LoadingButton
+              className="w-full sm:w-auto"
+              disabled={Boolean(drawerGate.isCloseoutSubmitting)}
+              isLoading={Boolean(drawerGate.isCloseoutSubmitting)}
+              type="submit"
+            >
+              Submit closeout
+            </LoadingButton>
+
+            <LoadingButton
+              className="w-full sm:w-auto"
+              disabled={Boolean(
+                drawerGate.isCloseoutSubmitting ||
+                  drawerGate.isReopeningCloseout,
+              )}
+              isLoading={Boolean(drawerGate.isReopeningCloseout)}
+              onClick={() => void drawerGate.onReopenRegister?.()}
+              type="button"
+              variant="outline"
+            >
+              {drawerGate.closeoutSecondaryActionLabel ?? "Reopen register"}
+            </LoadingButton>
+
+            <CashControlsButton className="w-full sm:w-auto" />
+
+            <Button
+              className="w-full sm:w-auto"
+              disabled={
+                drawerGate.isCloseoutSubmitting ||
+                drawerGate.isReopeningCloseout
+              }
+              onClick={() => void drawerGate.onSignOut()}
+              type="button"
+              variant="outline"
+            >
+              <LogOutIcon className="mr-2 h-4 w-4" />
+              Sign out
+            </Button>
+          </div>
+        </form>
       </div>
     );
   }

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -6,7 +6,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -57,6 +56,7 @@ export type StaffAuthenticationDialogProps = {
   ) => void;
   onDismiss: () => void;
   open: boolean;
+  presentation?: "dialog" | "inline";
   returnTriggerLabel?: string;
 };
 
@@ -69,6 +69,7 @@ export function StaffAuthenticationDialog({
   onAuthenticated,
   onDismiss,
   open,
+  presentation = "dialog",
   returnTriggerLabel,
 }: StaffAuthenticationDialogProps) {
   const [mode, setMode] = useState<StaffAuthMode>("authenticate");
@@ -160,6 +161,100 @@ export function StaffAuthenticationDialog({
     }
   }
 
+  if (!open) {
+    return null;
+  }
+
+  const content = (
+    <div className="space-y-layout-xl p-layout-lg">
+      <div className="space-y-layout-xs text-left">
+        {presentation === "dialog" ? (
+          <DialogTitle>{activeCopy.title}</DialogTitle>
+        ) : (
+          <h2 className="text-lg font-semibold tracking-tight">
+            {activeCopy.title}
+          </h2>
+        )}
+        {presentation === "dialog" ? (
+          <DialogDescription className="text-sm text-muted-foreground">
+            {activeCopy.description}
+          </DialogDescription>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {activeCopy.description}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-layout-lg">
+        <div className="max-w-72 space-y-layout-xs">
+          <Label htmlFor="staff-auth-username">Username</Label>
+          <Input
+            ref={usernameInputRef}
+            id="staff-auth-username"
+            placeholder="Enter username"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={isAuthenticating}
+          />
+        </div>
+
+        <div className="space-y-layout-xs">
+          <Label htmlFor="staff-auth-pin">PIN</Label>
+          <PinInput
+            value={pin}
+            onChange={setPin}
+            disabled={isAuthenticating}
+            onKeyDown={handleKeyDown}
+            maxLength={6}
+            size="sm"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-layout-sm border-t pt-layout-lg sm:flex-row sm:items-center sm:justify-between">
+        {alternateCopy && alternateTriggerLabel ? (
+          <button
+            type="button"
+            className="text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onClick={() => {
+              setMode((currentMode) =>
+                currentMode === "authenticate" ? "recover" : "authenticate",
+              );
+              setPin("");
+            }}
+            disabled={isAuthenticating}
+          >
+            {mode === "authenticate"
+              ? alternateTriggerLabel
+              : returnTriggerLabel ?? copy.title}
+          </button>
+        ) : (
+          <span />
+        )}
+
+        <LoadingButton
+          onClick={handleSubmit}
+          isLoading={isAuthenticating}
+          disabled={!canSubmit || isAuthenticating}
+        >
+          {activeCopy.submitLabel}
+        </LoadingButton>
+      </div>
+    </div>
+  );
+
+  if (presentation === "inline") {
+    return (
+      <div className="flex h-full min-h-0 items-start justify-center overflow-y-auto rounded-lg border border-gray-200 bg-gradient-to-br from-gray-50/50 to-gray-100/30 px-6 py-10 sm:px-8 sm:pt-20">
+        <div className="w-[min(100%,32rem)] rounded-xl border border-border bg-white shadow-sm">
+          {content}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Dialog open={open} onOpenChange={onDismiss}>
       <DialogContent
@@ -167,74 +262,7 @@ export function StaffAuthenticationDialog({
         onPointerDownOutside={(event) => event.preventDefault()}
         onEscapeKeyDown={(event) => event.preventDefault()}
       >
-        <div className="space-y-layout-xl p-layout-lg">
-          <DialogHeader className="space-y-layout-xs text-left">
-            <p className="text-xs font-medium uppercase tracking-[0.28em] text-muted-foreground">
-              Staff authentication
-            </p>
-            <DialogTitle>{activeCopy.title}</DialogTitle>
-            <DialogDescription className="text-sm text-muted-foreground">
-              {activeCopy.description}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-layout-lg">
-            <div className="max-w-72 space-y-layout-xs">
-              <Label htmlFor="staff-auth-username">Username</Label>
-              <Input
-                ref={usernameInputRef}
-                id="staff-auth-username"
-                placeholder="Enter username"
-                value={username}
-                onChange={(event) => setUsername(event.target.value)}
-                onKeyDown={handleKeyDown}
-                disabled={isAuthenticating}
-              />
-            </div>
-
-            <div className="space-y-layout-xs">
-              <Label htmlFor="staff-auth-pin">PIN</Label>
-              <PinInput
-                value={pin}
-                onChange={setPin}
-                disabled={isAuthenticating}
-                onKeyDown={handleKeyDown}
-                maxLength={6}
-                size="sm"
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-layout-sm border-t pt-layout-lg sm:flex-row sm:items-center sm:justify-between">
-            {alternateCopy && alternateTriggerLabel ? (
-              <button
-                type="button"
-                className="text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                onClick={() => {
-                  setMode((currentMode) =>
-                    currentMode === "authenticate" ? "recover" : "authenticate",
-                  );
-                  setPin("");
-                }}
-                disabled={isAuthenticating}
-              >
-                {mode === "authenticate"
-                  ? alternateTriggerLabel
-                  : returnTriggerLabel ?? copy.title}
-              </button>
-            ) : (
-              <span />
-            )}
-
-            <LoadingButton
-              onClick={handleSubmit}
-              isLoading={isAuthenticating}
-              disabled={!canSubmit || isAuthenticating}
-            >
-              {activeCopy.submitLabel}
-            </LoadingButton>
-          </div>
-        </div>
+        {content}
       </DialogContent>
     </Dialog>
   );

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,6 +21,16 @@ let mockActiveSessionQuery: {
     _id: Id<"expenseSessionItem">;
     quantity: number;
     updatedAt: number;
+    productName?: string;
+    productSku?: string;
+    barcode?: string;
+    price?: number;
+    image?: string | null;
+    size?: string;
+    length?: number | null;
+    color?: string;
+    productId?: Id<"product">;
+    productSkuId?: Id<"productSku">;
   }>;
 } | null;
 
@@ -165,5 +175,57 @@ describe("useExpenseRegisterViewModel", () => {
     const { result } = renderHook(() => useExpenseRegisterViewModel());
 
     expect(result.current.authDialog?.workflowMode).toBe("expense");
+  });
+
+  it("clears expense totals and transaction state after completing a session", async () => {
+    mockActiveSessionQuery = {
+      _id: "expense-session-1" as Id<"expenseSession">,
+      status: "active",
+      expiresAt: Date.now() + 60_000,
+      sessionNumber: "EXP-0001",
+      updatedAt: 100,
+      notes: "Damaged item",
+      cartItems: [],
+    };
+
+    const { result, rerender } = renderHook(() => useExpenseRegisterViewModel());
+
+    act(() => {
+      useExpenseStore
+        .getState()
+        .setCurrentSessionId("expense-session-1" as Id<"expenseSession">);
+      useExpenseStore.getState().setSessionExpiresAt(Date.now() + 60_000);
+      useExpenseStore.getState().setNotes("Damaged item");
+      useExpenseStore.getState().addToCart({
+        id: "expense-item-1" as Id<"expenseSessionItem">,
+        name: "Repair kit",
+        barcode: "123",
+        sku: "KIT-1",
+        price: 3600,
+        quantity: 1,
+        image: null,
+        productId: "product-1" as Id<"product">,
+        skuId: "product-sku-1" as Id<"productSku">,
+      });
+    });
+    rerender();
+
+    expect(useExpenseStore.getState().cart.total).toBeGreaterThan(0);
+
+    await act(async () => {
+      await result.current.checkout.onCompleteTransaction();
+    });
+
+    const state = useExpenseStore.getState();
+    expect(toast.success).toHaveBeenCalledWith("Expense recorded successfully");
+    expect(state.cart.items).toEqual([]);
+    expect(state.cart.total).toBe(0);
+    expect(state.session.currentSessionId).toBeNull();
+    expect(state.session.activeSession).toBeNull();
+    expect(state.session.expiresAt).toBeNull();
+    expect(state.transaction.isCompleted).toBe(false);
+    expect(state.transaction.completedTransactionData).toBeNull();
+    expect(state.cashier.isAuthenticated).toBe(false);
+    expect(state.ui.notes).toBe("");
   });
 });

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -448,15 +448,9 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
         return;
       }
 
-      store.setTransactionCompleted(true, result.data.transactionNumber, {
-        completedAt: new Date(),
-        cartItems: store.cart.items,
-        totalValue,
-        notes: store.ui.notes,
-      });
       toast.success("Expense recorded successfully");
-      cart.clearCart();
-      store.clearSession();
+      store.startNewTransaction();
+      resetAutoSessionInitialized();
       store.clearCashier();
     } catch (error) {
       logger.error("[Expense] Failed to complete expense", error as Error);
@@ -597,6 +591,7 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
       onSignOut: handleCashierSignOut,
     },
     drawerGate: null,
+    closeoutControl: null,
     authDialog:
       activeStore && terminal && !store.cashier.isAuthenticated
         ? {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -134,13 +134,29 @@ export interface RegisterDrawerGateState {
   registerNumber: string;
   currency?: string;
   openingFloat?: string;
+  closeoutCountedCash?: string;
+  closeoutDraftVariance?: number;
+  closeoutNotes?: string;
+  closeoutSecondaryActionLabel?: string;
+  expectedCash?: number;
   notes?: string;
   errorMessage: string | null;
+  isCloseoutSubmitting?: boolean;
+  isReopeningCloseout?: boolean;
   isSubmitting?: boolean;
+  onCloseoutCountedCashChange?: (value: string) => void;
+  onCloseoutNotesChange?: (value: string) => void;
   onOpeningFloatChange?: (value: string) => void;
   onNotesChange?: (value: string) => void;
+  onSubmitCloseout?: () => Promise<void>;
+  onReopenRegister?: () => Promise<void>;
   onSubmit?: () => Promise<void>;
   onSignOut: () => Promise<void>;
+}
+
+export interface RegisterCloseoutControlState {
+  canCloseout: boolean;
+  onRequestCloseout: () => void;
 }
 
 export interface RegisterAuthDialogState {
@@ -166,6 +182,7 @@ export interface RegisterViewModel {
   sessionPanel: RegisterSessionPanelState | null;
   cashierCard: RegisterCashierCardState | null;
   drawerGate: RegisterDrawerGateState | null;
+  closeoutControl: RegisterCloseoutControlState | null;
   authDialog: RegisterAuthDialogState | null;
   onNavigateBack: () => Promise<void>;
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -10,6 +10,7 @@ import type { Id } from "~/convex/_generated/dataModel";
 import { ok, userError } from "~/shared/commandResult";
 
 const mockUseQuery = vi.fn();
+const mockUseMutation = vi.fn();
 const mockStartSession = vi.fn();
 const mockAddItem = vi.fn();
 const mockHoldSession = vi.fn();
@@ -22,6 +23,8 @@ const mockSyncSessionCheckoutState = vi.fn();
 const mockReleaseSessionInventoryHoldsAndDeleteItems = vi.fn();
 const mockRemoveItem = vi.fn();
 const mockBindSessionToRegisterSession = vi.fn();
+const mockSubmitRegisterSessionCloseout = vi.fn();
+const mockReopenRegisterSessionCloseout = vi.fn();
 const mockNavigateBack = vi.fn();
 
 let mockActiveStore: { _id: Id<"store">; currency: string } | null;
@@ -98,9 +101,11 @@ let mockHeldSessions:
 let mockBarcodeSearchResult: null;
 let mockProductIdSearchResults: [] | null;
 let mockCashier: { firstName: string; lastName: string } | null;
+let mockUser: { _id: Id<"athenaUser"> } | null;
 
 vi.mock("convex/react", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (...args: unknown[]) => mockUseMutation(...args),
 }));
 
 vi.mock("sonner", () => ({
@@ -113,6 +118,12 @@ vi.mock("sonner", () => ({
 vi.mock("@/hooks/useGetActiveStore", () => ({
   default: () => ({
     activeStore: mockActiveStore,
+  }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: mockUser,
   }),
 }));
 
@@ -233,8 +244,30 @@ describe("useRegisterViewModel", () => {
       firstName: "Ama",
       lastName: "Kusi",
     };
+    mockUser = {
+      _id: "user-1" as Id<"athenaUser">,
+    };
 
     mockUseQuery.mockImplementation(() => mockCashier);
+    mockUseMutation.mockReset();
+    mockUseMutation.mockImplementation(() => {
+      const callIndex = mockUseMutation.mock.calls.length;
+      return callIndex % 2 === 1
+        ? mockSubmitRegisterSessionCloseout
+        : mockReopenRegisterSessionCloseout;
+    });
+    mockSubmitRegisterSessionCloseout.mockReset();
+    mockSubmitRegisterSessionCloseout.mockResolvedValue(
+      ok({
+        action: "closed",
+      }),
+    );
+    mockReopenRegisterSessionCloseout.mockReset();
+    mockReopenRegisterSessionCloseout.mockResolvedValue(
+      ok({
+        action: "reopened",
+      }),
+    );
     mockStartSession.mockReset();
     mockStartSession.mockResolvedValue(
       ok({
@@ -438,6 +471,130 @@ describe("useRegisterViewModel", () => {
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockOpenDrawer).not.toHaveBeenCalled();
     expect(result.current.drawerGate).not.toHaveProperty("onSubmit");
+    expect(result.current.drawerGate?.onSubmitCloseout).toEqual(
+      expect.any(Function),
+    );
+    expect(result.current.drawerGate?.expectedCash).toBe(5_000);
+  });
+
+  it("submits closeout from the POS drawer gate with the current cashier", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closing",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.drawerGate?.onCloseoutCountedCashChange?.("48.00");
+      result.current.drawerGate?.onCloseoutNotesChange?.("End of shift count");
+    });
+
+    expect(result.current.drawerGate?.closeoutDraftVariance).toBe(-200);
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmitCloseout?.();
+    });
+
+    expect(mockSubmitRegisterSessionCloseout).toHaveBeenCalledWith({
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-1",
+      countedCash: 4_800,
+      notes: "End of shift count",
+      registerSessionId: "drawer-1",
+      storeId: "store-1",
+    });
+    expect(toast.success).toHaveBeenCalledWith("Register session closed");
+  });
+
+  it("opens the closeout drawer gate from an active empty register", async () => {
+    mockActiveSession = {
+      ...mockActiveSession!,
+      cartItems: [],
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    expect(result.current.closeoutControl?.canCloseout).toBe(true);
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
+    });
+
+    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.expectedCash).toBe(5_000);
+    expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBe(
+      "Return to sale",
+    );
+    expect(result.current.productEntry.disabled).toBe(true);
+  });
+
+  it("reopens a closing register session from the POS drawer gate", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closing",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onReopenRegister?.();
+    });
+
+    expect(mockReopenRegisterSessionCloseout).toHaveBeenCalledWith({
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-1",
+      registerSessionId: "drawer-1",
+      storeId: "store-1",
+    });
+    expect(toast.success).toHaveBeenCalledWith("Register reopened.");
   });
 
   it("gates an active POS session without a register assignment while preserving the sale", async () => {
@@ -507,6 +664,9 @@ describe("useRegisterViewModel", () => {
     expect(mockBindSessionToRegisterSession).not.toHaveBeenCalled();
     expect(mockOpenDrawer).not.toHaveBeenCalled();
     expect(result.current.drawerGate).not.toHaveProperty("onSubmit");
+    expect(result.current.drawerGate?.onSubmitCloseout).toEqual(
+      expect.any(Function),
+    );
   });
 
   it("gates an active POS session assigned to a different open drawer", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent } from "react";
+import { useMutation } from "convex/react";
 import { toast } from "sonner";
 
+import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 
 import type { CustomerInfo, Payment, Product } from "@/components/pos/types";
+import { useAuth } from "@/hooks/useAuth";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useGetTerminal } from "@/hooks/useGetTerminal";
@@ -33,6 +36,7 @@ import {
 } from "@/lib/pos/constants";
 import { parseDisplayAmountInput } from "@/lib/pos/displayAmounts";
 import { toOperatorMessage } from "@/lib/errors/operatorMessages";
+import { runCommand } from "@/lib/errors/runCommand";
 import { logger } from "@/lib/logger";
 import { useConvexCommandGateway } from "@/lib/pos/infrastructure/convex/commandGateway";
 import { useConvexRegisterState } from "@/lib/pos/infrastructure/convex/registerGateway";
@@ -121,6 +125,7 @@ function presentOperatorError(message: string): void {
 
 export function useRegisterViewModel(): RegisterViewModel {
   const { activeStore } = useGetActiveStore();
+  const { user } = useAuth();
   const terminal = useGetTerminal();
   const navigateBack = useNavigateBack();
   const [staffProfileId, setStaffProfileId] =
@@ -141,10 +146,15 @@ export function useRegisterViewModel(): RegisterViewModel {
   >(null);
   const [drawerOpeningFloat, setDrawerOpeningFloat] = useState("");
   const [drawerNotes, setDrawerNotes] = useState("");
+  const [closeoutCountedCash, setCloseoutCountedCash] = useState("");
+  const [closeoutNotes, setCloseoutNotes] = useState("");
   const [drawerErrorMessage, setDrawerErrorMessage] = useState<string | null>(
     null,
   );
   const [isOpeningDrawer, setIsOpeningDrawer] = useState(false);
+  const [isSubmittingCloseout, setIsSubmittingCloseout] = useState(false);
+  const [isReopeningCloseout, setIsReopeningCloseout] = useState(false);
+  const [isCloseoutRequested, setIsCloseoutRequested] = useState(false);
   const [completedTransactionData, setCompletedTransactionData] =
     useState<RegisterViewModel["checkout"]["completedTransactionData"]>(null);
   const bootstrapInitialized = useRef(false);
@@ -214,6 +224,12 @@ export function useRegisterViewModel(): RegisterViewModel {
     openDrawer: openDrawerCommand,
     completeTransaction: completeTransactionCommand,
   } = useConvexCommandGateway();
+  const submitRegisterSessionCloseout = useMutation(
+    api.cashControls.closeouts.submitRegisterSessionCloseout,
+  );
+  const reopenRegisterSessionCloseout = useMutation(
+    api.cashControls.closeouts.reopenRegisterSessionCloseout,
+  );
   const {
     resumeSession,
     bindSessionToRegisterSession,
@@ -282,8 +298,11 @@ export function useRegisterViewModel(): RegisterViewModel {
     hasCloseoutBlockedDrawerState &&
     (hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding),
   );
+  const activeCloseoutRegisterSession =
+    closeoutBlockedRegisterSession ??
+    (isCloseoutRequested ? usableActiveRegisterSession : null);
   const drawerGateMode: "initialSetup" | "recovery" | "closeoutBlocked" =
-    hasCloseoutBlockedDrawerState
+    hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
       ? "closeoutBlocked"
       : hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding
         ? "recovery"
@@ -908,6 +927,135 @@ export function useRegisterViewModel(): RegisterViewModel {
     registerNumber,
     requestBootstrap,
     terminal?._id,
+  ]);
+
+  const handleSubmitRegisterCloseout = useCallback(async () => {
+    if (!activeStore?._id || !user?._id || !staffProfileId) {
+      setDrawerErrorMessage(
+        "Register sign-in required. Sign in before submitting closeout.",
+      );
+      return;
+    }
+
+    const registerSessionId = activeCloseoutRegisterSession?._id as
+      | Id<"registerSession">
+      | undefined;
+
+    if (!registerSessionId) {
+      setDrawerErrorMessage(
+        "Closeout unavailable. Refresh the register and try again.",
+      );
+      return;
+    }
+
+    const parsedCountedCash = parseDisplayAmountInput(closeoutCountedCash);
+
+    if (parsedCountedCash === undefined) {
+      setDrawerErrorMessage("Counted cash required. Enter the drawer total.");
+      return;
+    }
+
+    setDrawerErrorMessage(null);
+    setIsSubmittingCloseout(true);
+
+    const result = await runCommand(() =>
+      submitRegisterSessionCloseout({
+        actorStaffProfileId: staffProfileId,
+        actorUserId: user._id,
+        countedCash: parsedCountedCash,
+        notes: trimOptional(closeoutNotes),
+        registerSessionId,
+        storeId: activeStore._id,
+      }),
+    );
+
+    setIsSubmittingCloseout(false);
+
+    if (result.kind !== "ok") {
+      setDrawerErrorMessage(toOperatorMessage(result.error.message));
+      return;
+    }
+
+    setCloseoutCountedCash("");
+    setCloseoutNotes("");
+    if (result.data?.action === "closed") {
+      setIsCloseoutRequested(false);
+    }
+    requestBootstrap();
+    toast.success(
+      result.data?.action === "approval_required"
+        ? "Closeout submitted for manager review"
+        : "Register session closed",
+    );
+  }, [
+    activeStore?._id,
+    activeCloseoutRegisterSession?._id,
+    closeoutCountedCash,
+    closeoutNotes,
+    requestBootstrap,
+    staffProfileId,
+    submitRegisterSessionCloseout,
+    user?._id,
+  ]);
+
+  const handleReopenRegisterCloseout = useCallback(async () => {
+    if (!closeoutBlockedRegisterSession) {
+      setIsCloseoutRequested(false);
+      setCloseoutCountedCash("");
+      setCloseoutNotes("");
+      setDrawerErrorMessage(null);
+      return;
+    }
+
+    if (!activeStore?._id || !user?._id || !staffProfileId) {
+      setDrawerErrorMessage(
+        "Register sign-in required. Sign in before reopening the register.",
+      );
+      return;
+    }
+
+    const registerSessionId = activeCloseoutRegisterSession?._id as
+      | Id<"registerSession">
+      | undefined;
+
+    if (!registerSessionId) {
+      setDrawerErrorMessage(
+        "Reopen unavailable. Refresh the register and try again.",
+      );
+      return;
+    }
+
+    setDrawerErrorMessage(null);
+    setIsReopeningCloseout(true);
+
+    const result = await runCommand(() =>
+      reopenRegisterSessionCloseout({
+        actorStaffProfileId: staffProfileId,
+        actorUserId: user._id,
+        registerSessionId,
+        storeId: activeStore._id,
+      }),
+    );
+
+    setIsReopeningCloseout(false);
+
+    if (result.kind !== "ok") {
+      setDrawerErrorMessage(toOperatorMessage(result.error.message));
+      return;
+    }
+
+    setCloseoutCountedCash("");
+    setCloseoutNotes("");
+    requestBootstrap();
+    toast.success("Register reopened.");
+  }, [
+    activeStore?._id,
+    activeCloseoutRegisterSession?._id,
+    closeoutBlockedRegisterSession,
+    reopenRegisterSessionCloseout,
+    requestBootstrap,
+    staffProfileId,
+    user?._id,
   ]);
 
   useEffect(() => {
@@ -1688,16 +1836,45 @@ export function useRegisterViewModel(): RegisterViewModel {
           onSignOut: handleCashierSignOut,
         }
       : null;
+  const parsedCloseoutCountedCash = parseDisplayAmountInput(closeoutCountedCash);
+  const shouldShowDrawerGate = Boolean(
+    requiresDrawerGate || activeCloseoutRegisterSession,
+  );
 
   const drawerGate =
-    activeStore?._id && terminal?._id && staffProfileId && requiresDrawerGate
+    activeStore?._id && terminal?._id && staffProfileId && shouldShowDrawerGate
       ? drawerGateMode === "closeoutBlocked"
         ? {
             mode: drawerGateMode,
             isRecovery: closeoutBlockedGateIsRecovery,
             registerLabel: terminal.displayName,
             registerNumber,
+            currency: activeStore.currency,
+            closeoutCountedCash,
+            closeoutDraftVariance:
+              parsedCloseoutCountedCash !== undefined &&
+              activeCloseoutRegisterSession
+                ? parsedCloseoutCountedCash -
+                  activeCloseoutRegisterSession.expectedCash
+                : undefined,
+            closeoutNotes,
+            closeoutSecondaryActionLabel: closeoutBlockedRegisterSession
+              ? "Reopen register"
+              : "Return to sale",
+            expectedCash: activeCloseoutRegisterSession?.expectedCash,
             errorMessage: drawerErrorMessage,
+            isCloseoutSubmitting: isSubmittingCloseout,
+            isReopeningCloseout,
+            onCloseoutCountedCashChange: (value: string) => {
+              setCloseoutCountedCash(value);
+              setDrawerErrorMessage(null);
+            },
+            onCloseoutNotesChange: (value: string) => {
+              setCloseoutNotes(value);
+              setDrawerErrorMessage(null);
+            },
+            onSubmitCloseout: handleSubmitRegisterCloseout,
+            onReopenRegister: handleReopenRegisterCloseout,
             onSignOut: handleCashierSignOut,
           }
         : {
@@ -1724,6 +1901,23 @@ export function useRegisterViewModel(): RegisterViewModel {
             onSubmit: handleOpenDrawer,
             onSignOut: handleCashierSignOut,
           }
+      : null;
+  const closeoutControl =
+    activeStore?._id && terminal?._id && staffProfileId
+      ? {
+          canCloseout: Boolean(
+            usableActiveRegisterSession &&
+              !requiresDrawerGate &&
+              !hasActiveCartDraft &&
+              payments.length === 0 &&
+              !isTransactionCompleted,
+          ),
+          onRequestCloseout: () => {
+            setProductSearchQuery("");
+            setIsCloseoutRequested(true);
+            setDrawerErrorMessage(null);
+          },
+        }
       : null;
 
   const authDialog =
@@ -1752,7 +1946,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       disabled:
         !terminal ||
         !staffProfileId ||
-        requiresDrawerGate ||
+        shouldShowDrawerGate ||
         activeSessionHasBlockedRegisterBinding ||
         isOpeningDrawer,
       showProductLookup: showProductEntry,
@@ -1801,6 +1995,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     sessionPanel,
     cashierCard,
     drawerGate,
+    closeoutControl,
     authDialog,
     onNavigateBack: handleNavigateBack,
   };

--- a/packages/athena-webapp/src/stores/expenseStore.ts
+++ b/packages/athena-webapp/src/stores/expenseStore.ts
@@ -394,6 +394,7 @@ export const useExpenseStore = create<ExpenseState>()(
             state.cart.total = 0;
             state.session.currentSessionId = null;
             state.session.activeSession = null;
+            state.session.expiresAt = null;
             state.transaction.isCompleted = false;
             state.transaction.isCompleting = false;
             state.transaction.completedTransactionNumber = null;


### PR DESCRIPTION
## Summary
This updates the POS and expense register flows so blocking states stay inside the register shell instead of replacing the whole workspace. Cashier authentication, drawer setup, closeout, and expense completion now preserve the surrounding cart, controls, and cashier rail.

The closeout flow can now be launched from the POS action bar, completed inline from the register workspace, or reopened when a register should return to active selling. Expense completion now resets cart, session, transaction, notes, and cashier state so the next entry starts cleanly.

## What Changed
- Embedded cashier auth and drawer/closeout gates in the product lookup workspace while keeping POS controls, cart, checkout, and cashier context visible.
- Added inline register closeout submission and register reopen support, with backend mutations and register-session lifecycle coverage.
- Kept the expense right rail stable across entry, auth, and completed states: empty cart, expense controls, and cashier card render as shell-owned rail content.
- Tightened operator-facing copy for auth, closeout, drawer recovery, and expense entry states.
- Refreshed graphify artifacts after the webapp changes.

## Testing
- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- Pre-push suite: graphify check, architecture check, cash-controls tests, TypeScript, webapp build, workflow trace tests, full `@athena/webapp:test`, Convex audit, changed Convex lint, and harness behavior scenarios

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)