### PR TITLE
fix(pos): harden register session recovery

### DIFF
--- a/docs/plans/2026-04-30-001-feat-pos-correction-workflows-plan.md
+++ b/docs/plans/2026-04-30-001-feat-pos-correction-workflows-plan.md
@@ -1,0 +1,533 @@
+---
+title: "feat: Build POS correction workflow foundation"
+type: feat
+status: active
+date: 2026-04-30
+---
+
+# feat: Build POS correction workflow foundation
+
+## Summary
+
+Build a risk-tiered correction foundation for POS and Cash Controls so operators can recover from inaccurate data entry without silently rewriting committed operational facts. The implementation extends existing register-session, approval-request, operational-event, workflow-trace, and payment-allocation patterns with guided correction actions for opening float, transaction customer attribution, and same-amount payment-method corrections.
+
+---
+
+## Problem Frame
+
+POS operators can enter inaccurate values during high-pressure store workflows: an opening float can be typed wrong, or a completed transaction can carry the wrong customer or payment method. Athena needs to let stores recover quickly while preserving ledger trust: cash, payment, inventory, and completed-sale facts should remain auditable and correction history should be visible wherever the original action is reviewed.
+
+---
+
+## Requirements
+
+- R1. Corrections use a risk-tiered model: low-risk metadata corrections may update the current record with audit history, while cash/payment/inventory-impacting corrections use explicit correction events and approval when needed.
+- R2. Opening float can be corrected while the register session is open or active, updating effective drawer math and recording old value, new value, actor, timestamp, and reason.
+- R3. Opening float correction is blocked or approval-routed once the register session is closing or closed.
+- R4. Completed transaction records are not silently edited for financial or inventory facts; supported corrections are explicit, linked, and timeline-visible.
+- R5. Completed transaction customer attribution can be corrected with staff authentication, a reason, and visible audit history.
+- R6. Completed transaction payment method can be corrected only when total amount and payment count semantics stay safe; the payment ledger and transaction display remain consistent.
+- R7. High-risk corrections route through existing approval request patterns instead of introducing a parallel manager-review system.
+- R8. Operator-facing copy follows `docs/product-copy-tone.md`: calm, clear, restrained, and operational.
+- R9. Existing POS drawer invariants remain enforced at command boundaries; UI correction entry points are ergonomic gates, not the source of authorization or ledger integrity.
+
+---
+
+## Scope Boundaries
+
+- Do not allow direct editing of completed transaction items, quantities, totals, discounts, or inventory movements in this foundation.
+- Do not rebuild return, exchange, refund, or void workflows; the correction picker may route to existing or future flows, but this plan does not implement them.
+- Do not introduce a second approval system; use the existing `approvalRequest` rail.
+- Do not change receipt rendering beyond reflecting supported corrected metadata and payment-method display state.
+- Do not make correction actions available without staff identity.
+
+### Deferred to Follow-Up Work
+
+- Item/quantity, price, discount, and amount-charged corrections: future return, exchange, refund, or financial-adjustment workflows.
+- Cashier attribution correction: manager-only follow-up once the first correction foundation is proven.
+- Expense-session correction workflows: follow-up after POS transaction and register-session correction patterns are established.
+- Documentation refresh for operator runbooks: separate docs follow-up after the UX is validated in implementation.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/operations/registerSessions.ts` owns register-session state transitions, opening float, expected cash, sale/void cash deltas, closeout, reopen, and deposit math.
+- `packages/athena-webapp/convex/schemas/operations/registerSession.ts` defines the register-session persisted shape, including `openingFloat`, `expectedCash`, `countedCash`, `variance`, and manager approval linkage.
+- `packages/athena-webapp/convex/cashControls/closeouts.ts` shows public command-result wrappers, closeout approval routing, operational events, and workflow-trace recording.
+- `packages/athena-webapp/convex/operations/operationalEvents.ts` provides an idempotent subject-scoped audit/timeline rail that already links register sessions, approval requests, payment allocations, and POS transactions.
+- `packages/athena-webapp/convex/operations/approvalRequests.ts` provides the existing manager-review path for high-risk operational actions.
+- `packages/athena-webapp/convex/operations/paymentAllocations.ts` and `packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts` define payment ledger entries and idempotent allocation writes.
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` creates completed POS transactions, records register-session cash deltas, writes payment allocations, and voids completed transactions.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` is the natural Cash Controls surface for register-session correction controls and timelines.
+- `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx` is the natural completed-transaction detail surface for correction entry points.
+- `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx` supplies the staff-auth gate used by register-session and POS flows.
+- `packages/athena-webapp/src/lib/errors/runCommand.ts` and `packages/athena-webapp/src/lib/errors/operatorMessages.ts` provide the expected command-result and safe-copy presentation path.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`: POS drawer and register-session invariants must live at command boundaries, not only in UI gates.
+- `docs/superpowers/specs/2026-04-22-client-server-error-foundation-design.md`: expected business failures should return `user_error`; unexpected failures should throw and collapse to generic client copy.
+- `docs/product-copy-tone.md`: correction blocking states and confirmations should lead with system state, name the next action, and avoid dramatizing operator mistakes.
+
+### External References
+
+- None used. The codebase has strong local patterns for command results, approvals, operational timelines, and ledger-style payment allocation behavior.
+
+---
+
+## Key Technical Decisions
+
+- Use risk-tiered correction semantics: direct audited updates are limited to recoverable operational values and low-risk metadata; financial and inventory facts use linked correction events or existing reversal flows.
+- Extend existing ledger rails instead of creating a standalone correction subsystem: register-session math stays in register-session commands, payment facts stay in payment allocations, and visible history uses operational events plus workflow traces where register-session lifecycle needs them.
+- Treat opening float correction as an effective-value update while the drawer is still open or active: this keeps closeout math usable during the day while preserving the original and corrected values in audit history.
+- Treat completed transaction corrections as guided actions from the transaction detail surface: operators choose what is wrong, and Athena routes to the safe correction path rather than exposing generic edit controls.
+- Keep manager review centralized in `approvalRequest`: closing/closed register-session corrections and high-risk completed-sale corrections should not invent a separate review state.
+- Prefer inline errors inside correction dialogs/drawers and toasts only for quick confirmations, following the existing command-result presentation model.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should opening float correction rewrite the original opening value? Resolve as: update the effective register-session values needed for closeout math, while recording old/new values in operational history so the correction is not silent.
+- Should completed transaction records be directly editable? Resolve as: only low-risk metadata can be updated directly with audit history; payment and ledger-affecting changes must use explicit correction events or reversal flows.
+- Should all corrections require manager approval? Resolve as: no. Use manager approval only for high-risk or late-state corrections.
+
+### Deferred to Implementation
+
+- Exact correction event names and metadata field names: choose during implementation to match surrounding event-builder and trace naming conventions.
+- Whether same-amount payment-method correction should rewrite `paymentAllocation` rows, void-and-recreate allocations, or create linked correction allocations: decide after implementation reads the current reporting assumptions in payment-allocation consumers.
+- Whether the completed transaction correction picker lands as a menu, drawer, or dialog: decide during UI implementation while matching the existing transaction detail layout.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+    A[Operator selects Correct] --> B{What needs correction?}
+    B --> C[Opening float]
+    B --> D[Customer attribution]
+    B --> E[Payment method]
+    B --> F[Items, amount, discount, inventory]
+    C --> G{Register state}
+    G --> H[Open or active: staff auth + reason]
+    G --> I[Closing or closed: approval or blocked guidance]
+    H --> J[Update effective drawer math]
+    J --> K[Operational event + register trace]
+    D --> L[Staff auth + reason]
+    L --> M[Update transaction metadata]
+    M --> N[Operational event on transaction]
+    E --> O[Staff auth + reason + safety checks]
+    O --> P[Linked payment correction]
+    P --> Q[Transaction display and payment ledger remain consistent]
+    F --> R[Route to return, exchange, refund, void, or future flow]
+```
+
+---
+
+## Implementation Units
+
+- U1. **Establish correction taxonomy and audit primitives**
+
+**Goal:** Define the shared correction categories and reusable audit shape so later correction actions behave consistently.
+
+**Requirements:** R1, R4, R7, R8, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/convex/pos/application/corrections/correctionPolicy.ts`
+- Create: `packages/athena-webapp/convex/pos/application/corrections/correctionEvents.ts`
+- Modify: `packages/athena-webapp/convex/operations/operationalEvents.ts`
+- Test: `packages/athena-webapp/convex/pos/application/corrections/correctionPolicy.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/corrections/correctionEvents.test.ts`
+
+**Approach:**
+- Model correction intent at the domain level: opening float, customer attribution, payment method, and unsupported high-risk transaction corrections.
+- Centralize risk-tier decisions so UI surfaces and server commands do not each invent their own rules.
+- Reuse `operationalEvent` as the visible audit rail, with metadata that can carry previous value, corrected value, correction reason, actor identity, and linked subject IDs.
+- Keep expected policy failures as command-result `user_error` outcomes.
+
+**Execution note:** Implement domain behavior test-first so later units can lean on the policy contract.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- `packages/athena-webapp/convex/operations/operationalEvents.ts`
+- `docs/superpowers/specs/2026-04-22-client-server-error-foundation-design.md`
+
+**Test scenarios:**
+- Happy path: opening-float correction on an open register session is classified as staff-auth correction.
+- Happy path: customer-attribution correction is classified as low-risk metadata correction.
+- Happy path: payment-method correction is classified as ledger-affecting and requires stricter validation than metadata correction.
+- Error path: item, quantity, total, discount, and inventory correction intents return route-to-other-flow guidance rather than direct edit permission.
+- Error path: unknown correction intent returns safe validation feedback.
+- Integration: building a correction event includes subject linkage and old/new metadata without requiring a bespoke table.
+
+**Verification:**
+- Correction policy can be imported by command and UI units without coupling them to a specific screen.
+- Unsupported correction categories produce actionable, product-copy-compliant messages.
+
+---
+
+- U2. **Add opening float correction command**
+
+**Goal:** Allow authorized staff to correct an opening float while a register session is still open or active, update effective drawer math, and record the correction.
+
+**Requirements:** R1, R2, R3, R7, R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/schemas/operations/registerSession.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/registerSessions.test.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Test: `packages/athena-webapp/convex/operations/registerSessions.test.ts`
+
+**Approach:**
+- Add a public command-result mutation in the cash-controls boundary that authenticates staff identity, validates session ownership, validates session status, validates corrected amount, and applies the correction through register-session domain helpers.
+- Preserve register-session drawer math by adjusting `openingFloat` and `expectedCash` by the opening-float delta when the drawer is open or active.
+- Recalculate `variance` if `countedCash` already exists.
+- Record an operational event with previous opening float, corrected opening float, expected-cash delta, actor, reason, and register-session subject link.
+- Record a register-session trace event where appropriate so the session timeline tells the full story.
+- For `closing` or `closed` sessions, return a safe `user_error` or route to approval depending on the chosen implementation posture; do not silently patch closed drawer math.
+
+**Execution note:** Start with register-session domain tests for the cash math before adding the public mutation.
+
+**Patterns to follow:**
+- `buildRegisterSessionDepositPatch` and `buildRegisterSessionCloseoutPatch` in `packages/athena-webapp/convex/operations/registerSessions.ts`
+- `submitRegisterSessionCloseout` command-result shape in `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- `recordRegisterSessionTraceBestEffort` usage in register-session open/sale/void flows
+
+**Test scenarios:**
+- Happy path: correcting opening float from 300 to 200 on an open drawer reduces expected cash by 100 and records the correction event.
+- Happy path: correcting opening float after cash sales preserves sale deltas and updates expected cash by only the float delta.
+- Edge case: corrected opening float equal to current value returns safe validation feedback or no-op duplicate semantics without creating noisy duplicate events.
+- Edge case: corrected opening float cannot be negative or non-finite.
+- Error path: correcting a missing, wrong-store, closing, or closed register session returns `user_error` and leaves drawer math unchanged.
+- Integration: correction writes an operational event and, when trace creation succeeds, links the register-session trace without failing the correction if trace recording fails.
+
+**Verification:**
+- Register-session expected cash remains consistent across open, active, and counted states.
+- Stale clients cannot bypass correction status rules.
+
+---
+
+- U3. **Expose opening float correction in Cash Controls**
+
+**Goal:** Add a calm, guided Cash Controls UI for correcting opening float from the register session detail page.
+
+**Requirements:** R2, R3, R8
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx`
+- Modify: `packages/athena-webapp/src/lib/errors/operatorMessages.ts`
+
+**Approach:**
+- Add a `Correct opening float` action near the session summary, visible when the session status can accept corrections.
+- Use `StaffAuthenticationDialog` for staff identity, then collect corrected amount and reason in the same durable surface.
+- Show the current opening float and expected drawer impact before submission.
+- Render command-result failures inline in the correction surface; use short success toast copy after completion.
+- Add timeline visibility for opening-float correction events if the register detail already renders operational events; otherwise plan the query/display change in the same unit.
+
+**Execution note:** Add UI tests before wiring visual controls so the auth and command states are locked down.
+
+**Patterns to follow:**
+- Existing closeout staff-auth intent handling in `RegisterSessionView.tsx`
+- Product copy rules in `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: open/active register session renders `Correct opening float` and submits corrected amount plus reason after staff auth.
+- Happy path: success updates displayed session values and shows concise confirmation.
+- Error path: command-result `user_error` renders inline without exposing raw backend copy.
+- Error path: closed or closing session does not offer direct correction and shows guidance for Cash Controls review if reached by stale state.
+- Authorization: staff auth failure keeps the correction surface open and does not call the correction command.
+
+**Verification:**
+- Operators can correct opening float without leaving the register session detail page.
+- UI copy stays short and operational.
+
+---
+
+- U4. **Add completed transaction correction entry point and timeline**
+
+**Goal:** Give completed transaction detail pages a consistent `Correct` action that routes operators to safe correction paths and shows correction history.
+
+**Requirements:** R1, R4, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/queries/getTransactions.ts`
+- Test: `packages/athena-webapp/convex/pos/application/getTransactions.test.ts`
+
+**Approach:**
+- Add a transaction detail correction action that presents supported correction categories and routes unsupported categories to safe guidance.
+- Query operational events for the transaction subject and render correction history in the transaction detail page.
+- Keep this unit UI-only plus read-model focused; mutation behavior for customer and payment corrections lands in U5 and U6.
+- Present unsupported high-risk corrections as guided routes: return/exchange/refund/void/future adjustment, not as editable transaction fields.
+
+**Execution note:** Characterize the current transaction detail query shape before adding correction history to avoid breaking completed transaction listings.
+
+**Patterns to follow:**
+- `WorkflowTraceRouteLink` on transaction detail
+- `listOperationalEventsForSubject` in `packages/athena-webapp/convex/operations/operationalEvents.ts`
+- Existing transaction list/detail tests in `packages/athena-webapp/src/components/pos/transactions`
+
+**Test scenarios:**
+- Happy path: completed transaction detail renders a `Correct` action and supported correction categories.
+- Happy path: transaction correction history renders operational events linked to the transaction.
+- Error path: item/quantity/amount/discount correction choices show safe route-to-other-flow guidance.
+- Edge case: transaction with no correction history renders without empty visual noise.
+- Integration: transaction query can return correction history without affecting completed transaction list rows.
+
+**Verification:**
+- The transaction detail page explains how to correct mistakes without exposing direct edit controls for committed financial or inventory facts.
+
+---
+
+- U5. **Implement customer attribution correction**
+
+**Goal:** Allow staff to correct the customer attached to a completed transaction with audit history and safe metadata updates.
+
+**Requirements:** R1, R4, R5, R8
+
+**Dependencies:** U1, U4
+
+**Files:**
+- Create: `packages/athena-webapp/convex/pos/application/commands/correctTransactionCustomer.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/queries/getTransactions.ts`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Test: `packages/athena-webapp/convex/pos/application/correctTransactionCustomer.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+
+**Approach:**
+- Add a command-result mutation for completed transaction customer correction.
+- Validate transaction exists, belongs to the expected store context, is completed or otherwise eligible, and the actor has staff identity.
+- Update only customer attribution metadata, not line items, totals, payment, cashier, or inventory fields.
+- Record an operational event with previous customer attribution, corrected attribution, actor, and reason.
+- Update the transaction detail UI to offer this correction path from the picker.
+
+**Execution note:** Implement command behavior test-first; UI can then mock the command-result outcomes.
+
+**Patterns to follow:**
+- Customer attribution shape in `completeTransaction.ts`
+- Existing POS customer attribution plan and tests in `docs/brainstorms/2026-04-25-pos-customer-attribution-flow-requirements.md` and `docs/plans/2026-04-25-003-feat-pos-customer-attribution-flow-plan.md`
+- `runCommand` client pattern
+
+**Test scenarios:**
+- Happy path: completed transaction customer changes from walk-in/customer A to customer B and records old/new values.
+- Happy path: clearing customer attribution records a correction and returns the transaction to walk-in display state.
+- Error path: missing transaction, wrong store, unsupported transaction status, or missing staff actor returns `user_error`.
+- Error path: invalid customer profile ID returns safe not-found feedback and does not patch the transaction.
+- Integration: transaction detail refresh shows corrected customer and correction history.
+
+**Verification:**
+- Customer correction affects transaction attribution only and never changes sale totals, payments, item lines, register-session cash, or inventory.
+
+---
+
+- U6. **Implement same-amount payment-method correction**
+
+**Goal:** Allow staff to correct a completed transaction's payment method when the amount remains unchanged and ledger integrity can be preserved.
+
+**Requirements:** R1, R4, R6, R7, R8
+
+**Dependencies:** U1, U4
+
+**Files:**
+- Create: `packages/athena-webapp/convex/pos/application/commands/correctTransactionPaymentMethod.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Modify: `packages/athena-webapp/convex/operations/paymentAllocations.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Test: `packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts`
+- Test: `packages/athena-webapp/convex/operations/paymentAllocations.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+
+**Approach:**
+- Add a command-result mutation that corrects payment method only when the payment amount and payment count semantics remain safe.
+- Preserve ledger trust by linking payment correction history to the original transaction and payment allocation trail. The implementation should choose the least surprising payment-allocation strategy after reading consumers: either void-and-recreate allocations or add explicit correction allocations that reporting can summarize correctly.
+- Update transaction display fields only after the ledger representation is consistent.
+- Route multi-payment corrections or amount-changing corrections to future workflows unless implementation can prove a safe limited case.
+- Record an operational event with previous method, corrected method, actor, reason, and payment allocation linkage.
+
+**Execution note:** Characterize existing payment-allocation reporting before deciding the allocation correction representation.
+
+**Patterns to follow:**
+- `recordRetailSalePaymentAllocations` and `recordRetailVoidPaymentAllocations`
+- `summarizePaymentAllocations`
+- `voidTransaction` payment reversal behavior
+
+**Test scenarios:**
+- Happy path: single cash payment can be corrected to card with the same amount and the transaction detail reflects the corrected method.
+- Happy path: correction records operational event and linked payment-allocation history.
+- Edge case: no-op correction to the same payment method returns safe feedback or duplicate semantics.
+- Error path: multi-payment transaction is not corrected by the first slice unless explicitly supported by implementation.
+- Error path: amount-changing correction is blocked and routes to refund/additional-payment guidance.
+- Error path: closed or approval-sensitive register state routes to manager review if the selected representation impacts cash-control reports.
+- Integration: register-session expected cash and payment allocation summaries remain consistent after correction.
+
+**Verification:**
+- Payment-method correction cannot hide cash discrepancies or make Cash Controls disagree with the payment ledger.
+
+---
+
+- U7. **Route high-risk corrections through approval and safe guidance**
+
+**Goal:** Ensure corrections that cannot be direct audited updates either create an approval request or clearly route to an existing/future recovery workflow.
+
+**Requirements:** R1, R3, R4, R7, R8
+
+**Dependencies:** U1, U2, U4, U6
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/approvalRequests.ts`
+- Modify: `packages/athena-webapp/convex/schemas/operations/approvalRequest.ts`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Test: `packages/athena-webapp/convex/operations/approvalRequests.test.ts`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+
+**Approach:**
+- Reuse existing approval request status and reviewer semantics for high-risk correction requests.
+- Add correction-specific metadata and subject linkage rather than new approval request statuses.
+- Ensure rejected corrections leave original ledger state unchanged and leave a visible audit trail.
+- Ensure approved corrections call the same domain command path that a direct correction would use, so manager approval does not fork business logic.
+- For workflows intentionally deferred, display route guidance instead of generating approvals that no resolver can complete.
+
+**Patterns to follow:**
+- Closeout variance review approval path in `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Stock adjustment approval resolution in `packages/athena-webapp/convex/stockOps/adjustments.ts`
+
+**Test scenarios:**
+- Happy path: closing/closed opening-float correction request creates a pending approval request with register-session linkage.
+- Happy path: approved correction applies through the same register-session correction command path and records decision history.
+- Error path: rejected correction leaves effective values unchanged and records rejection notes.
+- Error path: non-manager approval attempt returns authorization `user_error`.
+- Integration: Cash Controls and transaction detail display pending approval state without offering duplicate correction submission.
+
+**Verification:**
+- Manager review remains centralized and auditable.
+- High-risk correction requests do not create unresolved approval records for unsupported workflows.
+
+---
+
+- U8. **Refresh tests, docs, and generated graph artifacts**
+
+**Goal:** Keep repo documentation and generated project graph honest after adding the correction foundation.
+
+**Requirements:** R8, R9
+
+**Dependencies:** U1, U2, U3, U4, U5, U6, U7
+
+**Files:**
+- Modify: `docs/product-copy-tone.md`
+- Create: `docs/solutions/logic-errors/athena-pos-correction-ledger-foundation-2026-04-30.md`
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/graph.json`
+- Modify: `graphify-out/wiki/index.md`
+
+**Approach:**
+- Add a small product-copy note for correction surfaces if implementation introduces reusable phrasing.
+- Capture the durable learning that POS correction workflows should preserve original ledger facts and record correction events.
+- Rebuild graphify artifacts once after all code changes land.
+
+**Execution note:** Sensor-only for documentation and generated artifacts; behavior should already be covered by earlier units.
+
+**Patterns to follow:**
+- Existing `docs/solutions/logic-errors/*` learning documents.
+- Existing graphify update policy in `AGENTS.md`.
+
+**Test scenarios:**
+- Test expectation: none -- documentation and generated artifacts only.
+
+**Verification:**
+- Documentation describes the new standing behavior and graphify artifacts are current.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Correction actions touch POS transaction detail, Cash Controls register detail, staff authentication, approval requests, operational events, payment allocations, and register-session traces.
+- **Error propagation:** All new user-initiated commands should return `CommandResult` with safe `user_error` for expected business failures and throw only for unexpected faults.
+- **State lifecycle risks:** Opening float correction must preserve existing sale/deposit deltas; payment-method correction must not make register expected cash, payment allocations, and transaction display disagree.
+- **API surface parity:** Transaction correction commands should be available from transaction detail and remain safe against direct Convex invocation.
+- **Integration coverage:** Cross-layer tests are needed for register-session math, operational events, approval resolution, payment allocation summaries, and UI command-result presentation.
+- **Unchanged invariants:** Completed transaction item lines, totals, inventory movement, and cash drawer binding rules remain protected; correction entry points do not replace command-boundary validation.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Opening float correction hides cash variance instead of explaining it | Record old/new values and reason as operational events and trace milestones; show correction history in Cash Controls. |
+| Payment-method correction breaks Cash Controls reports | Characterize payment-allocation consumers before choosing correction representation; block unsupported multi-payment or amount-changing cases. |
+| Operators mistake correction actions for unrestricted editing | Use guided correction picker with route guidance and clear unsupported states. |
+| Approval requests become orphaned for unsupported corrections | Only create approval requests for correction categories with implemented resolution paths. |
+| Raw backend text leaks through new correction commands | Use command-result helpers and existing client `runCommand` normalization. |
+
+---
+
+## Alternative Approaches Considered
+
+- Direct edits with audit notes: fastest for operators, but too easy to erode trust in completed sales and cash reports.
+- Immutable-only reversal model for every correction: strongest audit posture, but too heavy for opening-float typos and low-risk customer metadata corrections.
+- Manager approval for every correction: simple policy, but slows routine recovery and creates avoidable approval volume.
+- Separate correction table for all correction history: more explicit, but duplicates existing operational-event and approval-request rails before the product needs that carrying cost.
+
+---
+
+## Phased Delivery
+
+### Phase 1
+- U1, U2, U3: establish correction policy, backend opening-float correction, and Cash Controls UI.
+
+### Phase 2
+- U4, U5: add transaction correction entry point, correction history, and customer attribution correction.
+
+### Phase 3
+- U6, U7: add payment-method correction and approval routing for higher-risk cases.
+
+### Phase 4
+- U8: refresh docs and graph artifacts after behavior lands.
+
+---
+
+## Documentation / Operational Notes
+
+- Product-copy changes should stay small and focused on reusable correction-state language.
+- Any rollout should be observable through operational events and existing workflow trace views.
+- Implementation should prefer a coordinated integration PR if multiple tickets touch graphify artifacts or shared generated files.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Related code: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Related code: `packages/athena-webapp/convex/operations/operationalEvents.ts`
+- Related code: `packages/athena-webapp/convex/operations/approvalRequests.ts`
+- Related code: `packages/athena-webapp/convex/operations/paymentAllocations.ts`
+- Related code: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Related code: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`
+- Product copy: `docs/product-copy-tone.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1532 files · ~0 words
+- 1533 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4026 nodes · 3604 edges · 1460 communities detected
+- 4034 nodes · 3615 edges · 1461 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1470,6 +1470,7 @@
 - [[_COMMUNITY_Community 1457|Community 1457]]
 - [[_COMMUNITY_Community 1458|Community 1458]]
 - [[_COMMUNITY_Community 1459|Community 1459]]
+- [[_COMMUNITY_Community 1460|Community 1460]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1606,16 +1607,16 @@ Cohesion: 0.13
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
 ### Community 27 - "Community 27"
+Cohesion: 0.17
+Nodes (9): expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), normalizeCustomerSnapshot(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), registerSessionMatchesIdentity(), resolveCustomerTraceStage() (+1 more)
+
+### Community 28 - "Community 28"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.18
-Nodes (8): hasCustomerSnapshotValue(), isUsableRegisterSession(), normalizeCustomerSnapshot(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), registerSessionMatchesIdentity(), resolveCustomerTraceStage(), validateSessionDrawerBinding()
 
 ### Community 30 - "Community 30"
 Cohesion: 0.28
@@ -1670,8 +1671,8 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 43 - "Community 43"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+Cohesion: 0.25
+Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
 ### Community 44 - "Community 44"
 Cohesion: 0.33
@@ -1686,20 +1687,20 @@ Cohesion: 0.18
 Nodes (0):
 
 ### Community 47 - "Community 47"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 48 - "Community 48"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
-
-### Community 50 - "Community 50"
-Cohesion: 0.27
-Nodes (4): getTransactionById(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
 ### Community 51 - "Community 51"
 Cohesion: 0.22
@@ -1746,76 +1747,76 @@ Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
 ### Community 62 - "Community 62"
+Cohesion: 0.25
+Nodes (2): formatCorrectionEventType(), formatCorrectionHistoryTitle()
+
+### Community 63 - "Community 63"
 Cohesion: 0.33
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 73 - "Community 73"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 74 - "Community 74"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 75 - "Community 75"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 76 - "Community 76"
 Cohesion: 0.36
 Nodes (4): buildPendingSkuContextById(), listPurchaseOrderLineItems(), listReplenishmentRecommendationsWithCtx(), listStoreProductSkus()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 78 - "Community 78"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
 ### Community 79 - "Community 79"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
 ### Community 80 - "Community 80"
 Cohesion: 0.25
@@ -1910,84 +1911,84 @@ Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 103 - "Community 103"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 104 - "Community 104"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 114 - "Community 114"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 115 - "Community 115"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 116 - "Community 116"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 117 - "Community 117"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 118 - "Community 118"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.4
 Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 122 - "Community 122"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.33
@@ -2350,12 +2351,12 @@ Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 213 - "Community 213"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 214 - "Community 214"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.5
@@ -2366,28 +2367,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 217 - "Community 217"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 219 - "Community 219"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 221 - "Community 221"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
-
-### Community 222 - "Community 222"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 222 - "Community 222"
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.5
@@ -2406,24 +2407,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 228 - "Community 228"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 228 - "Community 228"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 231 - "Community 231"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 231 - "Community 231"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.5
@@ -2434,12 +2435,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 234 - "Community 234"
-Cohesion: 0.67
-Nodes (2): getSummaryAmount(), getSummaryLabel()
-
-### Community 235 - "Community 235"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 235 - "Community 235"
+Cohesion: 0.67
+Nodes (2): getSummaryAmount(), getSummaryLabel()
 
 ### Community 236 - "Community 236"
 Cohesion: 0.5
@@ -2462,24 +2463,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 242 - "Community 242"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 242 - "Community 242"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 244 - "Community 244"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 245 - "Community 245"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 245 - "Community 245"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.5
@@ -2490,36 +2491,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 248 - "Community 248"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 249 - "Community 249"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 255 - "Community 255"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.5
@@ -2546,55 +2547,55 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 262 - "Community 262"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 266 - "Community 266"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 267 - "Community 267"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 269 - "Community 269"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 271 - "Community 271"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 272 - "Community 272"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 273 - "Community 273"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 274 - "Community 274"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 275 - "Community 275"
@@ -2642,8 +2643,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 1.0
-Nodes (2): buildRegisterState(), getRegisterState()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
@@ -2994,56 +2995,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 374 - "Community 374"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 375 - "Community 375"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 376 - "Community 376"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 378 - "Community 378"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 381 - "Community 381"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 382 - "Community 382"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 383 - "Community 383"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 384 - "Community 384"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 385 - "Community 385"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 386 - "Community 386"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
@@ -3054,12 +3055,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 390 - "Community 390"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
@@ -3070,12 +3071,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 394 - "Community 394"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 394 - "Community 394"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.67
@@ -3150,16 +3151,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 414 - "Community 414"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 415 - "Community 415"
+### Community 414 - "Community 414"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 415 - "Community 415"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 1.0
@@ -3174,20 +3175,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 419 - "Community 419"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 421 - "Community 421"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 422 - "Community 422"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 423 - "Community 423"
 Cohesion: 1.0
@@ -7337,2082 +7338,2086 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1460 - "Community 1460"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 422`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 423`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 424`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 425`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 426`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 427`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 428`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 429`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 430`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 431`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 432`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 433`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 434`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 435`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 436`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 437`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 438`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 439`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 440`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 441`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 442`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 443`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 444`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 445`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 446`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 447`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 448`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 449`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `createDbGetMock()`, `openDrawer.test.ts`
+- **Thin community `Community 450`** (2 nodes): `createDbGetMock()`, `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 451`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 452`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 453`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 454`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 455`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 456`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 457`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 458`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 459`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 460`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 461`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 462`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 463`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 464`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 465`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 466`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 467`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 468`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 469`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 470`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 471`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 472`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 473`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 474`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 475`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 476`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 477`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 478`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 479`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 480`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 481`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 482`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 483`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 484`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 485`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 486`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 487`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 488`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 489`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 490`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 491`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 492`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 493`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 494`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 495`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 496`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 497`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 498`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 499`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 500`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 501`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 502`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 503`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 504`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 505`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 506`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 507`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 508`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 509`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 510`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 511`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 512`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 513`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 514`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 515`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 516`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 517`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 518`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 519`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 520`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 521`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 522`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 523`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 524`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 525`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 526`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 527`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 528`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 529`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 530`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 531`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 532`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 533`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 534`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 535`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 536`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 537`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 538`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 539`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 540`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 541`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 542`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 543`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 544`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 545`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 546`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 547`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 548`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 549`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 550`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 551`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 552`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 553`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 554`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 555`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 556`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 557`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 558`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 559`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 560`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 561`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 562`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 563`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 564`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 565`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 566`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 567`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 568`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 569`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 570`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 571`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 572`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 573`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 574`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 575`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 576`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 577`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 578`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 579`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 580`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 581`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 582`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 583`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 584`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 585`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 586`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 587`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 588`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 589`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 590`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 591`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 592`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 593`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 594`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 595`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 596`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 597`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 598`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 599`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 600`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 601`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 602`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 603`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 604`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 605`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 606`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 607`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 608`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 609`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 610`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 611`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 612`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 613`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 614`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 615`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 616`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 617`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 618`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 619`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 620`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 621`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 622`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 623`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 624`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 625`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 626`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 627`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 628`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 629`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 630`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 631`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 632`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 633`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 634`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 635`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 636`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 637`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 638`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 639`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 640`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 641`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 642`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 643`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 644`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 645`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 646`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 647`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
+- **Thin community `Community 648`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 649`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 650`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 651`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 652`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 653`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 654`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 655`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 656`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 657`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 658`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 659`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 660`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 661`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 662`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 663`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 664`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 665`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 666`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 667`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 668`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 669`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 670`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 671`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 672`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 673`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 674`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 675`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 676`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 677`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 678`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 679`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 680`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 681`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 682`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 683`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 684`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 685`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 686`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 687`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 688`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 689`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 690`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 691`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 692`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 693`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 694`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 695`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 696`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 697`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 698`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 699`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 700`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 701`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 702`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 703`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 704`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 705`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 706`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 707`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 708`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 709`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 710`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 711`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 712`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 713`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 714`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 715`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 716`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 717`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 718`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 719`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 720`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 721`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 722`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 723`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 724`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 725`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 726`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 727`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 728`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 729`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 730`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 731`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 732`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 733`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 734`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 735`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 736`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 737`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 738`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 739`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 740`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 741`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 742`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 743`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 744`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 745`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 746`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 747`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 748`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 749`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 750`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 751`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 752`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 753`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 754`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 755`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 756`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 757`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 758`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 759`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 760`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 761`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 762`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 763`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 764`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 765`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 766`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 767`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 768`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 769`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 770`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 771`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 772`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 773`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 774`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 775`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 776`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 777`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 778`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 779`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 780`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 781`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 782`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 783`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 784`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 785`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 786`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 787`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `api.d.ts`
+- **Thin community `Community 788`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `api.js`
+- **Thin community `Community 789`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 790`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `server.d.ts`
+- **Thin community `Community 791`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `server.js`
+- **Thin community `Community 792`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `app.ts`
+- **Thin community `Community 793`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `auth.config.js`
+- **Thin community `Community 794`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `auth.ts`
+- **Thin community `Community 795`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 796`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 797`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `countries.ts`
+- **Thin community `Community 798`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `email.ts`
+- **Thin community `Community 799`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `ghana.ts`
+- **Thin community `Community 800`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `payment.ts`
+- **Thin community `Community 801`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `crons.ts`
+- **Thin community `Community 802`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 803`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 804`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 805`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 806`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `env.ts`
+- **Thin community `Community 807`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `analytics.ts`
+- **Thin community `Community 808`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `auth.ts`
+- **Thin community `Community 809`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 810`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `colors.ts`
+- **Thin community `Community 811`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `index.ts`
+- **Thin community `Community 812`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `organizations.ts`
+- **Thin community `Community 813`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `products.ts`
+- **Thin community `Community 814`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 815`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `stores.ts`
+- **Thin community `Community 816`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `index.ts`
+- **Thin community `Community 817`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `bag.ts`
+- **Thin community `Community 818`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `guest.ts`
+- **Thin community `Community 819`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `index.ts`
+- **Thin community `Community 820`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `me.ts`
+- **Thin community `Community 821`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `offers.ts`
+- **Thin community `Community 822`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 823`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `paystack.ts`
+- **Thin community `Community 824`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 825`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `reviews.ts`
+- **Thin community `Community 826`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `rewards.ts`
+- **Thin community `Community 827`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 828`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `security.test.ts`
+- **Thin community `Community 829`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `storefront.ts`
+- **Thin community `Community 830`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `upsells.ts`
+- **Thin community `Community 831`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `user.ts`
+- **Thin community `Community 832`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 833`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `health.test.ts`
+- **Thin community `Community 834`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `http.ts`
+- **Thin community `Community 835`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 836`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 837`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 838`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `categories.ts`
+- **Thin community `Community 839`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `colors.ts`
+- **Thin community `Community 840`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 841`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 842`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 843`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 844`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 845`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `organizations.ts`
+- **Thin community `Community 846`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `pos.ts`
+- **Thin community `Community 847`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 848`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 849`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `productSku.ts`
+- **Thin community `Community 850`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 851`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 852`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 853`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 854`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 855`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 856`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 857`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 858`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 859`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `client.test.ts`
+- **Thin community `Community 860`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `config.test.ts`
+- **Thin community `Community 861`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 862`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `types.ts`
+- **Thin community `Community 863`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 864`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 865`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 866`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 867`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 868`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 869`** (1 nodes): `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 870`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 871`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `dto.ts`
+- **Thin community `Community 872`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 873`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 874`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 875`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `types.ts`
+- **Thin community `Community 876`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 877`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 878`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `catalog.ts`
+- **Thin community `Community 879`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `customers.ts`
+- **Thin community `Community 880`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `register.ts`
+- **Thin community `Community 881`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `terminals.ts`
+- **Thin community `Community 882`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `schema.ts`
+- **Thin community `Community 883`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 884`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 885`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 886`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 887`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `category.ts`
+- **Thin community `Community 888`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `color.ts`
+- **Thin community `Community 889`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 890`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 891`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `index.ts`
+- **Thin community `Community 892`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 893`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `organization.ts`
+- **Thin community `Community 894`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 895`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `product.ts`
+- **Thin community `Community 896`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 897`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 898`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `store.ts`
+- **Thin community `Community 899`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 900`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `index.ts`
+- **Thin community `Community 901`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 902`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 903`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 904`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 905`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 906`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `index.ts`
+- **Thin community `Community 907`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 908`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 909`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 910`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 911`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 912`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 913`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 914`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 915`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 916`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `customer.ts`
+- **Thin community `Community 917`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 918`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 919`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 920`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 921`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `index.ts`
+- **Thin community `Community 922`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `posSession.ts`
+- **Thin community `Community 923`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 924`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 925`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 926`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 927`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `index.ts`
+- **Thin community `Community 928`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 929`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 930`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 931`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 932`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 933`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `index.ts`
+- **Thin community `Community 934`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 935`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 936`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 937`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 938`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `vendor.ts`
+- **Thin community `Community 939`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `analytics.ts`
+- **Thin community `Community 940`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `bag.ts`
+- **Thin community `Community 941`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 942`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 943`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 944`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `guest.ts`
+- **Thin community `Community 945`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `index.ts`
+- **Thin community `Community 946`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `offer.ts`
+- **Thin community `Community 947`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 948`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 949`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `review.ts`
+- **Thin community `Community 950`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `rewards.ts`
+- **Thin community `Community 951`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 952`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 953`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 954`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 955`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 956`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 957`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 958`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `bag.ts`
+- **Thin community `Community 959`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 960`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `customer.ts`
+- **Thin community `Community 961`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `guest.ts`
+- **Thin community `Community 962`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 963`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 964`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `payment.ts`
+- **Thin community `Community 965`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 966`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 967`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 968`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `users.ts`
+- **Thin community `Community 969`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `payment.ts`
+- **Thin community `Community 970`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 971`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 972`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 973`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 974`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `index.ts`
+- **Thin community `Community 975`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 976`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `auth.ts`
+- **Thin community `Community 977`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 978`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 979`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 980`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 981`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 982`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 983`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 984`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 985`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 986`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 987`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `constants.ts`
+- **Thin community `Community 988`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 989`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 990`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 991`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `types.ts`
+- **Thin community `Community 992`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 993`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 994`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 995`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 996`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 997`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 998`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 999`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1000`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1003`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1004`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1005`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1006`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1007`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1008`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1009`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1012`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `constants.ts`
+- **Thin community `Community 1013`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1015`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1016`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `data.ts`
+- **Thin community `Community 1017`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1018`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1021`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1022`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1024`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1025`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 1026`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1027`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `constants.ts`
+- **Thin community `Community 1028`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1029`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1030`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `data.ts`
+- **Thin community `Community 1032`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1033`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1034`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 1035`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1036`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1037`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1038`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1040`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1043`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `constants.ts`
+- **Thin community `Community 1044`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1045`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1046`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1048`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1049`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1050`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1051`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1052`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1053`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1054`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1056`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1057`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1058`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1059`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1060`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1061`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1062`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1063`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1064`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1065`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1066`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1067`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1068`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `constants.ts`
+- **Thin community `Community 1069`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1070`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1071`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1072`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `data.ts`
+- **Thin community `Community 1073`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1074`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `constants.ts`
+- **Thin community `Community 1075`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1076`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1077`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1078`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1079`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `data.ts`
+- **Thin community `Community 1080`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1081`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `constants.ts`
+- **Thin community `Community 1082`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1084`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1085`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1086`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `data.ts`
+- **Thin community `Community 1087`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1088`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1089`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1090`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1091`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1092`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1093`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1094`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1095`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1096`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1097`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1098`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1099`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1100`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1101`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1102`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1103`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1104`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1105`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1106`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1107`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `types.ts`
+- **Thin community `Community 1109`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1110`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1111`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1112`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1113`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1114`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1115`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1116`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1117`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1118`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1119`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1120`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1121`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1122`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1123`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1124`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1126`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `data.ts`
+- **Thin community `Community 1127`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1128`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1129`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1130`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1131`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1132`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1133`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1134`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1135`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1137`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1138`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1139`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `constants.ts`
+- **Thin community `Community 1140`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1141`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1142`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1143`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `data.ts`
+- **Thin community `Community 1144`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `types.ts`
+- **Thin community `Community 1145`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1146`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1147`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1148`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1149`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `index.tsx`
+- **Thin community `Community 1150`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1151`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1152`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1153`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1154`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `index.tsx`
+- **Thin community `Community 1155`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1156`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1157`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1158`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `button.tsx`
+- **Thin community `Community 1159`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1160`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `card.tsx`
+- **Thin community `Community 1161`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1162`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1163`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `command.tsx`
+- **Thin community `Community 1164`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1165`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1166`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1167`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `form.tsx`
+- **Thin community `Community 1168`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1169`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1170`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `input.tsx`
+- **Thin community `Community 1171`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1172`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1173`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1174`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1175`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1176`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `select.tsx`
+- **Thin community `Community 1177`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1178`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1179`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1180`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `table.tsx`
+- **Thin community `Community 1181`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1182`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1183`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1184`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1185`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1186`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1187`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1188`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1189`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `constants.ts`
+- **Thin community `Community 1190`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1191`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1192`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data.ts`
+- **Thin community `Community 1194`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1195`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1196`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1197`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1198`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1200`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1201`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1202`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1203`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1204`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1205`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1206`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `index.ts`
+- **Thin community `Community 1207`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `config.ts`
+- **Thin community `Community 1208`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1209`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1211`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1212`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1214`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `aws.ts`
+- **Thin community `Community 1215`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `constants.ts`
+- **Thin community `Community 1216`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `countries.ts`
+- **Thin community `Community 1217`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1222`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1223`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `dto.ts`
+- **Thin community `Community 1224`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `ports.ts`
+- **Thin community `Community 1225`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `constants.ts`
+- **Thin community `Community 1226`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `index.ts`
+- **Thin community `Community 1229`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1230`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `types.ts`
+- **Thin community `Community 1231`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1232`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1234`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1236`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `category.ts`
+- **Thin community `Community 1238`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `product.ts`
+- **Thin community `Community 1239`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `store.ts`
+- **Thin community `Community 1240`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1241`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `user.ts`
+- **Thin community `Community 1242`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1246`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `index.tsx`
+- **Thin community `Community 1247`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1248`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1249`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1250`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1251`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1252`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1253`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1254`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `index.tsx`
+- **Thin community `Community 1255`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1256`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1257`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1258`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `home.tsx`
+- **Thin community `Community 1259`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1260`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1261`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1262`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `index.tsx`
+- **Thin community `Community 1263`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1264`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1265`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1266`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1267`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `index.tsx`
+- **Thin community `Community 1268`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1269`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1270`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1271`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1272`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1273`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1274`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `index.tsx`
+- **Thin community `Community 1275`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1276`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1277`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1278`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1279`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1280`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1281`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `index.tsx`
+- **Thin community `Community 1282`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1283`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `new.tsx`
+- **Thin community `Community 1284`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `index.tsx`
+- **Thin community `Community 1285`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `new.tsx`
+- **Thin community `Community 1286`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1287`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1288`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `index.tsx`
+- **Thin community `Community 1289`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `new.tsx`
+- **Thin community `Community 1290`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `index.tsx`
+- **Thin community `Community 1291`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1292`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1293`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1294`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1295`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1296`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1298`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `index.tsx`
+- **Thin community `Community 1299`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1302`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1303`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1304`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1305`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1306`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1307`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1309`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1311`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1312`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1314`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1315`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1316`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1317`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `setup.ts`
+- **Thin community `Community 1321`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1323`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `types.ts`
+- **Thin community `Community 1324`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1325`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1326`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1327`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1328`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `types.ts`
+- **Thin community `Community 1330`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1331`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1332`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1333`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1335`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1336`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1337`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1338`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1339`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `schema.ts`
+- **Thin community `Community 1340`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1341`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1344`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1345`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1346`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1347`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1348`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1349`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `types.ts`
+- **Thin community `Community 1350`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1351`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1352`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1354`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1355`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1357`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `constants.ts`
+- **Thin community `Community 1358`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1359`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `About.tsx`
+- **Thin community `Community 1360`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1361`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1363`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1364`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1365`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1366`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1367`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1368`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1369`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `types.ts`
+- **Thin community `Community 1370`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1371`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1372`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1373`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1374`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1375`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1376`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1377`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1378`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1379`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1380`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1381`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `button.tsx`
+- **Thin community `Community 1382`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `card.tsx`
+- **Thin community `Community 1383`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1384`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `command.tsx`
+- **Thin community `Community 1385`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1386`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1387`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1388`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `form.tsx`
+- **Thin community `Community 1389`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1390`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1391`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1392`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1393`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `input.tsx`
+- **Thin community `Community 1394`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `label.tsx`
+- **Thin community `Community 1395`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1396`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1397`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1398`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `index.ts`
+- **Thin community `Community 1399`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `types.ts`
+- **Thin community `Community 1400`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1401`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1402`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1403`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1404`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `select.tsx`
+- **Thin community `Community 1405`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1406`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1407`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `table.tsx`
+- **Thin community `Community 1408`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1409`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1410`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1411`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1412`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1413`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `config.ts`
+- **Thin community `Community 1414`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1415`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1416`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1417`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `constants.ts`
+- **Thin community `Community 1418`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `countries.ts`
+- **Thin community `Community 1419`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1420`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1421`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1422`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1423`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `index.ts`
+- **Thin community `Community 1424`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `store.ts`
+- **Thin community `Community 1425`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `bag.ts`
+- **Thin community `Community 1426`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1427`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `category.ts`
+- **Thin community `Community 1428`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `organization.ts`
+- **Thin community `Community 1429`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `product.ts`
+- **Thin community `Community 1430`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `store.ts`
+- **Thin community `Community 1431`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1432`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `user.ts`
+- **Thin community `Community 1433`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `states.ts`
+- **Thin community `Community 1434`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1435`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1438`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1439`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1440`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1441`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `index.tsx`
+- **Thin community `Community 1442`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1443`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `index.tsx`
+- **Thin community `Community 1444`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1445`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1446`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1447`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1448`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1449`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `index.tsx`
+- **Thin community `Community 1450`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1451`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1452`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1453`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1454`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `index.js`
+- **Thin community `Community 1455`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1457`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1460`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -719,7 +719,7 @@
       "relation": "calls",
       "source": "cashierauthdialog_getstaffdisplayname",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L132",
+      "source_location": "L133",
       "target": "cashierauthdialog_cashierauthdialog",
       "weight": 1
     },
@@ -2135,8 +2135,32 @@
       "relation": "calls",
       "source": "getregisterstate_buildregisterstate",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L57",
+      "source_location": "L107",
       "target": "getregisterstate_getregisterstate",
+      "weight": 1
+    },
+    {
+      "_src": "getregisterstate_getregisterstate",
+      "_tgt": "getregisterstate_getactivesessionconflictforregisterstate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "getregisterstate_getactivesessionconflictforregisterstate",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L103",
+      "target": "getregisterstate_getregisterstate",
+      "weight": 1
+    },
+    {
+      "_src": "gettransactions_gettransactionbyid",
+      "_tgt": "gettransactions_liststaffnames",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "gettransactions_liststaffnames",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L199",
+      "target": "gettransactions_gettransactionbyid",
       "weight": 1
     },
     {
@@ -2147,7 +2171,7 @@
       "relation": "calls",
       "source": "gettransactions_loadcorrectionevents",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L178",
+      "source_location": "L195",
       "target": "gettransactions_gettransactionbyid",
       "weight": 1
     },
@@ -2159,7 +2183,7 @@
       "relation": "calls",
       "source": "gettransactions_loadcustomerprofile",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L177",
+      "source_location": "L194",
       "target": "gettransactions_gettransactionbyid",
       "weight": 1
     },
@@ -2171,7 +2195,7 @@
       "relation": "calls",
       "source": "gettransactions_summarizecashiername",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L203",
+      "source_location": "L228",
       "target": "gettransactions_gettransactionbyid",
       "weight": 1
     },
@@ -8711,7 +8735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L227",
+      "source_location": "L247",
       "target": "possessions_trace_test_buildsession",
       "weight": 1
     },
@@ -8723,7 +8747,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L90",
+      "source_location": "L92",
       "target": "possessions_trace_test_createmutationctx",
       "weight": 1
     },
@@ -8735,8 +8759,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L244",
+      "source_location": "L264",
       "target": "possessions_trace_test_gethandler",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "_tgt": "possessions_expirepossessionnow",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L242",
+      "target": "possessions_expirepossessionnow",
       "weight": 1
     },
     {
@@ -8747,7 +8783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L321",
+      "source_location": "L373",
       "target": "possessions_hascustomersnapshotvalue",
       "weight": 1
     },
@@ -8807,7 +8843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L375",
+      "source_location": "L427",
       "target": "possessions_loadsessioncustomer",
       "weight": 1
     },
@@ -8819,7 +8855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L306",
+      "source_location": "L358",
       "target": "possessions_normalizecustomersnapshot",
       "weight": 1
     },
@@ -8831,7 +8867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L242",
+      "source_location": "L294",
       "target": "possessions_persistsessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -8843,7 +8879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L263",
+      "source_location": "L315",
       "target": "possessions_recordsessionlifecycletracebesteffort",
       "weight": 1
     },
@@ -8867,7 +8903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L332",
+      "source_location": "L384",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -12647,8 +12683,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L17",
+      "source_location": "L21",
       "target": "getregisterstate_buildregisterstate",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "_tgt": "getregisterstate_getactivesessionconflictforregisterstate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L42",
+      "target": "getregisterstate_getactivesessionconflictforregisterstate",
       "weight": 1
     },
     {
@@ -12659,7 +12707,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L37",
+      "source_location": "L80",
       "target": "getregisterstate_getregisterstate",
       "weight": 1
     },
@@ -12671,7 +12719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L99",
+      "source_location": "L116",
       "target": "gettransactions_getcompletedtransactions",
       "weight": 1
     },
@@ -12683,7 +12731,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L254",
+      "source_location": "L282",
       "target": "gettransactions_getrecenttransactionswithcustomers",
       "weight": 1
     },
@@ -12695,7 +12743,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L289",
+      "source_location": "L317",
       "target": "gettransactions_gettodaysummary",
       "weight": 1
     },
@@ -12707,7 +12755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L74",
+      "source_location": "L91",
       "target": "gettransactions_gettransaction",
       "weight": 1
     },
@@ -12719,7 +12767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L147",
+      "source_location": "L164",
       "target": "gettransactions_gettransactionbyid",
       "weight": 1
     },
@@ -12731,8 +12779,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L89",
+      "source_location": "L106",
       "target": "gettransactions_gettransactionsbystore",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "_tgt": "gettransactions_liststaffnames",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L74",
+      "target": "gettransactions_liststaffnames",
       "weight": 1
     },
     {
@@ -18671,7 +18731,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1779",
+      "source_location": "L1793",
       "target": "registersessionview_errormessage",
       "weight": 1
     },
@@ -21137,6 +21197,18 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "_tgt": "registerdrawergate_handleopeningfloatcorrectionsubmit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L74",
+      "target": "registerdrawergate_handleopeningfloatcorrectionsubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "_tgt": "registerdrawergate_handlesubmit",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -21335,7 +21407,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L193",
+      "source_location": "L230",
       "target": "transactionview_authenticatecorrectionstaff",
       "weight": 1
     },
@@ -21347,20 +21419,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L55",
+      "source_location": "L69",
       "target": "transactionview_formatcorrectioneventtype",
       "weight": 1
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "_tgt": "transactionview_getrelativetime",
+      "_tgt": "transactionview_formatcorrectionhistorymeta",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L661",
-      "target": "transactionview_getrelativetime",
+      "source_location": "L87",
+      "target": "transactionview_formatcorrectionhistorymeta",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "_tgt": "transactionview_formatcorrectionhistorytitle",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L75",
+      "target": "transactionview_formatcorrectionhistorytitle",
       "weight": 1
     },
     {
@@ -21371,7 +21455,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L61",
+      "source_location": "L96",
       "target": "transactionview_gettransactioncorrectionhistory",
       "weight": 1
     },
@@ -21383,7 +21467,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L292",
+      "source_location": "L331",
       "target": "transactionview_requestcorrectionsubmit",
       "weight": 1
     },
@@ -21395,7 +21479,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L217",
+      "source_location": "L254",
       "target": "transactionview_runcustomercorrection",
       "weight": 1
     },
@@ -21407,7 +21491,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L253",
+      "source_location": "L291",
       "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
@@ -25115,7 +25199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
-      "source_location": "L44",
+      "source_location": "L48",
       "target": "operatormessages_tooperatormessage",
       "weight": 1
     },
@@ -26051,7 +26135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L27",
+      "source_location": "L30",
       "target": "registergateway_mapterminaldto",
       "weight": 1
     },
@@ -26063,7 +26147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L33",
+      "source_location": "L36",
       "target": "registergateway_useconvexregisterstate",
       "weight": 1
     },
@@ -26075,7 +26159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L55",
+      "source_location": "L58",
       "target": "registergateway_useconvexterminalbyfingerprint",
       "weight": 1
     },
@@ -26291,7 +26375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L176",
+      "source_location": "L182",
       "target": "useregisterviewmodel_test_deferred",
       "weight": 1
     },
@@ -27517,6 +27601,30 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L29",
       "target": "storesettingsview_storesettings",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
+      "_tgt": "actioncolorreview_stories_swatch",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L179",
+      "target": "actioncolorreview_stories_swatch",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
+      "_tgt": "actioncolorreview_stories_tokenscope",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L168",
+      "target": "actioncolorreview_stories_tokenscope",
       "weight": 1
     },
     {
@@ -34132,6 +34240,18 @@
       "weight": 1
     },
     {
+      "_src": "possessions_expirepossessionnow",
+      "_tgt": "possessions_recordsessionlifecycletracebesteffort",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "possessions_expirepossessionnow",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L280",
+      "target": "possessions_recordsessionlifecycletracebesteffort",
+      "weight": 1
+    },
+    {
       "_src": "possessions_recordsessionlifecycletracebesteffort",
       "_tgt": "possessions_persistsessionworkflowtraceidbesteffort",
       "confidence": "EXTRACTED",
@@ -34139,7 +34259,7 @@
       "relation": "calls",
       "source": "possessions_persistsessionworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L285",
+      "source_location": "L337",
       "target": "possessions_recordsessionlifecycletracebesteffort",
       "weight": 1
     },
@@ -34151,7 +34271,7 @@
       "relation": "calls",
       "source": "possessions_hascustomersnapshotvalue",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L352",
+      "source_location": "L404",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -34163,7 +34283,7 @@
       "relation": "calls",
       "source": "possessions_normalizecustomersnapshot",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L339",
+      "source_location": "L391",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -34943,7 +35063,7 @@
       "relation": "calls",
       "source": "registergateway_mapregisterstatedto",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L52",
+      "source_location": "L55",
       "target": "registergateway_useconvexregisterstate",
       "weight": 1
     },
@@ -34955,7 +35075,7 @@
       "relation": "calls",
       "source": "registergateway_mapterminaldto",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L72",
+      "source_location": "L75",
       "target": "registergateway_useconvexterminalbyfingerprint",
       "weight": 1
     },
@@ -40763,7 +40883,7 @@
       "relation": "calls",
       "source": "staffcredentials_authenticatestaffcredentialwithctx",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L506",
+      "source_location": "L507",
       "target": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
       "weight": 1
     },
@@ -40775,7 +40895,7 @@
       "relation": "calls",
       "source": "staffcredentials_staffpreconditionfailedresult",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L544",
+      "source_location": "L549",
       "target": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
       "weight": 1
     },
@@ -43036,6 +43156,18 @@
       "weight": 1
     },
     {
+      "_src": "transactionview_formatcorrectionhistorytitle",
+      "_tgt": "transactionview_formatcorrectioneventtype",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "transactionview_formatcorrectioneventtype",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L83",
+      "target": "transactionview_formatcorrectionhistorytitle",
+      "weight": 1
+    },
+    {
       "_src": "upsells_getlastviewedproduct",
       "_tgt": "upsells_getbaseurl",
       "confidence": "EXTRACTED",
@@ -43079,7 +43211,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L254",
+      "source_location": "L268",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -44355,6 +44487,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -44362,7 +44503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44371,7 +44512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44380,7 +44521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44389,7 +44530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -44398,7 +44539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44407,7 +44548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44416,7 +44557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -44425,21 +44566,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -44508,6 +44640,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -44515,7 +44656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -44524,7 +44665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -44533,7 +44674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44542,7 +44683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44551,7 +44692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44560,7 +44701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -44569,7 +44710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -44578,21 +44719,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -44661,6 +44793,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -44668,7 +44809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44677,7 +44818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44686,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44695,7 +44836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44704,7 +44845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -44713,7 +44854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -44722,7 +44863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -44731,7 +44872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44740,7 +44881,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "label": "RegisterDrawerGate.tsx",
+      "norm_label": "registerdrawergate.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "registerdrawergate_cashcontrolsbutton",
+      "label": "CashControlsButton()",
+      "norm_label": "cashcontrolsbutton()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "registerdrawergate_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "registerdrawergate_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "registerdrawergate_handlecloseoutsubmit",
+      "label": "handleCloseoutSubmit()",
+      "norm_label": "handlecloseoutsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
+      "label": "handleOpeningFloatCorrectionSubmit()",
+      "norm_label": "handleopeningfloatcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "registerdrawergate_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 1030,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44749,70 +44953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
-    },
-    {
-      "community": 1030,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44821,7 +44962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -44830,7 +44971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -44839,7 +44980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -44848,7 +44989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -44857,7 +44998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -44866,7 +45007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -44875,7 +45016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -44884,7 +45025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44893,7 +45034,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
+    },
+    {
+      "community": 1040,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44902,70 +45106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 1040,
+      "community": 1041,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44974,7 +45115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44983,7 +45124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -44992,7 +45133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -45001,7 +45142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45010,7 +45151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45019,7 +45160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45028,7 +45169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -45037,7 +45178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -45046,7 +45187,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 1050,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -45055,70 +45259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 105,
-      "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1050,
+      "community": 1051,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -45127,7 +45268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -45136,7 +45277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -45145,7 +45286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
@@ -45154,7 +45295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -45163,7 +45304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -45172,7 +45313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45181,7 +45322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45190,7 +45331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -45199,7 +45340,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 106,
+      "file_type": "code",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1060,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -45208,70 +45412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 1060,
+      "community": 1061,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -45280,7 +45421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -45289,7 +45430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -45298,7 +45439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -45307,7 +45448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -45316,7 +45457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -45325,7 +45466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -45334,7 +45475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -45343,7 +45484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -45352,7 +45493,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 1070,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45361,70 +45565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 1070,
+      "community": 1071,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45433,7 +45574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -45442,7 +45583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -45451,7 +45592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -45460,7 +45601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -45469,7 +45610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45478,7 +45619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45487,7 +45628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -45496,7 +45637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -45505,7 +45646,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 1080,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -45514,70 +45718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 1080,
+      "community": 1081,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -45586,7 +45727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -45595,7 +45736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45604,7 +45745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45613,7 +45754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -45622,7 +45763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -45631,7 +45772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -45640,7 +45781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -45649,7 +45790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -45658,7 +45799,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 1090,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -45667,70 +45871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 109,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L394"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 1090,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -45739,7 +45880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -45748,7 +45889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -45757,7 +45898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -45766,7 +45907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -45775,7 +45916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -45784,7 +45925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -45793,7 +45934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -45802,21 +45943,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
       "norm_label": "totalsdisplay.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1"
     },
     {
@@ -46011,68 +46143,77 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
     },
     {
+      "community": 110,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171"
+    },
+    {
       "community": 1100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -46081,7 +46222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -46090,7 +46231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -46099,7 +46240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -46108,7 +46249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -46117,7 +46258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -46126,7 +46267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -46135,7 +46276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -46144,7 +46285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -46153,7 +46294,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 111,
+      "file_type": "code",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1110,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -46162,70 +46366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1110,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -46234,7 +46375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -46243,7 +46384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -46252,7 +46393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -46261,7 +46402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -46270,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -46279,7 +46420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -46288,7 +46429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -46297,7 +46438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -46306,7 +46447,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 112,
+      "file_type": "code",
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1120,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -46315,61 +46519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 112,
-      "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1120,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -46378,7 +46528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -46387,7 +46537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46396,7 +46546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46405,7 +46555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46414,7 +46564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -46423,7 +46573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -46432,7 +46582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -46441,7 +46591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -46450,7 +46600,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 113,
+      "file_type": "code",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1130,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -46459,61 +46663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 113,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 1130,
+      "community": 1131,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -46522,7 +46672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -46531,7 +46681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -46540,7 +46690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -46549,7 +46699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46558,7 +46708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46567,7 +46717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46576,7 +46726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -46585,7 +46735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -46594,7 +46744,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 1140,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -46603,61 +46807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
-      "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1140,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46666,7 +46816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46675,7 +46825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -46684,7 +46834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -46693,7 +46843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -46702,7 +46852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -46711,7 +46861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -46720,7 +46870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -46729,7 +46879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -46738,7 +46888,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 115,
+      "file_type": "code",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1150,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -46747,61 +46951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 1150,
+      "community": 1151,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -46810,7 +46960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -46819,7 +46969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -46828,7 +46978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -46837,7 +46987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -46846,7 +46996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -46855,7 +47005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -46864,7 +47014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -46873,7 +47023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -46882,7 +47032,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 1160,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -46891,61 +47095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
-      "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1160,
+      "community": 1161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -46954,7 +47104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -46963,7 +47113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -46972,7 +47122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -46981,7 +47131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -46990,7 +47140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -46999,7 +47149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -47008,7 +47158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -47017,7 +47167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -47026,7 +47176,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 117,
+      "file_type": "code",
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1170,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -47035,61 +47239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L1"
-    },
-    {
-      "community": 1170,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -47098,7 +47248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -47107,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -47116,7 +47266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -47125,7 +47275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -47134,7 +47284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -47143,7 +47293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -47152,7 +47302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -47161,7 +47311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -47170,7 +47320,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 118,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L1"
+    },
+    {
+      "community": 1180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -47179,61 +47383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 1180,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -47242,7 +47392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -47251,7 +47401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -47260,7 +47410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -47269,7 +47419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -47278,7 +47428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -47287,7 +47437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -47296,7 +47446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -47305,7 +47455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -47314,7 +47464,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -47323,61 +47527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 1190,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -47386,7 +47536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -47395,7 +47545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -47404,7 +47554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -47413,7 +47563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -47422,7 +47572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -47431,7 +47581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -47440,7 +47590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -47449,21 +47599,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -47649,59 +47790,68 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -47710,7 +47860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -47719,7 +47869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -47728,7 +47878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -47737,7 +47887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -47746,7 +47896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -47755,7 +47905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -47764,7 +47914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -47773,7 +47923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -47782,7 +47932,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 121,
+      "file_type": "code",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -47791,61 +47995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 1210,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -47854,7 +48004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -47863,7 +48013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -47872,7 +48022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -47881,7 +48031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -47890,7 +48040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -47899,7 +48049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -47908,7 +48058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -47917,7 +48067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -47926,7 +48076,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -47935,61 +48139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1220,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -47998,7 +48148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -48007,7 +48157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -48016,7 +48166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -48025,7 +48175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -48034,7 +48184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -48043,7 +48193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -48052,7 +48202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -48061,7 +48211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -48070,7 +48220,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 123,
+      "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1230,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -48079,61 +48283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "label": "RegisterDrawerGate.tsx",
-      "norm_label": "registerdrawergate.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "registerdrawergate_cashcontrolsbutton",
-      "label": "CashControlsButton()",
-      "norm_label": "cashcontrolsbutton()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "registerdrawergate_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "registerdrawergate_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "registerdrawergate_handlecloseoutsubmit",
-      "label": "handleCloseoutSubmit()",
-      "norm_label": "handlecloseoutsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "registerdrawergate_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 1230,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -48142,7 +48292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -48151,7 +48301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -48160,7 +48310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -48169,7 +48319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "label": "useExpenseRegisterViewModel.test.ts",
@@ -48178,7 +48328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -48187,7 +48337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -48196,7 +48346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -48205,21 +48355,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1"
     },
     {
@@ -48279,6 +48420,15 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -48286,7 +48436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -48295,7 +48445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -48304,7 +48454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -48313,7 +48463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -48322,7 +48472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -48331,7 +48481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -48340,7 +48490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -48349,21 +48499,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1"
     },
     {
@@ -48423,6 +48564,15 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
@@ -48430,7 +48580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -48439,7 +48589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -48448,7 +48598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -48457,7 +48607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -48466,7 +48616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -48475,7 +48625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -48484,7 +48634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -48493,21 +48643,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
       "norm_label": "dashboard.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1"
     },
     {
@@ -48567,6 +48708,15 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
@@ -48574,7 +48724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -48583,7 +48733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -48592,7 +48742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -48601,7 +48751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -48610,7 +48760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -48619,7 +48769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -48628,7 +48778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -48637,21 +48787,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
@@ -48711,6 +48852,15 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
@@ -48718,7 +48868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -48727,7 +48877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -48736,7 +48886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -48745,7 +48895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -48754,7 +48904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -48763,7 +48913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -48772,7 +48922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -48781,21 +48931,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
       "norm_label": "$transactionid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1"
     },
     {
@@ -48855,6 +48996,15 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
       "norm_label": "procurement.index.tsx",
@@ -48862,7 +49012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -48871,7 +49021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -48880,7 +49030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -48889,7 +49039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -48898,7 +49048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -48907,7 +49057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -48916,7 +49066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -48925,21 +49075,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
       "norm_label": "$promocodeslug.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
       "source_location": "L1"
     },
     {
@@ -48999,6 +49140,15 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
@@ -49006,7 +49156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -49015,7 +49165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -49024,7 +49174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -49033,7 +49183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -49042,7 +49192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -49051,7 +49201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -49060,7 +49210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -49069,21 +49219,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
       "norm_label": "users.$userid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1"
     },
     {
@@ -49323,6 +49464,15 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
       "norm_label": "_authed.test.tsx",
@@ -49330,7 +49480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -49339,7 +49489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -49348,7 +49498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -49357,7 +49507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -49366,7 +49516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -49375,7 +49525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -49384,7 +49534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -49393,21 +49543,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
       "norm_label": "foundations-content.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -49467,6 +49608,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
       "norm_label": "introduction-content.test.tsx",
@@ -49474,7 +49624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -49483,7 +49633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -49492,7 +49642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -49501,7 +49651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -49510,7 +49660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -49519,7 +49669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -49528,7 +49678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -49537,21 +49687,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
       "norm_label": "reference-fixtures.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
-      "label": "storybook-config.test.ts",
-      "norm_label": "storybook-config.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
       "source_location": "L1"
     },
     {
@@ -49611,6 +49752,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
+      "label": "storybook-config.test.ts",
+      "norm_label": "storybook-config.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
       "norm_label": "storybook-theme-decorator.test.ts",
@@ -49618,7 +49768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -49627,7 +49777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -49636,7 +49786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -49645,7 +49795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -49654,7 +49804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -49663,7 +49813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -49672,7 +49822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -49681,21 +49831,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
       "norm_label": "playwright.config.ts",
       "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
       "source_location": "L1"
     },
     {
@@ -49755,6 +49896,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -49762,7 +49912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -49771,7 +49921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -49780,7 +49930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -49789,7 +49939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -49798,7 +49948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -49807,7 +49957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -49816,7 +49966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -49825,21 +49975,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
       "norm_label": "checkout.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
@@ -49899,6 +50040,15 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
@@ -49906,7 +50056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -49915,7 +50065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -49924,7 +50074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -49933,7 +50083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -49942,7 +50092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -49951,7 +50101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -49960,7 +50110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -49969,21 +50119,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
       "norm_label": "deliverydetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
@@ -50043,6 +50184,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -50050,7 +50200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -50059,7 +50209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -50068,7 +50218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -50077,7 +50227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -50086,7 +50236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -50095,7 +50245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -50104,7 +50254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -50113,21 +50263,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
@@ -50187,6 +50328,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
       "norm_label": "about.tsx",
@@ -50194,7 +50344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -50203,7 +50353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -50212,7 +50362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -50221,7 +50371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -50230,7 +50380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -50239,7 +50389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -50248,7 +50398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -50257,21 +50407,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
       "norm_label": "reviewform.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -50331,6 +50472,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -50338,7 +50488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -50347,7 +50497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -50356,7 +50506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -50365,7 +50515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -50374,7 +50524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -50383,7 +50533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
@@ -50392,7 +50542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -50401,21 +50551,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
       "norm_label": "animatedcard.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1"
     },
     {
@@ -50475,6 +50616,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
       "norm_label": "alert.tsx",
@@ -50482,7 +50632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -50491,7 +50641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -50500,7 +50650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -50509,7 +50659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -50518,7 +50668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -50527,7 +50677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -50536,7 +50686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -50545,21 +50695,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
       "source_location": "L1"
     },
     {
@@ -50619,6 +50760,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
@@ -50626,7 +50776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -50635,7 +50785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -50644,7 +50794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -50653,7 +50803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -50662,7 +50812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -50671,7 +50821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -50680,7 +50830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -50689,21 +50839,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
       "norm_label": "welcomebackmodalanimations.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
       "source_location": "L1"
     },
     {
@@ -50943,6 +51084,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -50950,7 +51100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -50959,7 +51109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -50968,7 +51118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -50977,7 +51127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -50986,7 +51136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -50995,7 +51145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -51004,7 +51154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -51013,21 +51163,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
@@ -51087,6 +51228,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
@@ -51094,7 +51244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -51103,7 +51253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -51112,7 +51262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -51121,7 +51271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -51130,7 +51280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -51139,7 +51289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -51148,7 +51298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -51157,21 +51307,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
@@ -51231,6 +51372,15 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
       "norm_label": "feeutils.test.ts",
@@ -51238,7 +51388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -51247,7 +51397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -51256,7 +51406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -51265,7 +51415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -51274,7 +51424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -51283,7 +51433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -51292,7 +51442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -51301,21 +51451,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1"
     },
     {
@@ -51375,6 +51516,15 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -51382,7 +51532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -51391,7 +51541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -51400,7 +51550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -51409,7 +51559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -51418,7 +51568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -51427,7 +51577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -51436,7 +51586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -51445,21 +51595,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
-      "label": "-homePageLoader.test.ts",
-      "norm_label": "-homepageloader.test.ts",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
       "source_location": "L1"
     },
     {
@@ -51519,6 +51660,15 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
+      "label": "-homePageLoader.test.ts",
+      "norm_label": "-homepageloader.test.ts",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
       "norm_label": "__root.tsx",
@@ -51526,7 +51676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -51535,7 +51685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -51544,7 +51694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -51553,7 +51703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -51562,7 +51712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -51571,7 +51721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -51580,7 +51730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -51589,21 +51739,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
       "norm_label": "complete.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
-      "label": "incomplete.tsx",
-      "norm_label": "incomplete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
       "source_location": "L1"
     },
     {
@@ -51663,6 +51804,15 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
+      "label": "incomplete.tsx",
+      "norm_label": "incomplete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -51670,7 +51820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -51679,7 +51829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -51688,7 +51838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -51697,7 +51847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -51706,7 +51856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -51715,7 +51865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -51724,7 +51874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -51733,21 +51883,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
       "norm_label": "harness-behavior-scenarios.test.ts",
       "source_file": "scripts/harness-behavior-scenarios.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_test_ts",
-      "label": "harness-repo-validation.test.ts",
-      "norm_label": "harness-repo-validation.test.ts",
-      "source_file": "scripts/harness-repo-validation.test.ts",
       "source_location": "L1"
     },
     {
@@ -51802,6 +51943,15 @@
       "label": "graphify-check.ts",
       "norm_label": "graphify-check.ts",
       "source_file": "scripts/graphify-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1460,
+      "file_type": "code",
+      "id": "scripts_harness_repo_validation_test_ts",
+      "label": "harness-repo-validation.test.ts",
+      "norm_label": "harness-repo-validation.test.ts",
+      "source_file": "scripts/harness-repo-validation.test.ts",
       "source_location": "L1"
     },
     {
@@ -54133,7 +54283,7 @@
       "label": "mapTerminalDto()",
       "norm_label": "mapterminaldto()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L27"
+      "source_location": "L30"
     },
     {
       "community": 183,
@@ -54142,7 +54292,7 @@
       "label": "useConvexRegisterState()",
       "norm_label": "useconvexregisterstate()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L33"
+      "source_location": "L36"
     },
     {
       "community": 183,
@@ -54151,7 +54301,7 @@
       "label": "useConvexTerminalByFingerprint()",
       "norm_label": "useconvexterminalbyfingerprint()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L55"
+      "source_location": "L58"
     },
     {
       "community": 184,
@@ -55537,7 +55687,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L227"
+      "source_location": "L247"
     },
     {
       "community": 202,
@@ -55546,7 +55696,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L90"
+      "source_location": "L92"
     },
     {
       "community": 202,
@@ -55555,7 +55705,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L244"
+      "source_location": "L264"
     },
     {
       "community": 203,
@@ -56082,6 +56232,42 @@
     {
       "community": 213,
       "file_type": "code",
+      "id": "getregisterstate_buildregisterstate",
+      "label": "buildRegisterState()",
+      "norm_label": "buildregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "getregisterstate_getactivesessionconflictforregisterstate",
+      "label": "getActiveSessionConflictForRegisterState()",
+      "norm_label": "getactivesessionconflictforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "getregisterstate_getregisterstate",
+      "label": "getRegisterState()",
+      "norm_label": "getregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "label": "getRegisterState.ts",
+      "norm_label": "getregisterstate.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
       "norm_label": "searchcatalog.ts",
@@ -56089,7 +56275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -56098,7 +56284,7 @@
       "source_location": "L122"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -56107,7 +56293,7 @@
       "source_location": "L34"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -56116,7 +56302,7 @@
       "source_location": "L72"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -56125,7 +56311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -56134,7 +56320,7 @@
       "source_location": "L162"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -56143,7 +56329,7 @@
       "source_location": "L56"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -56152,7 +56338,7 @@
       "source_location": "L180"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -56161,7 +56347,7 @@
       "source_location": "L31"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -56170,7 +56356,7 @@
       "source_location": "L176"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -56179,7 +56365,7 @@
       "source_location": "L27"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -56188,7 +56374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -56197,7 +56383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -56206,7 +56392,7 @@
       "source_location": "L23"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -56215,7 +56401,7 @@
       "source_location": "L9"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -56224,7 +56410,7 @@
       "source_location": "L13"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -56233,7 +56419,7 @@
       "source_location": "L19"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -56242,7 +56428,7 @@
       "source_location": "L26"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -56251,7 +56437,7 @@
       "source_location": "L12"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -56260,7 +56446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -56269,7 +56455,7 @@
       "source_location": "L21"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -56278,7 +56464,7 @@
       "source_location": "L63"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -56287,49 +56473,13 @@
       "source_location": "L71"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
       "norm_label": "customerengagementevents.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 22,
@@ -56487,6 +56637,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
       "norm_label": "isusererrorresult()",
@@ -56494,7 +56680,7 @@
       "source_location": "L51"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -56503,7 +56689,7 @@
       "source_location": "L37"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -56512,7 +56698,7 @@
       "source_location": "L44"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -56521,7 +56707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -56530,7 +56716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -56539,7 +56725,7 @@
       "source_location": "L12"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -56548,7 +56734,7 @@
       "source_location": "L46"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -56557,7 +56743,7 @@
       "source_location": "L7"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -56566,7 +56752,7 @@
       "source_location": "L227"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -56575,7 +56761,7 @@
       "source_location": "L46"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -56584,7 +56770,7 @@
       "source_location": "L27"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -56593,7 +56779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -56602,7 +56788,7 @@
       "source_location": "L55"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -56611,7 +56797,7 @@
       "source_location": "L32"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -56620,7 +56806,7 @@
       "source_location": "L211"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -56629,7 +56815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -56638,7 +56824,7 @@
       "source_location": "L52"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -56647,7 +56833,7 @@
       "source_location": "L27"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -56656,7 +56842,7 @@
       "source_location": "L288"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -56665,7 +56851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -56674,7 +56860,7 @@
       "source_location": "L48"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -56683,7 +56869,7 @@
       "source_location": "L88"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -56692,7 +56878,7 @@
       "source_location": "L14"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -56701,7 +56887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -56710,7 +56896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -56719,7 +56905,7 @@
       "source_location": "L15"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -56728,7 +56914,7 @@
       "source_location": "L28"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -56737,7 +56923,7 @@
       "source_location": "L19"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -56746,7 +56932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -56755,7 +56941,7 @@
       "source_location": "L52"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -56764,7 +56950,7 @@
       "source_location": "L3"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -56773,7 +56959,7 @@
       "source_location": "L90"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -56782,7 +56968,7 @@
       "source_location": "L86"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -56791,7 +56977,7 @@
       "source_location": "L76"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -56800,49 +56986,13 @@
       "source_location": "L52"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
       "norm_label": "maintenancemessageeditor.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "label": "ShopLook.tsx",
-      "norm_label": "shoplook.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "shoplook_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "shoplook_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "shoplook_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L73"
     },
     {
       "community": 23,
@@ -57000,6 +57150,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
+      "label": "ShopLook.tsx",
+      "norm_label": "shoplook.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "shoplook_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "shoplook_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "shoplook_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
       "norm_label": "returnexchangeview.tsx",
@@ -57007,7 +57193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -57016,7 +57202,7 @@
       "source_location": "L105"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -57025,7 +57211,7 @@
       "source_location": "L97"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -57034,7 +57220,7 @@
       "source_location": "L83"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -57043,7 +57229,7 @@
       "source_location": "L91"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -57052,7 +57238,7 @@
       "source_location": "L68"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -57061,7 +57247,7 @@
       "source_location": "L22"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -57070,7 +57256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -57079,7 +57265,7 @@
       "source_location": "L36"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -57088,7 +57274,7 @@
       "source_location": "L53"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -57097,7 +57283,7 @@
       "source_location": "L32"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -57106,7 +57292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "ordersummary_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -57115,7 +57301,7 @@
       "source_location": "L377"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -57124,7 +57310,7 @@
       "source_location": "L259"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -57133,7 +57319,7 @@
       "source_location": "L276"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -57142,7 +57328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -57151,7 +57337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -57160,7 +57346,7 @@
       "source_location": "L27"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -57169,7 +57355,7 @@
       "source_location": "L18"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -57178,7 +57364,7 @@
       "source_location": "L14"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -57187,7 +57373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -57196,7 +57382,7 @@
       "source_location": "L312"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -57205,7 +57391,7 @@
       "source_location": "L364"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -57214,7 +57400,7 @@
       "source_location": "L219"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -57223,7 +57409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -57232,7 +57418,7 @@
       "source_location": "L22"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -57241,7 +57427,7 @@
       "source_location": "L27"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -57250,7 +57436,7 @@
       "source_location": "L40"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -57259,7 +57445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -57268,7 +57454,7 @@
       "source_location": "L78"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -57277,7 +57463,7 @@
       "source_location": "L118"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -57286,7 +57472,7 @@
       "source_location": "L89"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -57295,7 +57481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -57304,7 +57490,7 @@
       "source_location": "L63"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -57313,49 +57499,13 @@
       "source_location": "L54"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
       "norm_label": "productstockstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 24,
@@ -57513,6 +57663,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
       "norm_label": "promocodemoney.ts",
@@ -57520,7 +57706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -57529,7 +57715,7 @@
       "source_location": "L5"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -57538,7 +57724,7 @@
       "source_location": "L30"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -57547,7 +57733,7 @@
       "source_location": "L21"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -57556,7 +57742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -57565,7 +57751,7 @@
       "source_location": "L178"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -57574,7 +57760,7 @@
       "source_location": "L205"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -57583,7 +57769,7 @@
       "source_location": "L806"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -57592,7 +57778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -57601,7 +57787,7 @@
       "source_location": "L41"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -57610,7 +57796,7 @@
       "source_location": "L45"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -57619,7 +57805,7 @@
       "source_location": "L65"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -57628,7 +57814,7 @@
       "source_location": "L75"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -57637,7 +57823,7 @@
       "source_location": "L82"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -57646,7 +57832,7 @@
       "source_location": "L93"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -57655,7 +57841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -57664,7 +57850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -57673,7 +57859,7 @@
       "source_location": "L15"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -57682,7 +57868,7 @@
       "source_location": "L28"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -57691,7 +57877,7 @@
       "source_location": "L54"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -57700,7 +57886,7 @@
       "source_location": "L66"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -57709,7 +57895,7 @@
       "source_location": "L121"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -57718,7 +57904,7 @@
       "source_location": "L74"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -57727,7 +57913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -57736,7 +57922,7 @@
       "source_location": "L51"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -57745,7 +57931,7 @@
       "source_location": "L92"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -57754,7 +57940,7 @@
       "source_location": "L16"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -57763,7 +57949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -57772,7 +57958,7 @@
       "source_location": "L22"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -57781,7 +57967,7 @@
       "source_location": "L10"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -57790,7 +57976,7 @@
       "source_location": "L57"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -57799,7 +57985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -57808,7 +57994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -57817,7 +58003,7 @@
       "source_location": "L83"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -57826,49 +58012,13 @@
       "source_location": "L100"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
       "norm_label": "normalizecartitems()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
       "source_location": "L79"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
-      "label": "sessionGateway.ts",
-      "norm_label": "sessiongateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexactivesession",
-      "label": "useConvexActiveSession()",
-      "norm_label": "useconvexactivesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexheldsessions",
-      "label": "useConvexHeldSessions()",
-      "norm_label": "useconvexheldsessions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexsessionactions",
-      "label": "useConvexSessionActions()",
-      "norm_label": "useconvexsessionactions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L91"
     },
     {
       "community": 25,
@@ -58026,6 +58176,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
+      "label": "sessionGateway.ts",
+      "norm_label": "sessiongateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexactivesession",
+      "label": "useConvexActiveSession()",
+      "norm_label": "useconvexactivesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexheldsessions",
+      "label": "useConvexHeldSessions()",
+      "norm_label": "useconvexheldsessions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexsessionactions",
+      "label": "useConvexSessionActions()",
+      "norm_label": "useconvexsessionactions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
       "norm_label": "isbrowserfingerprintresult()",
@@ -58033,7 +58219,7 @@
       "source_location": "L4"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -58042,7 +58228,7 @@
       "source_location": "L20"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -58051,7 +58237,7 @@
       "source_location": "L42"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -58060,7 +58246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -58069,7 +58255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -58078,7 +58264,7 @@
       "source_location": "L36"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -58087,7 +58273,7 @@
       "source_location": "L48"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -58096,7 +58282,7 @@
       "source_location": "L64"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -58105,7 +58291,7 @@
       "source_location": "L13"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -58114,7 +58300,7 @@
       "source_location": "L46"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -58123,7 +58309,7 @@
       "source_location": "L21"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -58132,7 +58318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -58141,7 +58327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -58150,7 +58336,7 @@
       "source_location": "L8"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -58159,7 +58345,7 @@
       "source_location": "L5"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -58168,7 +58354,7 @@
       "source_location": "L20"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -58177,7 +58363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -58186,7 +58372,7 @@
       "source_location": "L11"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -58195,7 +58381,7 @@
       "source_location": "L9"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -58204,7 +58390,7 @@
       "source_location": "L25"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -58213,7 +58399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -58222,7 +58408,7 @@
       "source_location": "L50"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -58231,7 +58417,7 @@
       "source_location": "L92"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -58240,7 +58426,7 @@
       "source_location": "L74"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -58249,7 +58435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -58258,7 +58444,7 @@
       "source_location": "L62"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -58267,7 +58453,7 @@
       "source_location": "L109"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -58276,7 +58462,7 @@
       "source_location": "L177"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -58285,7 +58471,7 @@
       "source_location": "L18"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -58294,7 +58480,7 @@
       "source_location": "L52"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -58303,7 +58489,7 @@
       "source_location": "L68"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -58312,7 +58498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -58321,7 +58507,7 @@
       "source_location": "L68"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -58330,7 +58516,7 @@
       "source_location": "L26"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -58339,49 +58525,13 @@
       "source_location": "L7"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "productattribute_optionclassname",
-      "label": "optionClassName()",
-      "norm_label": "optionclassname()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L27"
     },
     {
       "community": 26,
@@ -58530,6 +58680,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "productattribute_optionclassname",
+      "label": "optionClassName()",
+      "norm_label": "optionclassname()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -58537,7 +58723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -58546,7 +58732,7 @@
       "source_location": "L43"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -58555,7 +58741,7 @@
       "source_location": "L13"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -58564,7 +58750,7 @@
       "source_location": "L88"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -58573,7 +58759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -58582,7 +58768,7 @@
       "source_location": "L111"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -58591,7 +58777,7 @@
       "source_location": "L66"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -58600,7 +58786,7 @@
       "source_location": "L127"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -58609,7 +58795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -58618,7 +58804,7 @@
       "source_location": "L25"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -58627,7 +58813,7 @@
       "source_location": "L90"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -58636,7 +58822,7 @@
       "source_location": "L82"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -58645,7 +58831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -58654,7 +58840,7 @@
       "source_location": "L115"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -58663,7 +58849,7 @@
       "source_location": "L105"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -58672,7 +58858,7 @@
       "source_location": "L110"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -58681,7 +58867,7 @@
       "source_location": "L121"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -58690,7 +58876,7 @@
       "source_location": "L26"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -58699,7 +58885,7 @@
       "source_location": "L71"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -58708,7 +58894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -58717,7 +58903,7 @@
       "source_location": "L46"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -58726,7 +58912,7 @@
       "source_location": "L24"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -58735,7 +58921,7 @@
       "source_location": "L20"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -58744,7 +58930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -58753,7 +58939,7 @@
       "source_location": "L33"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -58762,7 +58948,7 @@
       "source_location": "L6"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -58771,7 +58957,7 @@
       "source_location": "L25"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -58780,7 +58966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -58789,7 +58975,7 @@
       "source_location": "L17"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -58798,7 +58984,7 @@
       "source_location": "L11"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -58807,7 +58993,7 @@
       "source_location": "L24"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -58816,7 +59002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -58825,7 +59011,7 @@
       "source_location": "L20"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -58834,7 +59020,7 @@
       "source_location": "L65"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -58843,7 +59029,7 @@
       "source_location": "L14"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -58852,7 +59038,151 @@
       "source_location": "L1"
     },
     {
-      "community": 269,
+      "community": 27,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_expirepossessionnow",
+      "label": "expirePosSessionNow()",
+      "norm_label": "expirepossessionnow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L242"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L373"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_loadsessioncustomer",
+      "label": "loadSessionCustomer()",
+      "norm_label": "loadsessioncustomer()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L427"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L315"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L384"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_validatesessiondrawerbinding",
+      "label": "validateSessionDrawerBinding()",
+      "norm_label": "validatesessiondrawerbinding()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 270,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -58861,7 +59191,7 @@
       "source_location": "L126"
     },
     {
-      "community": 269,
+      "community": 270,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -58870,7 +59200,7 @@
       "source_location": "L130"
     },
     {
-      "community": 269,
+      "community": 270,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -58879,7 +59209,7 @@
       "source_location": "L875"
     },
     {
-      "community": 269,
+      "community": 270,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -58888,151 +59218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -59041,7 +59227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -59050,7 +59236,7 @@
       "source_location": "L8"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -59059,7 +59245,7 @@
       "source_location": "L79"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -59068,7 +59254,7 @@
       "source_location": "L61"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59077,7 +59263,7 @@
       "source_location": "L49"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -59086,7 +59272,7 @@
       "source_location": "L17"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -59095,7 +59281,7 @@
       "source_location": "L11"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -59104,7 +59290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -59113,7 +59299,7 @@
       "source_location": "L26"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -59122,7 +59308,7 @@
       "source_location": "L72"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -59131,7 +59317,7 @@
       "source_location": "L36"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -59140,7 +59326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -59149,7 +59335,7 @@
       "source_location": "L96"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -59158,7 +59344,7 @@
       "source_location": "L94"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -59167,7 +59353,7 @@
       "source_location": "L95"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -59176,7 +59362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -59185,7 +59371,7 @@
       "source_location": "L13"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -59194,7 +59380,7 @@
       "source_location": "L9"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -59203,7 +59389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -59212,7 +59398,7 @@
       "source_location": "L98"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -59221,7 +59407,7 @@
       "source_location": "L33"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -59230,7 +59416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -59239,7 +59425,7 @@
       "source_location": "L85"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -59248,7 +59434,7 @@
       "source_location": "L31"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -59257,7 +59443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -59266,7 +59452,7 @@
       "source_location": "L12"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -59275,7 +59461,7 @@
       "source_location": "L21"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -59284,7 +59470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -59293,7 +59479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -59302,7 +59488,7 @@
       "source_location": "L5"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -59311,7 +59497,151 @@
       "source_location": "L12"
     },
     {
-      "community": 279,
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -59320,7 +59650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 280,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -59329,7 +59659,7 @@
       "source_location": "L14"
     },
     {
-      "community": 279,
+      "community": 280,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -59338,151 +59668,7 @@
       "source_location": "L10"
     },
     {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror",
-      "label": "CheckoutSessionError",
-      "norm_label": "checkoutsessionerror",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_createcheckoutsession",
-      "label": "createCheckoutSession()",
-      "norm_label": "createcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_defaultcheckoutactionmessage",
-      "label": "defaultCheckoutActionMessage()",
-      "norm_label": "defaultcheckoutactionmessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_getactivecheckoutsession",
-      "label": "getActiveCheckoutSession()",
-      "norm_label": "getactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutactionerrormessage",
-      "label": "getCheckoutActionErrorMessage()",
-      "norm_label": "getcheckoutactionerrormessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "label": "getCheckoutErrorMessageFromPayload()",
-      "norm_label": "getcheckouterrormessagefrompayload()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutsession",
-      "label": "getCheckoutSession()",
-      "norm_label": "getcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_getpendingcheckoutsessions",
-      "label": "getPendingCheckoutSessions()",
-      "norm_label": "getpendingcheckoutsessions()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_parsecheckoutresponse",
-      "label": "parseCheckoutResponse()",
-      "norm_label": "parsecheckoutresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_parsejson",
-      "label": "parseJson()",
-      "norm_label": "parsejson()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_updatecheckoutsession",
-      "label": "updateCheckoutSession()",
-      "norm_label": "updatecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "checkoutsession_verifycheckoutsessionpayment",
-      "label": "verifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L274"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -59491,7 +59677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -59500,7 +59686,7 @@
       "source_location": "L6"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -59509,7 +59695,7 @@
       "source_location": "L9"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -59518,7 +59704,7 @@
       "source_location": "L43"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -59527,7 +59713,7 @@
       "source_location": "L11"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -59536,7 +59722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -59545,7 +59731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -59554,7 +59740,7 @@
       "source_location": "L23"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -59563,7 +59749,7 @@
       "source_location": "L105"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -59572,7 +59758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -59581,7 +59767,7 @@
       "source_location": "L16"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -59590,7 +59776,7 @@
       "source_location": "L92"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -59599,7 +59785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -59608,7 +59794,7 @@
       "source_location": "L21"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -59617,7 +59803,7 @@
       "source_location": "L31"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -59626,7 +59812,7 @@
       "source_location": "L7"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -59635,39 +59821,12 @@
       "source_location": "L109"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "getregisterstate_buildregisterstate",
-      "label": "buildRegisterState()",
-      "norm_label": "buildregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "getregisterstate_getregisterstate",
-      "label": "getRegisterState()",
-      "norm_label": "getregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
-      "label": "getRegisterState.ts",
-      "norm_label": "getregisterstate.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
       "source_location": "L1"
     },
     {
@@ -59754,137 +59913,146 @@
     {
       "community": 29,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "id": "checkoutsession_checkoutsessionerror",
+      "label": "CheckoutSessionError",
+      "norm_label": "checkoutsessionerror",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_checkoutsessionerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_createcheckoutsession",
+      "label": "createCheckoutSession()",
+      "norm_label": "createcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_defaultcheckoutactionmessage",
+      "label": "defaultCheckoutActionMessage()",
+      "norm_label": "defaultcheckoutactionmessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_getactivecheckoutsession",
+      "label": "getActiveCheckoutSession()",
+      "norm_label": "getactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckoutactionerrormessage",
+      "label": "getCheckoutActionErrorMessage()",
+      "norm_label": "getcheckoutactionerrormessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckouterrormessagefrompayload",
+      "label": "getCheckoutErrorMessageFromPayload()",
+      "norm_label": "getcheckouterrormessagefrompayload()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckoutsession",
+      "label": "getCheckoutSession()",
+      "norm_label": "getcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_getpendingcheckoutsessions",
+      "label": "getPendingCheckoutSessions()",
+      "norm_label": "getpendingcheckoutsessions()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_parsecheckoutresponse",
+      "label": "parseCheckoutResponse()",
+      "norm_label": "parsecheckoutresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_parsejson",
+      "label": "parseJson()",
+      "norm_label": "parsejson()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_updatecheckoutsession",
+      "label": "updateCheckoutSession()",
+      "norm_label": "updatecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "checkoutsession_verifycheckoutsessionpayment",
+      "label": "verifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L321"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_loadsessioncustomer",
-      "label": "loadSessionCustomer()",
-      "norm_label": "loadsessioncustomer()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L375"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L306"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L263"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L332"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_usererrorfromsessioncommandfailure",
-      "label": "userErrorFromSessionCommandFailure()",
-      "norm_label": "usererrorfromsessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_usererrorfromvalidationmessage",
-      "label": "userErrorFromValidationMessage()",
-      "norm_label": "usererrorfromvalidationmessage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "possessions_validatesessiondrawerbinding",
-      "label": "validateSessionDrawerBinding()",
-      "norm_label": "validatesessiondrawerbinding()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L131"
     },
     {
       "community": 290,
@@ -63390,6 +63558,33 @@
     {
       "community": 373,
       "file_type": "code",
+      "id": "actioncolorreview_stories_swatch",
+      "label": "Swatch()",
+      "norm_label": "swatch()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L179"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
+      "id": "actioncolorreview_stories_tokenscope",
+      "label": "TokenScope()",
+      "norm_label": "tokenscope()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
+      "label": "ActionColorReview.stories.tsx",
+      "norm_label": "actioncolorreview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 374,
+      "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
       "norm_label": "patterncard()",
@@ -63397,7 +63592,7 @@
       "source_location": "L127"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -63406,7 +63601,7 @@
       "source_location": "L106"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -63415,7 +63610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -63424,7 +63619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -63433,7 +63628,7 @@
       "source_location": "L49"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -63442,7 +63637,7 @@
       "source_location": "L62"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -63451,7 +63646,7 @@
       "source_location": "L66"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -63460,7 +63655,7 @@
       "source_location": "L20"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -63469,7 +63664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -63478,7 +63673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -63487,7 +63682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -63496,7 +63691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -63505,7 +63700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -63514,7 +63709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -63523,7 +63718,7 @@
       "source_location": "L16"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -63532,7 +63727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -63541,40 +63736,13 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
       "norm_label": "manualchunks()",
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L23"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "vitest_setup_pointercapturestub",
-      "label": "pointerCaptureStub()",
-      "norm_label": "pointercapturestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "vitest_setup_pointerreleasestub",
-      "label": "pointerReleaseStub()",
-      "norm_label": "pointerreleasestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L24"
     },
     {
       "community": 38,
@@ -63696,6 +63864,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
       "norm_label": "logout()",
@@ -63703,7 +63898,7 @@
       "source_location": "L32"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -63712,7 +63907,7 @@
       "source_location": "L3"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -63721,7 +63916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -63730,7 +63925,7 @@
       "source_location": "L7"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -63739,7 +63934,7 @@
       "source_location": "L5"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -63748,7 +63943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -63757,7 +63952,7 @@
       "source_location": "L6"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -63766,7 +63961,7 @@
       "source_location": "L18"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -63775,7 +63970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -63784,7 +63979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -63793,7 +63988,7 @@
       "source_location": "L60"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "postransaction_getpostransaction",
       "label": "getPosTransaction()",
@@ -63802,7 +63997,7 @@
       "source_location": "L62"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -63811,7 +64006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -63820,7 +64015,7 @@
       "source_location": "L3"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -63829,7 +64024,7 @@
       "source_location": "L5"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -63838,7 +64033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -63847,7 +64042,7 @@
       "source_location": "L18"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -63856,7 +64051,7 @@
       "source_location": "L23"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -63865,7 +64060,7 @@
       "source_location": "L22"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -63874,7 +64069,7 @@
       "source_location": "L55"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -63883,7 +64078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -63892,7 +64087,7 @@
       "source_location": "L77"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -63901,7 +64096,7 @@
       "source_location": "L11"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -63910,7 +64105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -63919,7 +64114,7 @@
       "source_location": "L11"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -63928,39 +64123,12 @@
       "source_location": "L22"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
       "norm_label": "deliverysection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -64083,6 +64251,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
       "norm_label": "loadcheckoutstate()",
@@ -64090,7 +64285,7 @@
       "source_location": "L4"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -64099,7 +64294,7 @@
       "source_location": "L24"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -64108,7 +64303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -64117,7 +64312,7 @@
       "source_location": "L131"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -64126,7 +64321,7 @@
       "source_location": "L12"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -64135,7 +64330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -64144,7 +64339,7 @@
       "source_location": "L20"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -64153,7 +64348,7 @@
       "source_location": "L46"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -64162,7 +64357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -64171,7 +64366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -64180,7 +64375,7 @@
       "source_location": "L20"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -64189,7 +64384,7 @@
       "source_location": "L59"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -64198,7 +64393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -64207,7 +64402,7 @@
       "source_location": "L25"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -64216,7 +64411,7 @@
       "source_location": "L20"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -64225,7 +64420,7 @@
       "source_location": "L30"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -64234,7 +64429,7 @@
       "source_location": "L95"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -64243,7 +64438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -64252,7 +64447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -64261,7 +64456,7 @@
       "source_location": "L150"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -64270,7 +64465,7 @@
       "source_location": "L157"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -64279,7 +64474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -64288,7 +64483,7 @@
       "source_location": "L63"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -64297,7 +64492,7 @@
       "source_location": "L48"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -64306,7 +64501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -64315,40 +64510,13 @@
       "source_location": "L63"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
     },
     {
       "community": 4,
@@ -64713,6 +64881,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
       "norm_label": "navigationbarprovider()",
@@ -64720,7 +64915,7 @@
       "source_location": "L16"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -64729,7 +64924,7 @@
       "source_location": "L39"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -64738,7 +64933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -64747,7 +64942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -64756,7 +64951,7 @@
       "source_location": "L20"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -64765,7 +64960,7 @@
       "source_location": "L55"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -64774,7 +64969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -64783,7 +64978,7 @@
       "source_location": "L107"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -64792,7 +64987,7 @@
       "source_location": "L25"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -64801,7 +64996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -64810,7 +65005,7 @@
       "source_location": "L556"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -64819,7 +65014,7 @@
       "source_location": "L52"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -64828,7 +65023,7 @@
       "source_location": "L429"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -64837,7 +65032,7 @@
       "source_location": "L102"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -64846,7 +65041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -64855,7 +65050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -64864,7 +65059,7 @@
       "source_location": "L250"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -64873,7 +65068,7 @@
       "source_location": "L46"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -64882,7 +65077,7 @@
       "source_location": "L17"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -64891,7 +65086,7 @@
       "source_location": "L63"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -64900,7 +65095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -64909,7 +65104,7 @@
       "source_location": "L47"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -64918,7 +65113,7 @@
       "source_location": "L141"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -64927,7 +65122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -64936,7 +65131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -64945,40 +65140,13 @@
       "source_location": "L21"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
       "norm_label": "verifycheckoutsessionpayment()",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "index_money",
-      "label": "money()",
-      "norm_label": "money()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "index_paymentlabel",
-      "label": "paymentLabel()",
-      "norm_label": "paymentlabel()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 41,
@@ -65091,6 +65259,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "index_money",
+      "label": "money()",
+      "norm_label": "money()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "index_paymentlabel",
+      "label": "paymentLabel()",
+      "norm_label": "paymentlabel()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
       "norm_label": "signup.tsx",
@@ -65098,7 +65293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -65107,7 +65302,7 @@
       "source_location": "L161"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -65116,7 +65311,7 @@
       "source_location": "L66"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -65125,7 +65320,7 @@
       "source_location": "L11"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -65134,7 +65329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -65143,7 +65338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -65152,7 +65347,7 @@
       "source_location": "L16"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -65161,7 +65356,7 @@
       "source_location": "L10"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -65170,7 +65365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65179,7 +65374,7 @@
       "source_location": "L17"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -65188,7 +65383,7 @@
       "source_location": "L11"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -65197,7 +65392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -65206,7 +65401,7 @@
       "source_location": "L21"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -65215,7 +65410,7 @@
       "source_location": "L15"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -65224,7 +65419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65233,7 +65428,7 @@
       "source_location": "L48"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -65242,7 +65437,7 @@
       "source_location": "L42"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -65251,7 +65446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65260,7 +65455,7 @@
       "source_location": "L16"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -65269,7 +65464,7 @@
       "source_location": "L10"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -65278,7 +65473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65287,7 +65482,7 @@
       "source_location": "L19"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -65296,7 +65491,7 @@
       "source_location": "L13"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -65305,7 +65500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65314,7 +65509,7 @@
       "source_location": "L16"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -65323,39 +65518,12 @@
       "source_location": "L10"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
       "norm_label": "harness-self-review.test.ts",
       "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "harness_test_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "harness_test_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "scripts_harness_test_test_ts",
-      "label": "harness-test.test.ts",
-      "norm_label": "harness-test.test.ts",
-      "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
     },
     {
@@ -65469,6 +65637,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "harness_test_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "harness_test_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "scripts_harness_test_test_ts",
+      "label": "harness-test.test.ts",
+      "norm_label": "harness-test.test.ts",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
       "norm_label": "log()",
@@ -65476,7 +65671,7 @@
       "source_location": "L26"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -65485,7 +65680,7 @@
       "source_location": "L18"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -65494,7 +65689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -65503,7 +65698,7 @@
       "source_location": "L45"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -65512,7 +65707,7 @@
       "source_location": "L20"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -65521,7 +65716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -65530,7 +65725,7 @@
       "source_location": "L9"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -65539,7 +65734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -65548,7 +65743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -65557,7 +65752,7 @@
       "source_location": "L12"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -65566,7 +65761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -65575,7 +65770,7 @@
       "source_location": "L8"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -65584,7 +65779,7 @@
       "source_location": "L10"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -65593,7 +65788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -65602,7 +65797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -65611,7 +65806,7 @@
       "source_location": "L18"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -65620,7 +65815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -65629,7 +65824,7 @@
       "source_location": "L10"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -65638,7 +65833,7 @@
       "source_location": "L10"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -65647,7 +65842,106 @@
       "source_location": "L1"
     },
     {
-      "community": 429,
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L282"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -65656,7 +65950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 429,
+      "community": 430,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -65665,106 +65959,7 @@
       "source_location": "L6"
     },
     {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -65773,7 +65968,7 @@
       "source_location": "L110"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -65782,7 +65977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
@@ -65791,7 +65986,7 @@
       "source_location": "L14"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -65800,7 +65995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -65809,7 +66004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -65818,7 +66013,7 @@
       "source_location": "L8"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -65827,7 +66022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -65836,7 +66031,7 @@
       "source_location": "L22"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -65845,7 +66040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -65854,7 +66049,7 @@
       "source_location": "L8"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -65863,7 +66058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -65872,7 +66067,7 @@
       "source_location": "L29"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -65881,7 +66076,7 @@
       "source_location": "L22"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -65890,7 +66085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -65899,7 +66094,7 @@
       "source_location": "L4"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -65908,7 +66103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -65917,30 +66112,12 @@
       "source_location": "L3"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
       "norm_label": "anthropic.ts",
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "openai_callopenai",
-      "label": "callOpenAi()",
-      "norm_label": "callopenai()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "label": "openai.ts",
-      "norm_label": "openai.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1"
     },
     {
@@ -66045,6 +66222,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "openai_callopenai",
+      "label": "callOpenAi()",
+      "norm_label": "callopenai()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
+      "label": "openai.ts",
+      "norm_label": "openai.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
@@ -66052,7 +66247,7 @@
       "source_location": "L6"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -66061,7 +66256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -66070,7 +66265,7 @@
       "source_location": "L3"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -66079,7 +66274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -66088,7 +66283,7 @@
       "source_location": "L19"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -66097,7 +66292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -66106,7 +66301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -66115,7 +66310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -66124,7 +66319,7 @@
       "source_location": "L9"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -66133,7 +66328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -66142,7 +66337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -66151,7 +66346,7 @@
       "source_location": "L17"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -66160,7 +66355,7 @@
       "source_location": "L63"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -66169,7 +66364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -66178,7 +66373,7 @@
       "source_location": "L35"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -66187,7 +66382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -66196,30 +66391,12 @@
       "source_location": "L30"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
       "norm_label": "gettransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "opendrawer_test_createdbgetmock",
-      "label": "createDbGetMock()",
-      "norm_label": "createdbgetmock()",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
-      "label": "openDrawer.test.ts",
-      "norm_label": "opendrawer.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
       "source_location": "L1"
     },
     {
@@ -66324,6 +66501,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "opendrawer_test_createdbgetmock",
+      "label": "createDbGetMock()",
+      "norm_label": "createdbgetmock()",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
+      "label": "openDrawer.test.ts",
+      "norm_label": "opendrawer.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
       "norm_label": "createinventoryholdgateway()",
@@ -66331,7 +66526,7 @@
       "source_location": "L31"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -66340,7 +66535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -66349,7 +66544,7 @@
       "source_location": "L6"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -66358,7 +66553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -66367,7 +66562,7 @@
       "source_location": "L60"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -66376,7 +66571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -66385,7 +66580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -66394,7 +66589,7 @@
       "source_location": "L88"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -66403,7 +66598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -66412,7 +66607,7 @@
       "source_location": "L37"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -66421,7 +66616,7 @@
       "source_location": "L9"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -66430,7 +66625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -66439,7 +66634,7 @@
       "source_location": "L4"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -66448,7 +66643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -66457,7 +66652,7 @@
       "source_location": "L15"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -66466,7 +66661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -66475,31 +66670,13 @@
       "source_location": "L7"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
       "norm_label": "access.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
-      "label": "purchaseOrders.test.ts",
-      "norm_label": "purchaseorders.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "purchaseorders_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 46,
@@ -66603,6 +66780,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
+      "label": "purchaseOrders.test.ts",
+      "norm_label": "purchaseorders.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "purchaseorders_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
       "norm_label": "vendors.test.ts",
@@ -66610,7 +66805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -66619,7 +66814,7 @@
       "source_location": "L5"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -66628,7 +66823,7 @@
       "source_location": "L15"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -66637,7 +66832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -66646,7 +66841,7 @@
       "source_location": "L8"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -66655,7 +66850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -66664,7 +66859,7 @@
       "source_location": "L17"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -66673,7 +66868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -66682,7 +66877,7 @@
       "source_location": "L6"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -66691,7 +66886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -66700,7 +66895,7 @@
       "source_location": "L5"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -66709,7 +66904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -66718,7 +66913,7 @@
       "source_location": "L25"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -66727,7 +66922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -66736,7 +66931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -66745,7 +66940,7 @@
       "source_location": "L19"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -66754,7 +66949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -66763,7 +66958,106 @@
       "source_location": "L7"
     },
     {
-      "community": 469,
+      "community": 47,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 470,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -66772,7 +67066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 469,
+      "community": 470,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -66781,106 +67075,7 @@
       "source_location": "L14"
     },
     {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getbanneranimationdelay",
-      "label": "getBannerAnimationDelay()",
-      "norm_label": "getbanneranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getbannerbgclass",
-      "label": "getBannerBGClass()",
-      "norm_label": "getbannerbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getbannertextclass",
-      "label": "getBannerTextClass()",
-      "norm_label": "getbannertextclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_gethoverclass",
-      "label": "getHoverClass()",
-      "norm_label": "gethoverclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getmainwrapperclass",
-      "label": "getMainWrapperClass()",
-      "norm_label": "getmainwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getnavbaranimationdelay",
-      "label": "getNavBarAnimationDelay()",
-      "norm_label": "getnavbaranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getnavbarwrapperclass",
-      "label": "getNavBarWrapperClass()",
-      "norm_label": "getnavbarwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getnavbgclass",
-      "label": "getNavBGClass()",
-      "norm_label": "getnavbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getoverlayclass",
-      "label": "getOverlayClass()",
-      "norm_label": "getoverlayclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "navbarstyles_getsubmenubgclass",
-      "label": "getSubmenuBGClass()",
-      "norm_label": "getsubmenubgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
-      "label": "navBarStyles.ts",
-      "norm_label": "navbarstyles.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -66889,7 +67084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -66898,7 +67093,7 @@
       "source_location": "L8"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -66907,7 +67102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -66916,7 +67111,7 @@
       "source_location": "L3"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -66925,7 +67120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -66934,7 +67129,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -66943,7 +67138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -66952,7 +67147,7 @@
       "source_location": "L16"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -66961,7 +67156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -66970,7 +67165,7 @@
       "source_location": "L30"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -66979,7 +67174,7 @@
       "source_location": "L42"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
@@ -66988,7 +67183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -66997,7 +67192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -67006,7 +67201,7 @@
       "source_location": "L42"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -67015,7 +67210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -67024,7 +67219,7 @@
       "source_location": "L31"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -67033,7 +67228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -67042,7 +67237,106 @@
       "source_location": "L5"
     },
     {
-      "community": 479,
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getbanneranimationdelay",
+      "label": "getBannerAnimationDelay()",
+      "norm_label": "getbanneranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getbannerbgclass",
+      "label": "getBannerBGClass()",
+      "norm_label": "getbannerbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getbannertextclass",
+      "label": "getBannerTextClass()",
+      "norm_label": "getbannertextclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_gethoverclass",
+      "label": "getHoverClass()",
+      "norm_label": "gethoverclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getmainwrapperclass",
+      "label": "getMainWrapperClass()",
+      "norm_label": "getmainwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbaranimationdelay",
+      "label": "getNavBarAnimationDelay()",
+      "norm_label": "getnavbaranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbarwrapperclass",
+      "label": "getNavBarWrapperClass()",
+      "norm_label": "getnavbarwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbgclass",
+      "label": "getNavBGClass()",
+      "norm_label": "getnavbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getoverlayclass",
+      "label": "getOverlayClass()",
+      "norm_label": "getoverlayclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "navbarstyles_getsubmenubgclass",
+      "label": "getSubmenuBGClass()",
+      "norm_label": "getsubmenubgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
+      "label": "navBarStyles.ts",
+      "norm_label": "navbarstyles.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -67051,7 +67345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 479,
+      "community": 480,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -67060,97 +67354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 48,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
-      "label": "resultTypes.ts",
-      "norm_label": "resulttypes.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_expenseitemsuccess",
-      "label": "expenseItemSuccess()",
-      "norm_label": "expenseitemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_expensesessionsuccess",
-      "label": "expenseSessionSuccess()",
-      "norm_label": "expensesessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_iserror",
-      "label": "isError()",
-      "norm_label": "iserror()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_issuccess",
-      "label": "isSuccess()",
-      "norm_label": "issuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_itemsuccess",
-      "label": "itemSuccess()",
-      "norm_label": "itemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_operationsuccess",
-      "label": "operationSuccess()",
-      "norm_label": "operationsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_sessionsuccess",
-      "label": "sessionSuccess()",
-      "norm_label": "sessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "resulttypes_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -67159,7 +67363,7 @@
       "source_location": "L7"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -67168,7 +67372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -67177,7 +67381,7 @@
       "source_location": "L12"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -67186,7 +67390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -67195,7 +67399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -67204,7 +67408,7 @@
       "source_location": "L11"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -67213,7 +67417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -67222,7 +67426,7 @@
       "source_location": "L11"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -67231,7 +67435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -67240,7 +67444,7 @@
       "source_location": "L3"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -67249,7 +67453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -67258,7 +67462,7 @@
       "source_location": "L12"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -67267,7 +67471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -67276,7 +67480,7 @@
       "source_location": "L42"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -67285,7 +67489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -67294,7 +67498,7 @@
       "source_location": "L13"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -67303,7 +67507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -67312,7 +67516,97 @@
       "source_location": "L42"
     },
     {
-      "community": 489,
+      "community": 49,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
+      "label": "resultTypes.ts",
+      "norm_label": "resulttypes.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_expenseitemsuccess",
+      "label": "expenseItemSuccess()",
+      "norm_label": "expenseitemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_expensesessionsuccess",
+      "label": "expenseSessionSuccess()",
+      "norm_label": "expensesessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_iserror",
+      "label": "isError()",
+      "norm_label": "iserror()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_issuccess",
+      "label": "isSuccess()",
+      "norm_label": "issuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_itemsuccess",
+      "label": "itemSuccess()",
+      "norm_label": "itemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_operationsuccess",
+      "label": "operationSuccess()",
+      "norm_label": "operationsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_sessionsuccess",
+      "label": "sessionSuccess()",
+      "norm_label": "sessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "resulttypes_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 490,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -67321,7 +67615,7 @@
       "source_location": "L31"
     },
     {
-      "community": 489,
+      "community": 490,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -67330,97 +67624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 49,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
-      "label": "sessionValidation.ts",
-      "norm_label": "sessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L303"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatecartitems",
-      "label": "validateCartItems()",
-      "norm_label": "validatecartitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatecustomerinfo",
-      "label": "validateCustomerInfo()",
-      "norm_label": "validatecustomerinfo()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validateitembelongstosession",
-      "label": "validateItemBelongsToSession()",
-      "norm_label": "validateitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatepaymentdetails",
-      "label": "validatePaymentDetails()",
-      "norm_label": "validatepaymentdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionactive",
-      "label": "validateSessionActive()",
-      "norm_label": "validatesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionexists",
-      "label": "validateSessionExists()",
-      "norm_label": "validatesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionmodifiable",
-      "label": "validateSessionModifiable()",
-      "norm_label": "validatesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionownership",
-      "label": "validateSessionOwnership()",
-      "norm_label": "validatesessionownership()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -67429,7 +67633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -67438,7 +67642,7 @@
       "source_location": "L10"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -67447,7 +67651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -67456,7 +67660,7 @@
       "source_location": "L14"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -67465,7 +67669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -67474,7 +67678,7 @@
       "source_location": "L5"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -67483,7 +67687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -67492,7 +67696,7 @@
       "source_location": "L10"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -67501,7 +67705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -67510,7 +67714,7 @@
       "source_location": "L15"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -67519,7 +67723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -67528,7 +67732,7 @@
       "source_location": "L13"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -67537,7 +67741,7 @@
       "source_location": "L118"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -67546,7 +67750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -67555,7 +67759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -67564,7 +67768,7 @@
       "source_location": "L47"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -67573,30 +67777,12 @@
       "source_location": "L151"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
       "norm_label": "activitytimeline.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "analyticsitems_analyticsitems",
-      "label": "AnalyticsItems()",
-      "norm_label": "analyticsitems()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "label": "AnalyticsItems.tsx",
-      "norm_label": "analyticsitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L1"
     },
     {
@@ -67854,95 +68040,113 @@
     {
       "community": 50,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L254"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
+      "label": "sessionValidation.ts",
+      "norm_label": "sessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L1"
     },
     {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L303"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatecartitems",
+      "label": "validateCartItems()",
+      "norm_label": "validatecartitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatecustomerinfo",
+      "label": "validateCustomerInfo()",
+      "norm_label": "validatecustomerinfo()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validateitembelongstosession",
+      "label": "validateItemBelongsToSession()",
+      "norm_label": "validateitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatepaymentdetails",
+      "label": "validatePaymentDetails()",
+      "norm_label": "validatepaymentdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionactive",
+      "label": "validateSessionActive()",
+      "norm_label": "validatesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionexists",
+      "label": "validateSessionExists()",
+      "norm_label": "validatesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionmodifiable",
+      "label": "validateSessionModifiable()",
+      "norm_label": "validatesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionownership",
+      "label": "validateSessionOwnership()",
+      "norm_label": "validatesessionownership()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L140"
+    },
+    {
       "community": 500,
+      "file_type": "code",
+      "id": "analyticsitems_analyticsitems",
+      "label": "AnalyticsItems()",
+      "norm_label": "analyticsitems()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
+      "label": "AnalyticsItems.tsx",
+      "norm_label": "analyticsitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -67951,7 +68155,7 @@
       "source_location": "L19"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -67960,7 +68164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -67969,7 +68173,7 @@
       "source_location": "L7"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -67978,7 +68182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -67987,7 +68191,7 @@
       "source_location": "L42"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -67996,7 +68200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -68005,7 +68209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -68014,7 +68218,7 @@
       "source_location": "L66"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -68023,7 +68227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -68032,7 +68236,7 @@
       "source_location": "L18"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -68041,7 +68245,7 @@
       "source_location": "L6"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -68050,7 +68254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -68059,7 +68263,7 @@
       "source_location": "L10"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -68068,7 +68272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -68077,7 +68281,7 @@
       "source_location": "L27"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -68086,7 +68290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -68095,31 +68299,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
       "norm_label": "useloadlogitems()",
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "auth_auth",
-      "label": "Auth()",
-      "norm_label": "auth()",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
     },
     {
       "community": 51,
@@ -68214,6 +68400,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "auth_auth",
+      "label": "Auth()",
+      "norm_label": "auth()",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "index_login",
       "label": "Login()",
       "norm_label": "login()",
@@ -68221,7 +68425,7 @@
       "source_location": "L5"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -68230,7 +68434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
@@ -68239,7 +68443,7 @@
       "source_location": "L24"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -68248,7 +68452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -68257,7 +68461,7 @@
       "source_location": "L49"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -68266,7 +68470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -68275,7 +68479,7 @@
       "source_location": "L23"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -68284,7 +68488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -68293,7 +68497,7 @@
       "source_location": "L50"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -68302,7 +68506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "formatreviewreason_formatreviewreason",
       "label": "formatReviewReason()",
@@ -68311,7 +68515,7 @@
       "source_location": "L3"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
       "label": "formatReviewReason.ts",
@@ -68320,7 +68524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
@@ -68329,7 +68533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -68338,7 +68542,7 @@
       "source_location": "L25"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -68347,7 +68551,7 @@
       "source_location": "L13"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -68356,7 +68560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -68365,30 +68569,12 @@
       "source_location": "L11"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
       "norm_label": "checkoutsesssionsview.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "expensecompletion_expensecompletion",
-      "label": "ExpenseCompletion()",
-      "norm_label": "expensecompletion()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1"
     },
     {
@@ -68484,6 +68670,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "expensecompletion_expensecompletion",
+      "label": "ExpenseCompletion()",
+      "norm_label": "expensecompletion()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "expenseview_expenseview",
       "label": "ExpenseView()",
       "norm_label": "expenseview()",
@@ -68491,7 +68695,7 @@
       "source_location": "L4"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
       "label": "ExpenseView.tsx",
@@ -68500,7 +68704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -68509,7 +68713,7 @@
       "source_location": "L29"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -68518,7 +68722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -68527,7 +68731,7 @@
       "source_location": "L37"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -68536,7 +68740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -68545,7 +68749,7 @@
       "source_location": "L25"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -68554,7 +68758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -68563,7 +68767,7 @@
       "source_location": "L83"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -68572,7 +68776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -68581,7 +68785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -68590,7 +68794,7 @@
       "source_location": "L35"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -68599,7 +68803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -68608,7 +68812,7 @@
       "source_location": "L28"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -68617,7 +68821,7 @@
       "source_location": "L12"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -68626,7 +68830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -68635,30 +68839,12 @@
       "source_location": "L13"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
       "norm_label": "customerdetailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "emailstatusview_handlesendorderemail",
-      "label": "handleSendOrderEmail()",
-      "norm_label": "handlesendorderemail()",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "label": "EmailStatusView.tsx",
-      "norm_label": "emailstatusview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1"
     },
     {
@@ -68754,6 +68940,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "emailstatusview_handlesendorderemail",
+      "label": "handleSendOrderEmail()",
+      "norm_label": "handlesendorderemail()",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
+      "label": "EmailStatusView.tsx",
+      "norm_label": "emailstatusview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
       "norm_label": "handletimerangechange()",
@@ -68761,7 +68965,7 @@
       "source_location": "L33"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -68770,7 +68974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -68779,7 +68983,7 @@
       "source_location": "L35"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -68788,7 +68992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -68797,7 +69001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -68806,7 +69010,7 @@
       "source_location": "L81"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -68815,7 +69019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -68824,7 +69028,7 @@
       "source_location": "L6"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -68833,7 +69037,7 @@
       "source_location": "L34"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -68842,7 +69046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -68851,7 +69055,7 @@
       "source_location": "L89"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -68860,7 +69064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -68869,7 +69073,7 @@
       "source_location": "L215"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -68878,7 +69082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -68887,7 +69091,7 @@
       "source_location": "L5"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -68896,7 +69100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -68905,31 +69109,13 @@
       "source_location": "L7"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
     },
     {
       "community": 54,
@@ -69024,6 +69210,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
       "norm_label": "pointofsaleview.tsx",
@@ -69031,7 +69235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -69040,7 +69244,7 @@
       "source_location": "L35"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -69049,7 +69253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -69058,7 +69262,7 @@
       "source_location": "L3"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -69067,7 +69271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -69076,7 +69280,7 @@
       "source_location": "L14"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -69085,7 +69289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -69094,7 +69298,7 @@
       "source_location": "L12"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -69103,7 +69307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -69112,7 +69316,7 @@
       "source_location": "L15"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -69121,7 +69325,7 @@
       "source_location": "L9"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -69130,7 +69334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -69139,7 +69343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -69148,7 +69352,7 @@
       "source_location": "L28"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -69157,7 +69361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -69166,7 +69370,7 @@
       "source_location": "L9"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -69175,31 +69379,13 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
       "norm_label": "registersessionpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
-      "label": "transactionColumns.test.tsx",
-      "norm_label": "transactioncolumns.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "transactioncolumns_test_rendertransactioncell",
-      "label": "renderTransactionCell()",
-      "norm_label": "rendertransactioncell()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L34"
     },
     {
       "community": 55,
@@ -69294,6 +69480,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
+      "label": "transactionColumns.test.tsx",
+      "norm_label": "transactioncolumns.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "transactioncolumns_test_rendertransactioncell",
+      "label": "renderTransactionCell()",
+      "norm_label": "rendertransactioncell()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
       "norm_label": "transactioncolumns.tsx",
@@ -69301,7 +69505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -69310,7 +69514,7 @@
       "source_location": "L26"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -69319,7 +69523,7 @@
       "source_location": "L14"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -69328,7 +69532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -69337,7 +69541,7 @@
       "source_location": "L6"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -69346,7 +69550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -69355,7 +69559,7 @@
       "source_location": "L37"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -69364,7 +69568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -69373,7 +69577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -69382,7 +69586,7 @@
       "source_location": "L11"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -69391,7 +69595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -69400,7 +69604,7 @@
       "source_location": "L10"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -69409,7 +69613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -69418,7 +69622,7 @@
       "source_location": "L6"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -69427,7 +69631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -69436,7 +69640,7 @@
       "source_location": "L5"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -69445,31 +69649,13 @@
       "source_location": "L17"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
       "norm_label": "add-product-command.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "products_products",
-      "label": "Products()",
-      "norm_label": "products()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L4"
     },
     {
       "community": 56,
@@ -69564,6 +69750,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "products_products",
+      "label": "Products()",
+      "norm_label": "products()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
       "norm_label": "promocodeform.tsx",
@@ -69571,7 +69775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -69580,7 +69784,7 @@
       "source_location": "L84"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -69589,7 +69793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -69598,7 +69802,7 @@
       "source_location": "L23"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -69607,7 +69811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -69616,7 +69820,7 @@
       "source_location": "L37"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -69625,7 +69829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -69634,7 +69838,7 @@
       "source_location": "L9"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -69643,7 +69847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -69652,7 +69856,7 @@
       "source_location": "L23"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -69661,7 +69865,7 @@
       "source_location": "L5"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -69670,7 +69874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -69679,7 +69883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -69688,7 +69892,7 @@
       "source_location": "L4"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -69697,7 +69901,7 @@
       "source_location": "L13"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -69706,7 +69910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -69715,31 +69919,13 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
       "norm_label": "promocodemodal()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "label": "ReviewActions.tsx",
-      "norm_label": "reviewactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "reviewactions_reviewactions",
-      "label": "ReviewActions()",
-      "norm_label": "reviewactions()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L20"
     },
     {
       "community": 57,
@@ -69834,6 +70020,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
+      "label": "ReviewActions.tsx",
+      "norm_label": "reviewactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "reviewactions_reviewactions",
+      "label": "ReviewActions()",
+      "norm_label": "reviewactions()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
       "norm_label": "servicecasesview.test.tsx",
@@ -69841,7 +70045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -69850,7 +70054,7 @@
       "source_location": "L63"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -69859,7 +70063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -69868,7 +70072,7 @@
       "source_location": "L30"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -69877,7 +70081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -69886,7 +70090,7 @@
       "source_location": "L59"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -69895,7 +70099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -69904,7 +70108,7 @@
       "source_location": "L45"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -69913,7 +70117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -69922,7 +70126,7 @@
       "source_location": "L47"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -69931,7 +70135,7 @@
       "source_location": "L29"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -69940,7 +70144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -69949,7 +70153,7 @@
       "source_location": "L3"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -69958,7 +70162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -69967,7 +70171,7 @@
       "source_location": "L4"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -69976,7 +70180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -69985,31 +70189,13 @@
       "source_location": "L4"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
       "norm_label": "notfoundview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
-      "label": "ProtectedAdminSignInView.tsx",
-      "norm_label": "protectedadminsigninview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "protectedadminsigninview_protectedadminsigninview",
-      "label": "ProtectedAdminSignInView()",
-      "norm_label": "protectedadminsigninview()",
-      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
-      "source_location": "L9"
     },
     {
       "community": 58,
@@ -70095,6 +70281,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
+      "label": "ProtectedAdminSignInView.tsx",
+      "norm_label": "protectedadminsigninview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "protectedadminsigninview_protectedadminsigninview",
+      "label": "ProtectedAdminSignInView()",
+      "norm_label": "protectedadminsigninview()",
+      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
       "norm_label": "contactview()",
@@ -70102,7 +70306,7 @@
       "source_location": "L9"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -70111,7 +70315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -70120,7 +70324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -70129,7 +70333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -70138,7 +70342,7 @@
       "source_location": "L11"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -70147,7 +70351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -70156,7 +70360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -70165,7 +70369,7 @@
       "source_location": "L25"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -70174,7 +70378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -70183,7 +70387,7 @@
       "source_location": "L21"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -70192,7 +70396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -70201,7 +70405,7 @@
       "source_location": "L63"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -70210,7 +70414,7 @@
       "source_location": "L7"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -70219,7 +70423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -70228,7 +70432,7 @@
       "source_location": "L25"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -70237,7 +70441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -70246,30 +70450,12 @@
       "source_location": "L15"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
       "norm_label": "copy-button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "copy_wrapper_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "label": "copy-wrapper.tsx",
-      "norm_label": "copy-wrapper.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1"
     },
     {
@@ -70356,6 +70542,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "copy_wrapper_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
+      "label": "copy-wrapper.tsx",
+      "norm_label": "copy-wrapper.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "label_label",
       "label": "Label()",
       "norm_label": "label()",
@@ -70363,7 +70567,7 @@
       "source_location": "L6"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -70372,7 +70576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -70381,7 +70585,7 @@
       "source_location": "L25"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -70390,7 +70594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -70399,7 +70603,7 @@
       "source_location": "L49"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -70408,7 +70612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -70417,7 +70621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -70426,7 +70630,7 @@
       "source_location": "L63"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -70435,7 +70639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -70444,7 +70648,7 @@
       "source_location": "L5"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -70453,7 +70657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -70462,7 +70666,7 @@
       "source_location": "L12"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -70471,7 +70675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -70480,7 +70684,7 @@
       "source_location": "L15"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -70489,7 +70693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -70498,7 +70702,7 @@
       "source_location": "L3"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -70507,30 +70711,12 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "bagitems_bagitems",
-      "label": "BagItems()",
-      "norm_label": "bagitems()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "label": "BagItems.tsx",
-      "norm_label": "bagitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1"
     },
     {
@@ -70851,6 +71037,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "bagitems_bagitems",
+      "label": "BagItems()",
+      "norm_label": "bagitems()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
+      "label": "BagItems.tsx",
+      "norm_label": "bagitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
       "norm_label": "bagitemsview()",
@@ -70858,7 +71062,7 @@
       "source_location": "L11"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -70867,7 +71071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -70876,7 +71080,7 @@
       "source_location": "L4"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -70885,7 +71089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -70894,7 +71098,7 @@
       "source_location": "L102"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -70903,7 +71107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -70912,7 +71116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -70921,7 +71125,7 @@
       "source_location": "L13"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -70930,7 +71134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -70939,7 +71143,7 @@
       "source_location": "L7"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -70948,7 +71152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -70957,7 +71161,7 @@
       "source_location": "L11"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -70966,7 +71170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -70975,7 +71179,7 @@
       "source_location": "L7"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -70984,7 +71188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -70993,7 +71197,7 @@
       "source_location": "L45"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -71002,31 +71206,13 @@
       "source_location": "L13"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
       "norm_label": "customerjourneystage.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "label": "use-image-upload.ts",
-      "norm_label": "use-image-upload.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "use_image_upload_useimageupload",
-      "label": "useImageUpload()",
-      "norm_label": "useimageupload()",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L7"
     },
     {
       "community": 61,
@@ -71112,6 +71298,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
+      "label": "use-image-upload.ts",
+      "norm_label": "use-image-upload.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "use_image_upload_useimageupload",
+      "label": "useImageUpload()",
+      "norm_label": "useimageupload()",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
       "norm_label": "use-mobile.tsx",
@@ -71119,7 +71323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -71128,7 +71332,7 @@
       "source_location": "L5"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -71137,7 +71341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -71146,7 +71350,7 @@
       "source_location": "L5"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -71155,7 +71359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -71164,7 +71368,7 @@
       "source_location": "L7"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -71173,7 +71377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -71182,7 +71386,7 @@
       "source_location": "L9"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -71191,7 +71395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -71200,7 +71404,7 @@
       "source_location": "L6"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -71209,7 +71413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -71218,7 +71422,7 @@
       "source_location": "L168"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -71227,7 +71431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -71236,7 +71440,7 @@
       "source_location": "L5"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -71245,7 +71449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -71254,7 +71458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -71263,7 +71467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -71272,7 +71476,88 @@
       "source_location": "L6"
     },
     {
-      "community": 619,
+      "community": 62,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_authenticatecorrectionstaff",
+      "label": "authenticateCorrectionStaff()",
+      "norm_label": "authenticatecorrectionstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectioneventtype",
+      "label": "formatCorrectionEventType()",
+      "norm_label": "formatcorrectioneventtype()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectionhistorymeta",
+      "label": "formatCorrectionHistoryMeta()",
+      "norm_label": "formatcorrectionhistorymeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectionhistorytitle",
+      "label": "formatCorrectionHistoryTitle()",
+      "norm_label": "formatcorrectionhistorytitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_gettransactioncorrectionhistory",
+      "label": "getTransactionCorrectionHistory()",
+      "norm_label": "gettransactioncorrectionhistory()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_requestcorrectionsubmit",
+      "label": "requestCorrectionSubmit()",
+      "norm_label": "requestcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L331"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_runcustomercorrection",
+      "label": "runCustomerCorrection()",
+      "norm_label": "runcustomercorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L254"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "transactionview_runpaymentmethodcorrection",
+      "label": "runPaymentMethodCorrection()",
+      "norm_label": "runpaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L291"
+    },
+    {
+      "community": 620,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -71281,7 +71566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 619,
+      "community": 620,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -71290,88 +71575,7 @@
       "source_location": "L12"
     },
     {
-      "community": 62,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
-      "label": "ServiceCatalogView.tsx",
-      "norm_label": "servicecatalogview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L187"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_handleedit",
-      "label": "handleEdit()",
-      "norm_label": "handleedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_handlereset",
-      "label": "handleReset()",
-      "norm_label": "handlereset()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L209"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_itemtoformstate",
-      "label": "itemToFormState()",
-      "norm_label": "itemtoformstate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_parseservicecatalogform",
-      "label": "parseServiceCatalogForm()",
-      "norm_label": "parseservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_validateservicecatalogform",
-      "label": "validateServiceCatalogForm()",
-      "norm_label": "validateservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "servicecatalogview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L499"
-    },
-    {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -71380,7 +71584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -71389,7 +71593,7 @@
       "source_location": "L24"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -71398,7 +71602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -71407,7 +71611,7 @@
       "source_location": "L6"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -71416,7 +71620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -71425,7 +71629,7 @@
       "source_location": "L4"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -71434,7 +71638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -71443,7 +71647,7 @@
       "source_location": "L5"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -71452,7 +71656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -71461,7 +71665,7 @@
       "source_location": "L5"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -71470,7 +71674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -71479,7 +71683,7 @@
       "source_location": "L4"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -71488,7 +71692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -71497,7 +71701,7 @@
       "source_location": "L5"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -71506,7 +71710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -71515,7 +71719,7 @@
       "source_location": "L5"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -71524,7 +71728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -71533,7 +71737,88 @@
       "source_location": "L8"
     },
     {
-      "community": 629,
+      "community": 63,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
+      "label": "ServiceCatalogView.tsx",
+      "norm_label": "servicecatalogview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L187"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_handleedit",
+      "label": "handleEdit()",
+      "norm_label": "handleedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_handlereset",
+      "label": "handleReset()",
+      "norm_label": "handlereset()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L209"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_itemtoformstate",
+      "label": "itemToFormState()",
+      "norm_label": "itemtoformstate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_parseservicecatalogform",
+      "label": "parseServiceCatalogForm()",
+      "norm_label": "parseservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_validateservicecatalogform",
+      "label": "validateServiceCatalogForm()",
+      "norm_label": "validateservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "servicecatalogview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L499"
+    },
+    {
+      "community": 630,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -71542,7 +71827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 629,
+      "community": 630,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -71551,88 +71836,7 @@
       "source_location": "L13"
     },
     {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "label": "handleDeliveryRestrictionToggle()",
-      "norm_label": "handledeliveryrestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "label": "handlePickupRestrictionToggle()",
-      "norm_label": "handlepickuprestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "label": "handleSaveDeliveryRestriction()",
-      "norm_label": "handlesavedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_handlesavepickuprestriction",
-      "label": "handleSavePickupRestriction()",
-      "norm_label": "handlesavepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_savedeliveryrestriction",
-      "label": "saveDeliveryRestriction()",
-      "norm_label": "savedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_saveenabledeliverychanges",
-      "label": "saveEnableDeliveryChanges()",
-      "norm_label": "saveenabledeliverychanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_saveenablestorepickupchanges",
-      "label": "saveEnableStorePickupChanges()",
-      "norm_label": "saveenablestorepickupchanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "fulfillmentview_savepickuprestriction",
-      "label": "savePickupRestriction()",
-      "norm_label": "savepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
-      "label": "FulfillmentView.tsx",
-      "norm_label": "fulfillmentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -71641,7 +71845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -71650,7 +71854,7 @@
       "source_location": "L3"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -71659,7 +71863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -71668,7 +71872,7 @@
       "source_location": "L27"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -71677,7 +71881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -71686,7 +71890,7 @@
       "source_location": "L7"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -71695,7 +71899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -71704,7 +71908,7 @@
       "source_location": "L5"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -71713,7 +71917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -71722,7 +71926,7 @@
       "source_location": "L12"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -71731,7 +71935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -71740,7 +71944,7 @@
       "source_location": "L12"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -71749,7 +71953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -71758,16 +71962,16 @@
       "source_location": "L5"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
       "norm_label": "tooperatormessage()",
       "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
-      "source_location": "L44"
+      "source_location": "L48"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -71776,7 +71980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -71785,7 +71989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -71794,7 +71998,88 @@
       "source_location": "L6"
     },
     {
-      "community": 639,
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
+      "label": "handleDeliveryRestrictionToggle()",
+      "norm_label": "handledeliveryrestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_handlepickuprestrictiontoggle",
+      "label": "handlePickupRestrictionToggle()",
+      "norm_label": "handlepickuprestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_handlesavedeliveryrestriction",
+      "label": "handleSaveDeliveryRestriction()",
+      "norm_label": "handlesavedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_handlesavepickuprestriction",
+      "label": "handleSavePickupRestriction()",
+      "norm_label": "handlesavepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_savedeliveryrestriction",
+      "label": "saveDeliveryRestriction()",
+      "norm_label": "savedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_saveenabledeliverychanges",
+      "label": "saveEnableDeliveryChanges()",
+      "norm_label": "saveenabledeliverychanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_saveenablestorepickupchanges",
+      "label": "saveEnableStorePickupChanges()",
+      "norm_label": "saveenablestorepickupchanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "fulfillmentview_savepickuprestriction",
+      "label": "savePickupRestriction()",
+      "norm_label": "savepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
+      "label": "FulfillmentView.tsx",
+      "norm_label": "fulfillmentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -71803,7 +72088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 639,
+      "community": 640,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -71812,88 +72097,7 @@
       "source_location": "L7"
     },
     {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger",
-      "label": "Logger",
-      "norm_label": "logger",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_debug",
-      "label": ".debug()",
-      "norm_label": ".debug()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_error",
-      "label": ".error()",
-      "norm_label": ".error()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_formatmessage",
-      "label": ".formatMessage()",
-      "norm_label": ".formatmessage()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_info",
-      "label": ".info()",
-      "norm_label": ".info()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_shouldlog",
-      "label": ".shouldLog()",
-      "norm_label": ".shouldlog()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "logger_logger_warn",
-      "label": ".warn()",
-      "norm_label": ".warn()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_logger_ts",
-      "label": "logger.ts",
-      "norm_label": "logger.ts",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -71902,7 +72106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -71911,7 +72115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -71920,7 +72124,7 @@
       "source_location": "L5"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -71929,7 +72133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -71938,7 +72142,7 @@
       "source_location": "L6"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -71947,7 +72151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -71956,7 +72160,7 @@
       "source_location": "L5"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -71965,7 +72169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -71974,7 +72178,7 @@
       "source_location": "L5"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -71983,7 +72187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -71992,7 +72196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -72001,7 +72205,7 @@
       "source_location": "L5"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -72010,7 +72214,7 @@
       "source_location": "L10"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -72019,7 +72223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -72028,16 +72232,16 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "useregisterviewmodel_test_deferred",
       "label": "deferred()",
       "norm_label": "deferred()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L176"
+      "source_location": "L182"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -72046,7 +72250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -72055,7 +72259,88 @@
       "source_location": "L12"
     },
     {
-      "community": 649,
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger",
+      "label": "Logger",
+      "norm_label": "logger",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_debug",
+      "label": ".debug()",
+      "norm_label": ".debug()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_error",
+      "label": ".error()",
+      "norm_label": ".error()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_formatmessage",
+      "label": ".formatMessage()",
+      "norm_label": ".formatmessage()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_info",
+      "label": ".info()",
+      "norm_label": ".info()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_shouldlog",
+      "label": ".shouldLog()",
+      "norm_label": ".shouldlog()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "logger_logger_warn",
+      "label": ".warn()",
+      "norm_label": ".warn()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_logger_ts",
+      "label": "logger.ts",
+      "norm_label": "logger.ts",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -72064,7 +72349,7 @@
       "source_location": "L6"
     },
     {
-      "community": 649,
+      "community": 650,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -72073,88 +72358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L277"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L357"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L336"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L259"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L212"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -72163,7 +72367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -72172,7 +72376,7 @@
       "source_location": "L6"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -72181,7 +72385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -72190,7 +72394,7 @@
       "source_location": "L6"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -72199,7 +72403,7 @@
       "source_location": "L13"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -72208,7 +72412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -72217,7 +72421,7 @@
       "source_location": "L6"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -72226,7 +72430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -72235,7 +72439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -72244,7 +72448,7 @@
       "source_location": "L9"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -72253,7 +72457,7 @@
       "source_location": "L13"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -72262,7 +72466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -72271,7 +72475,7 @@
       "source_location": "L4"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -72280,7 +72484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -72289,7 +72493,7 @@
       "source_location": "L13"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -72298,7 +72502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -72307,7 +72511,7 @@
       "source_location": "L5"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -72316,7 +72520,88 @@
       "source_location": "L1"
     },
     {
-      "community": 659,
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L277"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L357"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L208"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L336"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L259"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L212"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -72325,7 +72610,7 @@
       "source_location": "L17"
     },
     {
-      "community": 659,
+      "community": 660,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -72334,79 +72619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 66,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_getr2",
-      "label": "getR2()",
-      "norm_label": "getr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_readenvvalue",
-      "label": "readEnvValue()",
-      "norm_label": "readenvvalue()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_resolver2configfromenv",
-      "label": "resolveR2ConfigFromEnv()",
-      "norm_label": "resolver2configfromenv()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -72415,7 +72628,7 @@
       "source_location": "L15"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -72424,7 +72637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -72433,7 +72646,7 @@
       "source_location": "L12"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -72442,7 +72655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -72451,7 +72664,7 @@
       "source_location": "L5"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -72460,7 +72673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -72469,7 +72682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -72478,7 +72691,7 @@
       "source_location": "L13"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -72487,7 +72700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -72496,7 +72709,7 @@
       "source_location": "L14"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -72505,7 +72718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -72514,7 +72727,7 @@
       "source_location": "L13"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -72523,7 +72736,7 @@
       "source_location": "L5"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -72532,7 +72745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -72541,7 +72754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -72550,7 +72763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -72559,7 +72772,7 @@
       "source_location": "L4"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -72568,7 +72781,79 @@
       "source_location": "L1"
     },
     {
-      "community": 669,
+      "community": 67,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_getr2",
+      "label": "getR2()",
+      "norm_label": "getr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_readenvvalue",
+      "label": "readEnvValue()",
+      "norm_label": "readenvvalue()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_resolver2configfromenv",
+      "label": "resolveR2ConfigFromEnv()",
+      "norm_label": "resolver2configfromenv()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 670,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -72577,7 +72862,7 @@
       "source_location": "L27"
     },
     {
-      "community": 669,
+      "community": 670,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -72586,79 +72871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_findathenauserbyemailwithctx",
-      "label": "findAthenaUserByEmailWithCtx()",
-      "norm_label": "findathenauserbyemailwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_getauthenticatedathenauserwithctx",
-      "label": "getAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "getauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_getauthenticateduserrecord",
-      "label": "getAuthenticatedUserRecord()",
-      "norm_label": "getauthenticateduserrecord()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_normalizeemail",
-      "label": "normalizeEmail()",
-      "norm_label": "normalizeemail()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
-      "label": "requireAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "requireauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_requireorganizationmemberrolewithctx",
-      "label": "requireOrganizationMemberRoleWithCtx()",
-      "norm_label": "requireorganizationmemberrolewithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
-      "label": "syncAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "syncauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
-      "label": "athenaUserAuth.ts",
-      "norm_label": "athenauserauth.ts",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -72667,7 +72880,7 @@
       "source_location": "L4"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -72676,7 +72889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -72685,7 +72898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -72694,7 +72907,7 @@
       "source_location": "L5"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -72703,7 +72916,7 @@
       "source_location": "L10"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -72712,7 +72925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -72721,7 +72934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -72730,7 +72943,7 @@
       "source_location": "L10"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -72739,7 +72952,7 @@
       "source_location": "L4"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -72748,7 +72961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -72757,7 +72970,7 @@
       "source_location": "L39"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -72766,7 +72979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -72775,7 +72988,7 @@
       "source_location": "L18"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -72784,7 +72997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -72793,7 +73006,7 @@
       "source_location": "L71"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -72802,7 +73015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -72811,7 +73024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -72820,7 +73033,79 @@
       "source_location": "L12"
     },
     {
-      "community": 679,
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_findathenauserbyemailwithctx",
+      "label": "findAthenaUserByEmailWithCtx()",
+      "norm_label": "findathenauserbyemailwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_getauthenticatedathenauserwithctx",
+      "label": "getAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "getauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_getauthenticateduserrecord",
+      "label": "getAuthenticatedUserRecord()",
+      "norm_label": "getauthenticateduserrecord()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_normalizeemail",
+      "label": "normalizeEmail()",
+      "norm_label": "normalizeemail()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
+      "label": "requireAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "requireauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_requireorganizationmemberrolewithctx",
+      "label": "requireOrganizationMemberRoleWithCtx()",
+      "norm_label": "requireorganizationmemberrolewithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
+      "label": "syncAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "syncauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
+      "label": "athenaUserAuth.ts",
+      "norm_label": "athenauserauth.ts",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -72829,7 +73114,7 @@
       "source_location": "L6"
     },
     {
-      "community": 679,
+      "community": 680,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -72838,79 +73123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -72919,7 +73132,7 @@
       "source_location": "L18"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -72928,7 +73141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -72937,7 +73150,7 @@
       "source_location": "L10"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -72946,7 +73159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -72955,7 +73168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -72964,7 +73177,7 @@
       "source_location": "L8"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -72973,7 +73186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -72982,7 +73195,7 @@
       "source_location": "L27"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -72991,7 +73204,7 @@
       "source_location": "L40"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -73000,7 +73213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -73009,7 +73222,7 @@
       "source_location": "L3"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -73018,7 +73231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -73027,7 +73240,7 @@
       "source_location": "L8"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -73036,7 +73249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -73045,7 +73258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -73054,7 +73267,7 @@
       "source_location": "L12"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -73063,7 +73276,7 @@
       "source_location": "L77"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -73072,7 +73285,79 @@
       "source_location": "L1"
     },
     {
-      "community": 689,
+      "community": 69,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -73081,7 +73366,7 @@
       "source_location": "L161"
     },
     {
-      "community": 689,
+      "community": 690,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -73090,79 +73375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -73171,7 +73384,7 @@
       "source_location": "L3"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -73180,7 +73393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -73189,7 +73402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -73198,7 +73411,7 @@
       "source_location": "L4"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -73207,7 +73420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -73216,7 +73429,7 @@
       "source_location": "L14"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -73225,7 +73438,7 @@
       "source_location": "L27"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -73234,7 +73447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -73243,7 +73456,7 @@
       "source_location": "L17"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -73252,7 +73465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -73261,7 +73474,7 @@
       "source_location": "L13"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -73270,7 +73483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -73279,7 +73492,7 @@
       "source_location": "L47"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -73288,7 +73501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -73297,7 +73510,7 @@
       "source_location": "L7"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -73306,7 +73519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -73315,31 +73528,13 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
       "norm_label": "sitebanner()",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
     },
     {
       "community": 7,
@@ -73569,77 +73764,95 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
-      "community": 70,
+      "community": 700,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
     },
     {
       "community": 700,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -73648,7 +73861,7 @@
       "source_location": "L12"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -73657,7 +73870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -73666,7 +73879,7 @@
       "source_location": "L7"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -73675,7 +73888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -73684,7 +73897,7 @@
       "source_location": "L45"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -73693,7 +73906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -73702,7 +73915,7 @@
       "source_location": "L5"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -73711,7 +73924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -73720,7 +73933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -73729,7 +73942,7 @@
       "source_location": "L17"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -73738,7 +73951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -73747,7 +73960,7 @@
       "source_location": "L3"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -73756,7 +73969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -73765,7 +73978,7 @@
       "source_location": "L37"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -73774,7 +73987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -73783,7 +73996,7 @@
       "source_location": "L79"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -73792,7 +74005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -73801,7 +74014,79 @@
       "source_location": "L87"
     },
     {
-      "community": 709,
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 710,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -73810,7 +74095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 709,
+      "community": 710,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -73819,79 +74104,7 @@
       "source_location": "L8"
     },
     {
-      "community": 71,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
-    },
-    {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -73900,7 +74113,7 @@
       "source_location": "L12"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -73909,7 +74122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -73918,7 +74131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -73927,7 +74140,7 @@
       "source_location": "L18"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -73936,7 +74149,7 @@
       "source_location": "L10"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -73945,7 +74158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -73954,7 +74167,7 @@
       "source_location": "L11"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -73963,7 +74176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -73972,7 +74185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -73981,7 +74194,7 @@
       "source_location": "L59"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -73990,7 +74203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -73999,7 +74212,7 @@
       "source_location": "L33"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -74008,7 +74221,7 @@
       "source_location": "L19"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -74017,7 +74230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -74026,7 +74239,7 @@
       "source_location": "L4"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -74035,7 +74248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -74044,7 +74257,7 @@
       "source_location": "L22"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -74053,7 +74266,79 @@
       "source_location": "L1"
     },
     {
-      "community": 719,
+      "community": 72,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 720,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -74062,7 +74347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 719,
+      "community": 720,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -74071,79 +74356,7 @@
       "source_location": "L11"
     },
     {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -74152,7 +74365,7 @@
       "source_location": "L3"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -74161,7 +74374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -74170,7 +74383,7 @@
       "source_location": "L3"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -74179,7 +74392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -74188,7 +74401,7 @@
       "source_location": "L9"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -74197,7 +74410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -74206,7 +74419,7 @@
       "source_location": "L66"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -74215,7 +74428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -74224,7 +74437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -74233,7 +74446,7 @@
       "source_location": "L19"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -74242,7 +74455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -74251,7 +74464,7 @@
       "source_location": "L13"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -74260,7 +74473,7 @@
       "source_location": "L46"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -74269,7 +74482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -74278,7 +74491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -74287,7 +74500,7 @@
       "source_location": "L46"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -74296,7 +74509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -74305,7 +74518,79 @@
       "source_location": "L1"
     },
     {
-      "community": 729,
+      "community": 73,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 730,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -74314,7 +74599,7 @@
       "source_location": "L15"
     },
     {
-      "community": 729,
+      "community": 730,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -74323,79 +74608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -74404,7 +74617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -74413,7 +74626,7 @@
       "source_location": "L5"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -74422,7 +74635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -74431,7 +74644,7 @@
       "source_location": "L14"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -74440,7 +74653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -74449,7 +74662,7 @@
       "source_location": "L29"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -74458,7 +74671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -74467,7 +74680,7 @@
       "source_location": "L5"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -74476,7 +74689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -74485,7 +74698,7 @@
       "source_location": "L5"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -74494,7 +74707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -74503,7 +74716,7 @@
       "source_location": "L3"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -74512,7 +74725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -74521,7 +74734,7 @@
       "source_location": "L4"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -74530,7 +74743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -74539,7 +74752,7 @@
       "source_location": "L4"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -74548,7 +74761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -74557,7 +74770,79 @@
       "source_location": "L9"
     },
     {
-      "community": 739,
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -74566,7 +74851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 739,
+      "community": 740,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -74575,79 +74860,7 @@
       "source_location": "L17"
     },
     {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2348"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2342"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2338"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2358"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2104"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2194"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2086"
-    },
-    {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -74656,7 +74869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -74665,7 +74878,7 @@
       "source_location": "L5"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -74674,7 +74887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -74683,7 +74896,7 @@
       "source_location": "L15"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -74692,7 +74905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -74701,7 +74914,7 @@
       "source_location": "L18"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -74710,7 +74923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -74719,7 +74932,7 @@
       "source_location": "L9"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -74728,7 +74941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -74737,7 +74950,7 @@
       "source_location": "L16"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -74746,7 +74959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -74755,7 +74968,7 @@
       "source_location": "L4"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -74764,7 +74977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -74773,7 +74986,7 @@
       "source_location": "L11"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -74782,7 +74995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -74791,7 +75004,7 @@
       "source_location": "L3"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -74800,7 +75013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -74809,7 +75022,79 @@
       "source_location": "L7"
     },
     {
-      "community": 749,
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2348"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2342"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2338"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2358"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2104"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2194"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2086"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -74818,7 +75103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 750,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -74827,79 +75112,7 @@
       "source_location": "L4"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_buildpendingskucontextbyid",
-      "label": "buildPendingSkuContextById()",
-      "norm_label": "buildpendingskucontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_getstatusrank",
-      "label": "getStatusRank()",
-      "norm_label": "getstatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -74908,7 +75121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -74917,7 +75130,7 @@
       "source_location": "L14"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -74926,7 +75139,7 @@
       "source_location": "L4"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -74935,7 +75148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -74944,7 +75157,7 @@
       "source_location": "L7"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -74953,7 +75166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -74962,7 +75175,7 @@
       "source_location": "L6"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -74971,7 +75184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -74980,7 +75193,7 @@
       "source_location": "L10"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -74989,7 +75202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -74998,7 +75211,7 @@
       "source_location": "L6"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -75007,7 +75220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -75016,7 +75229,7 @@
       "source_location": "L5"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -75025,7 +75238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -75034,7 +75247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -75043,7 +75256,7 @@
       "source_location": "L5"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -75052,7 +75265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -75061,7 +75274,79 @@
       "source_location": "L14"
     },
     {
-      "community": 759,
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_buildpendingskucontextbyid",
+      "label": "buildPendingSkuContextById()",
+      "norm_label": "buildpendingskucontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_getstatusrank",
+      "label": "getStatusRank()",
+      "norm_label": "getstatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -75070,7 +75355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 760,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -75079,79 +75364,7 @@
       "source_location": "L9"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "data_table_row_actions_datatablerowactions",
-      "label": "DataTableRowActions()",
-      "norm_label": "datatablerowactions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -75160,7 +75373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -75169,7 +75382,7 @@
       "source_location": "L10"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -75178,7 +75391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -75187,7 +75400,7 @@
       "source_location": "L11"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -75196,7 +75409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -75205,7 +75418,7 @@
       "source_location": "L6"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -75214,7 +75427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -75223,7 +75436,7 @@
       "source_location": "L5"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -75232,7 +75445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -75241,7 +75454,7 @@
       "source_location": "L6"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -75250,7 +75463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -75259,7 +75472,7 @@
       "source_location": "L10"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -75268,7 +75481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -75277,7 +75490,7 @@
       "source_location": "L15"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -75286,7 +75499,7 @@
       "source_location": "L14"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -75295,7 +75508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -75304,7 +75517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -75313,7 +75526,79 @@
       "source_location": "L6"
     },
     {
-      "community": 769,
+      "community": 77,
+      "file_type": "code",
+      "id": "data_table_row_actions_datatablerowactions",
+      "label": "DataTableRowActions()",
+      "norm_label": "datatablerowactions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -75322,7 +75607,7 @@
       "source_location": "L13"
     },
     {
-      "community": 769,
+      "community": 770,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -75331,79 +75616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
-      "label": "RegisterSessionsView.tsx",
-      "norm_label": "registersessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_formatsessioncode",
-      "label": "formatSessionCode()",
-      "norm_label": "formatsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_getstaffname",
-      "label": "getStaffName()",
-      "norm_label": "getstaffname()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "registersessionsview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -75412,7 +75625,7 @@
       "source_location": "L8"
     },
     {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -75421,7 +75634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -75430,7 +75643,7 @@
       "source_location": "L14"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -75439,7 +75652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -75448,7 +75661,7 @@
       "source_location": "L13"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -75457,7 +75670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -75466,7 +75679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -75475,7 +75688,7 @@
       "source_location": "L9"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -75484,7 +75697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -75493,7 +75706,7 @@
       "source_location": "L15"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -75502,7 +75715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -75511,7 +75724,7 @@
       "source_location": "L16"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -75520,7 +75733,7 @@
       "source_location": "L6"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -75529,7 +75742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -75538,7 +75751,7 @@
       "source_location": "L10"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -75547,7 +75760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -75556,7 +75769,7 @@
       "source_location": "L21"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -75565,7 +75778,79 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
+      "label": "RegisterSessionsView.tsx",
+      "norm_label": "registersessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_formatsessioncode",
+      "label": "formatSessionCode()",
+      "norm_label": "formatsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_getstaffname",
+      "label": "getStaffName()",
+      "norm_label": "getstaffname()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "registersessionsview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -75574,7 +75859,7 @@
       "source_location": "L33"
     },
     {
-      "community": 779,
+      "community": 780,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -75583,79 +75868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_clearcustomer",
-      "label": "clearCustomer()",
-      "norm_label": "clearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L172"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_handlecreatecustomer",
-      "label": "handleCreateCustomer()",
-      "norm_label": "handlecreatecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L130"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "customerinfopanel_showcommanderror",
-      "label": "showCommandError()",
-      "norm_label": "showcommanderror()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
-      "label": "CustomerInfoPanel.tsx",
-      "norm_label": "customerinfopanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -75664,7 +75877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -75673,7 +75886,7 @@
       "source_location": "L193"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -75682,7 +75895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -75691,7 +75904,7 @@
       "source_location": "L7"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -75700,7 +75913,7 @@
       "source_location": "L10"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -75709,7 +75922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -75718,7 +75931,7 @@
       "source_location": "L32"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -75727,7 +75940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -75736,7 +75949,7 @@
       "source_location": "L211"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -75745,7 +75958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -75754,7 +75967,7 @@
       "source_location": "L85"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -75763,7 +75976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -75772,7 +75985,7 @@
       "source_location": "L15"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -75781,7 +75994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -75790,7 +76003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -75799,7 +76012,79 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_clearcustomer",
+      "label": "clearCustomer()",
+      "norm_label": "clearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L172"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecreatecustomer",
+      "label": "handleCreateCustomer()",
+      "norm_label": "handlecreatecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L130"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "customerinfopanel_showcommanderror",
+      "label": "showCommandError()",
+      "norm_label": "showcommanderror()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "label": "CustomerInfoPanel.tsx",
+      "norm_label": "customerinfopanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -75808,79 +76093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L313"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L56"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L244"
-    },
-    {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -75889,7 +76102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -75898,7 +76111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -75907,7 +76120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -75916,7 +76129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -75925,7 +76138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -75934,7 +76147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -75943,7 +76156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -75952,21 +76165,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
       "source_file": "packages/athena-webapp/convex/constants/email.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
       "source_location": "L1"
     },
     {
@@ -76012,7 +76216,7 @@
       "label": "errorMessage()",
       "norm_label": "errormessage()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1779"
+      "source_location": "L1793"
     },
     {
       "community": 8,
@@ -76170,77 +76374,86 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_authenticatecorrectionstaff",
-      "label": "authenticateCorrectionStaff()",
-      "norm_label": "authenticatecorrectionstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L193"
+      "id": "paymentsaddedlist_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L313"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_formatcorrectioneventtype",
-      "label": "formatCorrectionEventType()",
-      "norm_label": "formatcorrectioneventtype()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L55"
+      "id": "paymentsaddedlist_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L45"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_getrelativetime",
-      "label": "getRelativeTime()",
-      "norm_label": "getrelativetime()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L661"
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L56"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_gettransactioncorrectionhistory",
-      "label": "getTransactionCorrectionHistory()",
-      "norm_label": "gettransactioncorrectionhistory()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L61"
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L135"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_requestcorrectionsubmit",
-      "label": "requestCorrectionSubmit()",
-      "norm_label": "requestcorrectionsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L292"
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L102"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_runcustomercorrection",
-      "label": "runCustomerCorrection()",
-      "norm_label": "runcustomercorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L217"
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L95"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "transactionview_runpaymentmethodcorrection",
-      "label": "runPaymentMethodCorrection()",
-      "norm_label": "runpaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L253"
+      "id": "paymentsaddedlist_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L244"
     },
     {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -76249,7 +76462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -76258,7 +76471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -76267,7 +76480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -76276,7 +76489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -76285,7 +76498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -76294,7 +76507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -76303,7 +76516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -76312,21 +76525,12 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -76404,6 +76608,15 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
@@ -76411,7 +76624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -76420,7 +76633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -76429,7 +76642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -76438,7 +76651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -76447,7 +76660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -76456,7 +76669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -76465,7 +76678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -76474,21 +76687,12 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
       "source_location": "L1"
     },
     {
@@ -76566,6 +76770,15 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
       "norm_label": "me.ts",
@@ -76573,7 +76786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -76582,7 +76795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -76591,7 +76804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -76600,7 +76813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -76609,7 +76822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -76618,7 +76831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -76627,7 +76840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -76636,21 +76849,12 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
       "norm_label": "security.test.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
       "source_location": "L1"
     },
     {
@@ -76728,6 +76932,15 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
@@ -76735,7 +76948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -76744,7 +76957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -76753,7 +76966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -76762,7 +76975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -76771,7 +76984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -76780,7 +76993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -76789,7 +77002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -76798,21 +77011,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1"
     },
     {
@@ -76890,6 +77094,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -76897,7 +77110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
@@ -76906,7 +77119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -76915,7 +77128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -76924,7 +77137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -76933,7 +77146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -76942,7 +77155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -76951,7 +77164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -76960,21 +77173,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
       "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productsku_ts",
-      "label": "productSku.ts",
-      "norm_label": "productsku.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1"
     },
     {
@@ -77052,6 +77256,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productsku_ts",
+      "label": "productSku.ts",
+      "norm_label": "productsku.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
       "norm_label": "productutil.test.ts",
@@ -77059,7 +77272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -77068,7 +77281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -77077,7 +77290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -77086,7 +77299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -77095,7 +77308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -77104,7 +77317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -77113,7 +77326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -77122,21 +77335,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
       "norm_label": "migrateamountstopesewas.ts",
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_test_ts",
-      "label": "client.test.ts",
-      "norm_label": "client.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1"
     },
     {
@@ -77214,6 +77418,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_client_test_ts",
+      "label": "client.test.ts",
+      "norm_label": "client.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
@@ -77221,7 +77434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -77230,7 +77443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -77239,7 +77452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -77248,7 +77461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -77257,7 +77470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -77266,7 +77479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -77275,7 +77488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -77284,21 +77497,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
       "norm_label": "correcttransactionpaymentmethod.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
-      "label": "correctionEvents.test.ts",
-      "norm_label": "correctionevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -77367,6 +77571,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
+      "label": "correctionEvents.test.ts",
+      "norm_label": "correctionevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
       "norm_label": "correctionpolicy.test.ts",
@@ -77374,7 +77587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -77383,7 +77596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -77392,7 +77605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -77401,7 +77614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -77410,7 +77623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -77419,7 +77632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -77428,7 +77641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -77437,21 +77650,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
-      "label": "customers.ts",
-      "norm_label": "customers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
       "source_location": "L1"
     },
     {
@@ -77520,6 +77724,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
+      "label": "customers.ts",
+      "norm_label": "customers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -77527,7 +77740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -77536,7 +77749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -77545,7 +77758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -77554,7 +77767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -77563,7 +77776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -77572,7 +77785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -77581,7 +77794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -77590,21 +77803,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1"
     },
     {
@@ -77673,6 +77877,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
@@ -77680,7 +77893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -77689,7 +77902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -77698,7 +77911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -77707,7 +77920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -77716,7 +77929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -77725,7 +77938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -77734,7 +77947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -77743,21 +77956,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -78024,6 +78228,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -78031,7 +78244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -78040,7 +78253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -78049,7 +78262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -78058,7 +78271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -78067,7 +78280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -78076,7 +78289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -78085,7 +78298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -78094,21 +78307,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
       "norm_label": "operationalevent.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
-      "label": "operationalWorkItem.ts",
-      "norm_label": "operationalworkitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
       "source_location": "L1"
     },
     {
@@ -78177,6 +78381,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
+      "label": "operationalWorkItem.ts",
+      "norm_label": "operationalworkitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
       "norm_label": "paymentallocation.ts",
@@ -78184,7 +78397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -78193,7 +78406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -78202,7 +78415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -78211,7 +78424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -78220,7 +78433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -78229,7 +78442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -78238,7 +78451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -78247,21 +78460,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
       "norm_label": "expensesessionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
-      "label": "expenseTransaction.ts",
-      "norm_label": "expensetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -78330,6 +78534,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
+      "label": "expenseTransaction.ts",
+      "norm_label": "expensetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
       "norm_label": "expensetransactionitem.ts",
@@ -78337,7 +78550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -78346,7 +78559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -78355,7 +78568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -78364,7 +78577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -78373,7 +78586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -78382,7 +78595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -78391,7 +78604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -78400,21 +78613,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
       "norm_label": "serviceappointment.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
-      "label": "serviceCase.ts",
-      "norm_label": "servicecase.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
       "source_location": "L1"
     },
     {
@@ -78483,6 +78687,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
+      "label": "serviceCase.ts",
+      "norm_label": "servicecase.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
       "norm_label": "servicecaselineitem.ts",
@@ -78490,7 +78703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -78499,7 +78712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -78508,7 +78721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -78517,7 +78730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -78526,7 +78739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -78535,7 +78748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -78544,7 +78757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -78553,21 +78766,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
       "norm_label": "vendor.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -78636,6 +78840,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
@@ -78643,7 +78856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -78652,7 +78865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -78661,7 +78874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -78670,7 +78883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -78679,7 +78892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -78688,7 +78901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -78697,7 +78910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -78706,21 +78919,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "label": "review.ts",
-      "norm_label": "review.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
       "source_location": "L1"
     },
     {
@@ -78789,6 +78993,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
+      "label": "review.ts",
+      "norm_label": "review.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -78796,7 +79009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -78805,7 +79018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -78814,7 +79027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -78823,7 +79036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -78832,7 +79045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -78841,7 +79054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -78850,7 +79063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -78859,21 +79072,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -78942,6 +79146,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
@@ -78949,7 +79162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -78958,7 +79171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -78967,7 +79180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -78976,7 +79189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -78985,7 +79198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -78994,7 +79207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -79003,7 +79216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -79012,21 +79225,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
       "norm_label": "users.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_types_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/types/payment.ts",
       "source_location": "L1"
     },
     {
@@ -79095,6 +79299,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_types_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/types/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
@@ -79102,7 +79315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -79111,7 +79324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -79120,7 +79333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -79129,7 +79342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -79138,7 +79351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -79147,7 +79360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -79156,7 +79369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -79165,21 +79378,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
       "norm_label": "currencyformatter.test.ts",
       "source_file": "packages/athena-webapp/shared/currencyFormatter.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
-      "label": "registerSessionStatus.test.ts",
-      "norm_label": "registersessionstatus.test.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
       "source_location": "L1"
     },
     {
@@ -79248,6 +79452,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
+      "label": "registerSessionStatus.test.ts",
+      "norm_label": "registersessionstatus.test.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
       "label": "staffDisplayName.test.ts",
       "norm_label": "staffdisplayname.test.ts",
@@ -79255,7 +79468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -79264,7 +79477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -79273,7 +79486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -79282,7 +79495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -79291,7 +79504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -79300,7 +79513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -79309,7 +79522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -79318,21 +79531,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -79401,6 +79605,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -79408,7 +79621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -79417,7 +79630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -79426,7 +79639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -79435,7 +79648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -79444,7 +79657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -79453,7 +79666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -79462,7 +79675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -79471,21 +79684,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1532
-- Graph nodes: 4026
-- Graph edges: 3604
-- Communities: 1460
+- Code files discovered: 1533
+- Graph nodes: 4034
+- Graph edges: 3615
+- Communities: 1461
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 9) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 28) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 29) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 9) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 266) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 267) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
@@ -27,6 +27,7 @@ vi.mock("../pos/application/commands/posSessionTracing", () => ({
 
 import {
   completeSession,
+  expireAllSessionsForStaff,
   releaseSessionInventoryHoldsAndDeleteItems,
   releasePosSessionItems,
   syncSessionCheckoutState,
@@ -84,6 +85,7 @@ type RegisterSessionRecord = {
 type QueryBuilderFilters = {
   status?: string;
   expiresBefore?: number;
+  staffProfileId?: string;
   sessionId?: string;
 };
 
@@ -156,6 +158,9 @@ function createMutationCtx(seed?: {
             if (field === "status") {
               filters.status = String(value);
             }
+            if (field === "staffProfileId") {
+              filters.staffProfileId = String(value);
+            }
             if (field === "sessionId") {
               filters.sessionId = String(value);
             }
@@ -206,6 +211,21 @@ function createMutationCtx(seed?: {
 
         if (tableName === "posSessionItem" && indexName === "by_sessionId") {
           const page = items.filter((item) => item.sessionId === filters.sessionId);
+
+          return {
+            take: async () => page,
+          };
+        }
+
+        if (
+          tableName === "posSession" &&
+          indexName === "by_staffProfileId_and_status"
+        ) {
+          const page = sessions.filter(
+            (session) =>
+              session.staffProfileId === filters.staffProfileId &&
+              session.status === filters.status,
+          );
 
           return {
             take: async () => page,
@@ -1585,5 +1605,107 @@ describe("pos session lifecycle trace handlers", () => {
       notes: "Session expired - inventory holds released",
     });
     expect(mocks.traceRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("expires other-terminal sessions immediately during cashier recovery", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-current",
+          terminalId: "terminal-1",
+          status: "active",
+        }),
+        buildSession({
+          _id: "session-other-active",
+          sessionNumber: "SES-OTHER-ACTIVE",
+          terminalId: "terminal-2",
+          status: "active",
+        }),
+        buildSession({
+          _id: "session-other-held",
+          sessionNumber: "SES-OTHER-HELD",
+          terminalId: "terminal-3",
+          status: "held",
+        }),
+      ],
+      items: [
+        {
+          _id: "item-current",
+          sessionId: "session-current",
+          productSkuId: "sku-current",
+          quantity: 1,
+        },
+        {
+          _id: "item-other-active",
+          sessionId: "session-other-active",
+          productSkuId: "sku-active",
+          quantity: 3,
+        },
+        {
+          _id: "item-other-held",
+          sessionId: "session-other-held",
+          productSkuId: "sku-held",
+          quantity: 2,
+        },
+      ],
+    });
+
+    const result = await getHandler(expireAllSessionsForStaff)(ctx as never, {
+      staffProfileId: "cashier-1",
+      terminalId: "terminal-1",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { staffProfileId: "cashier-1" },
+    });
+    expect(ctx.sessions.find((session) => session._id === "session-current")).toEqual(
+      expect.objectContaining({
+        status: "active",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(
+      ctx.sessions.find((session) => session._id === "session-other-active"),
+    ).toEqual(
+      expect.objectContaining({
+        status: "expired",
+        notes: "Session expired - inventory holds released",
+      }),
+    );
+    expect(
+      ctx.sessions.find((session) => session._id === "session-other-held"),
+    ).toEqual(
+      expect.objectContaining({
+        status: "expired",
+        notes: "Session expired - inventory holds released",
+      }),
+    );
+    expect(mocks.releaseInventoryHoldsBatch.mock.calls).toEqual(
+      expect.arrayContaining([
+        [ctx.db, [{ skuId: "sku-active", quantity: 3 }]],
+        [ctx.db, [{ skuId: "sku-held", quantity: 2 }]],
+      ]),
+    );
+    expect(mocks.releaseInventoryHoldsBatch).toHaveBeenCalledTimes(2);
+    expect(mocks.traceRecord).toHaveBeenCalledTimes(2);
+    expect(mocks.traceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "expired",
+        session: expect.objectContaining({
+          _id: "session-other-active",
+          status: "expired",
+        }),
+      }),
+    );
+    expect(mocks.traceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "expired",
+        session: expect.objectContaining({
+          _id: "session-other-held",
+          status: "expired",
+        }),
+      }),
+    );
   });
 });

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -239,6 +239,58 @@ async function listPosSessionsForStoreStatus(
   return sessions;
 }
 
+async function expirePosSessionNow(
+  ctx: MutationCtx,
+  session: Awaited<ReturnType<typeof listPosSessionsByStatusBefore>>[number],
+  now: number,
+) {
+  const items = await ctx.db
+    .query("posSessionItem")
+    .withIndex("by_sessionId", (q) => q.eq("sessionId", session._id))
+    .take(MAX_SESSION_ITEMS);
+
+  const heldQuantities = new Map<Id<"productSku">, number>();
+  for (const item of items) {
+    const currentQty = heldQuantities.get(item.productSkuId) || 0;
+    heldQuantities.set(item.productSkuId, currentQty + item.quantity);
+  }
+
+  const releaseItems = Array.from(heldQuantities.entries()).map(
+    ([skuId, quantity]) => ({
+      skuId,
+      quantity,
+    }),
+  );
+
+  await releaseInventoryHoldsBatch(ctx.db, releaseItems);
+
+  const wasVoided = session.status === "void";
+  const expirationNote = wasVoided
+    ? session.notes
+    : "Session expired - inventory holds released";
+
+  await ctx.db.patch("posSession", session._id, {
+    status: "expired",
+    expiresAt: now,
+    updatedAt: now,
+    notes: expirationNote,
+  });
+
+  if (!wasVoided) {
+    await recordSessionLifecycleTraceBestEffort(ctx, {
+      stage: "expired",
+      session: {
+        ...session,
+        status: "expired",
+        expiresAt: now,
+        updatedAt: now,
+        notes: expirationNote,
+      },
+      occurredAt: now,
+    });
+  }
+}
+
 async function persistSessionWorkflowTraceIdBestEffort(
   ctx: MutationCtx,
   args: {
@@ -1184,59 +1236,7 @@ export const releasePosSessionItems = internalMutation({
     // Process each expired session
     for (const session of expiredSessions) {
       try {
-        // Query all items for this session from posSessionItem table
-        const items = await ctx.db
-          .query("posSessionItem")
-          .withIndex("by_sessionId", (q) => q.eq("sessionId", session._id))
-          .take(MAX_SESSION_ITEMS);
-
-        // Calculate total quantities held per SKU
-        const heldQuantities = new Map<Id<"productSku">, number>();
-        for (const item of items) {
-          const currentQty = heldQuantities.get(item.productSkuId) || 0;
-          heldQuantities.set(item.productSkuId, currentQty + item.quantity);
-        }
-
-        // Use batch helper to release all inventory holds
-        const releaseItems = Array.from(heldQuantities.entries()).map(
-          ([skuId, quantity]) => ({
-            skuId,
-            quantity,
-          }),
-        );
-
-        await releaseInventoryHoldsBatch(ctx.db, releaseItems);
-        console.log(
-          `[POS] Released inventory holds for ${releaseItems.length} SKUs`,
-        );
-
-        // Keep items for record-keeping - don't delete them
-        // Items remain associated with expired session for audit trail
-        const wasVoided = session.status === "void";
-        const expirationNote = wasVoided
-          ? session.notes
-          : "Session expired - inventory holds released";
-
-        // Mark session as expired
-        await ctx.db.patch("posSession", session._id, {
-          status: "expired",
-          updatedAt: now,
-          notes: expirationNote,
-        });
-
-        if (!wasVoided) {
-          await recordSessionLifecycleTraceBestEffort(ctx, {
-            stage: "expired",
-            session: {
-              ...session,
-              status: "expired",
-              updatedAt: now,
-              notes: expirationNote,
-            },
-            occurredAt: now,
-          });
-        }
-
+        await expirePosSessionNow(ctx, session, now);
         releasedSessionIds.push(session._id);
         console.log(
           `[POS] Released inventory holds for session ${session.sessionNumber}`,
@@ -1316,9 +1316,7 @@ export const expireAllSessionsForStaff = mutation({
     await Promise.all(
       sessions
         .filter((session) => session.terminalId !== args.terminalId)
-        .map((session) =>
-          ctx.db.patch("posSession", session._id, { expiresAt: now }),
-        ),
+        .map((session) => expirePosSessionNow(ctx, session, now)),
     );
 
     return {

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -663,6 +663,23 @@ describe("staff credential operations", () => {
     await expect(
       authenticateStaffCredentialForTerminalWithCtx(ctx, {
         allowedRoles: ["cashier"],
+        allowActiveSessionsOnOtherTerminals: true,
+        pinHash: "hash-1",
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        username: "frontdesk",
+      })
+    ).resolves.toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        staffProfileId: "staff_profile_1",
+        activeRoles: ["cashier"],
+      }),
+    });
+
+    await expect(
+      authenticateStaffCredentialForTerminalWithCtx(ctx, {
+        allowedRoles: ["cashier"],
         pinHash: "hash-1",
         storeId: "store_1" as Id<"store">,
         terminalId: "terminal-2" as Id<"posTerminal">,

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -497,6 +497,7 @@ export async function authenticateStaffCredentialForTerminalWithCtx(
   ctx: Pick<MutationCtx, "db">,
   args: {
     allowedRoles?: OperationalRole[];
+    allowActiveSessionsOnOtherTerminals?: boolean;
     pinHash: string;
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;
@@ -506,6 +507,10 @@ export async function authenticateStaffCredentialForTerminalWithCtx(
   const authentication = await authenticateStaffCredentialWithCtx(ctx, args);
 
   if (authentication.kind === "user_error") {
+    return authentication;
+  }
+
+  if (args.allowActiveSessionsOnOtherTerminals) {
     return authentication;
   }
 
@@ -679,6 +684,7 @@ export const authenticateStaffCredential = mutation({
 export const authenticateStaffCredentialForTerminal = mutation({
   args: {
     allowedRoles: v.optional(v.array(operationalRoleValidator)),
+    allowActiveSessionsOnOtherTerminals: v.optional(v.boolean()),
     pinHash: v.string(),
     storeId: v.id("store"),
     terminalId: v.id("posTerminal"),

--- a/packages/athena-webapp/convex/pos/application/dto.ts
+++ b/packages/athena-webapp/convex/pos/application/dto.ts
@@ -1,5 +1,6 @@
 import type { Id } from "../../_generated/dataModel";
 import type {
+  PosActiveSessionConflict,
   PosCashDrawerSummary,
   PosCashierSummary,
   PosRegisterSessionSummary,
@@ -20,5 +21,6 @@ export interface RegisterStateDto {
   cashier: PosCashierSummary | null;
   activeRegisterSession: PosCashDrawerSummary | null;
   activeSession: PosRegisterSessionSummary | null;
+  activeSessionConflict: PosActiveSessionConflict | null;
   resumableSession: PosRegisterSessionSummary | null;
 }

--- a/packages/athena-webapp/convex/pos/application/getRegisterState.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getRegisterState.test.ts
@@ -79,6 +79,28 @@ describe("buildRegisterState", () => {
     expect(result.phase).toBe("readyToStart");
   });
 
+  it("carries active-session terminal conflicts alongside ready state", () => {
+    const result = buildRegisterState({
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "cashier-1", firstName: "Ama", lastName: "K" },
+      activeRegisterSession: null,
+      activeSession: null,
+      activeSessionConflict: {
+        kind: "activeOnOtherTerminal",
+        message: "A session is active for this cashier on a different terminal",
+        terminalId: "terminal-2",
+      },
+      heldSessions: [],
+    });
+
+    expect(result.phase).toBe("readyToStart");
+    expect(result.activeSessionConflict).toEqual({
+      kind: "activeOnOtherTerminal",
+      message: "A session is active for this cashier on a different terminal",
+      terminalId: "terminal-2",
+    });
+  });
+
   it("keeps the visible drawer in readyToStart state", () => {
     const result = buildRegisterState({
       terminal: { _id: "terminal-1", displayName: "Front Counter" },

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -340,7 +340,16 @@ describe("getTransactionById", () => {
     ]);
     const ctx = {
       db: {
-        get: vi.fn().mockResolvedValue(null),
+        get: vi.fn((table, id) => {
+          if (table === "staffProfile" && id === "staff-1") {
+            return Promise.resolve({
+              _id: "staff-1",
+              fullName: "Ama Mensah",
+            });
+          }
+
+          return Promise.resolve(null);
+        }),
         query: vi.fn(() => ({
           withIndex: vi.fn((_indexName, callback) => {
             callback({
@@ -366,6 +375,7 @@ describe("getTransactionById", () => {
           expect.objectContaining({
             _id: "event-1",
             eventType: "pos_transaction_payment_method_corrected",
+            actorStaffName: "Ama M.",
             metadata: { paymentMethod: "card" },
           }),
         ],

--- a/packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts
@@ -1,7 +1,11 @@
 import type { QueryCtx } from "../../../_generated/server";
+import type { Id } from "../../../_generated/dataModel";
 
 import type { GetRegisterStateArgs, RegisterStateDto } from "../dto";
-import type { PosRegisterStateInput } from "../../domain/types";
+import type {
+  PosActiveSessionConflict,
+  PosRegisterStateInput,
+} from "../../domain/types";
 import {
   deriveRegisterPhase,
   selectResumableSession,
@@ -30,7 +34,46 @@ export function buildRegisterState(
     cashier: input.cashier,
     activeRegisterSession: input.activeRegisterSession,
     activeSession: input.activeSession,
+    activeSessionConflict: input.activeSessionConflict ?? null,
     resumableSession,
+  };
+}
+
+async function getActiveSessionConflictForRegisterState(
+  ctx: QueryCtx,
+  identity: {
+    storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
+    staffProfileId?: Id<"staffProfile">;
+  },
+): Promise<PosActiveSessionConflict | null> {
+  if (!identity.terminalId || !identity.staffProfileId) {
+    return null;
+  }
+
+  const now = Date.now();
+  const activeSessions = await ctx.db
+    .query("posSession")
+    .withIndex("by_storeId_status_staffProfileId", (q) =>
+      q
+        .eq("storeId", identity.storeId)
+        .eq("status", "active")
+        .eq("staffProfileId", identity.staffProfileId!),
+    )
+    .take(20);
+  const conflictingSession = activeSessions.find(
+    (session) =>
+      session.terminalId !== identity.terminalId && session.expiresAt > now,
+  );
+
+  if (!conflictingSession) {
+    return null;
+  }
+
+  return {
+    kind: "activeOnOtherTerminal",
+    message: "A session is active for this cashier on a different terminal",
+    terminalId: conflictingSession.terminalId,
   };
 }
 
@@ -45,20 +88,28 @@ export async function getRegisterState(
     registerNumber: args.registerNumber,
   };
 
-  const [terminal, cashier, activeRegisterSession, activeSession, heldSessions] =
-    await Promise.all([
+  const [
+    terminal,
+    cashier,
+    activeRegisterSession,
+    activeSession,
+    activeSessionConflict,
+    heldSessions,
+  ] = await Promise.all([
     getTerminalForRegisterState(ctx, identity),
     getCashierForRegisterState(ctx, identity),
     getActiveRegisterSessionForRegisterState(ctx, identity),
     getActiveSessionForRegisterState(ctx, identity),
+    getActiveSessionConflictForRegisterState(ctx, identity),
     listHeldSessionsForRegisterState(ctx, identity),
-    ]);
+  ]);
 
   return buildRegisterState({
     terminal,
     cashier,
     activeRegisterSession,
     activeSession,
+    activeSessionConflict,
     heldSessions,
   });
 }

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -71,6 +71,23 @@ async function loadCorrectionEvents(
     .collect();
 }
 
+async function listStaffNames(
+  ctx: QueryCtx,
+  staffProfileIds: Set<Id<"staffProfile">>,
+) {
+  const staffEntries = await Promise.all(
+    Array.from(staffProfileIds).map(async (staffProfileId) => {
+      const staffProfile = await ctx.db.get("staffProfile", staffProfileId);
+      const staffName = formatStaffDisplayName(staffProfile);
+      return staffName ? [staffProfileId, staffName] : null;
+    }),
+  );
+
+  return new Map(
+    staffEntries.filter(Boolean) as Array<[Id<"staffProfile">, string]>,
+  );
+}
+
 export async function getTransaction(
   ctx: QueryCtx,
   args: {
@@ -179,6 +196,14 @@ export async function getTransactionById(
     storeId: transaction.storeId,
     transactionId: transaction._id,
   });
+  const actorStaffNamesById = await listStaffNames(
+    ctx,
+    new Set(
+      correctionHistory.flatMap((event) =>
+        event.actorStaffProfileId ? [event.actorStaffProfileId] : [],
+      ),
+    ),
+  );
 
   return {
     _id: transaction._id,
@@ -233,6 +258,9 @@ export async function getTransactionById(
       createdAt: event.createdAt,
       actorUserId: event.actorUserId,
       actorStaffProfileId: event.actorStaffProfileId,
+      actorStaffName: event.actorStaffProfileId
+        ? actorStaffNamesById.get(event.actorStaffProfileId) ?? null
+        : null,
     })),
     items: items.map((item) => ({
       _id: item._id,

--- a/packages/athena-webapp/convex/pos/domain/types.ts
+++ b/packages/athena-webapp/convex/pos/domain/types.ts
@@ -43,6 +43,12 @@ export interface PosRegisterSessionSummary {
   workflowTraceId?: string;
 }
 
+export interface PosActiveSessionConflict {
+  kind: "activeOnOtherTerminal";
+  message: string;
+  terminalId?: string;
+}
+
 export interface PosCashDrawerSummary {
   _id: Id<"registerSession">;
   status: "open" | "active" | "closing" | "closed";
@@ -67,5 +73,6 @@ export interface PosRegisterStateInput {
   cashier: PosCashierSummary | null;
   activeRegisterSession: PosCashDrawerSummary | null;
   activeSession: PosRegisterSessionSummary | null;
+  activeSessionConflict?: PosActiveSessionConflict | null;
   heldSessions: PosRegisterSessionSummary[];
 }

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -191,6 +191,7 @@ export const getTransactionById = query({
           createdAt: v.number(),
           actorUserId: v.optional(v.id("athenaUser")),
           actorStaffProfileId: v.optional(v.id("staffProfile")),
+          actorStaffName: v.union(v.string(), v.null()),
         }),
       ),
       items: v.array(

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -492,6 +492,10 @@ describe("RegisterSessionViewContent", () => {
     await user.click(
       screen.getByRole("button", { name: "Correct opening float" }),
     );
+    expect(
+      screen.getByRole("button", { name: "Correct opening float" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     await user.clear(screen.getByLabelText("Corrected opening float"));
     await user.type(screen.getByLabelText("Corrected opening float"), "60");
     await user.type(
@@ -499,7 +503,7 @@ describe("RegisterSessionViewContent", () => {
       "Opening cash was recounted.",
     );
     expect(screen.getByText("$10")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Submit correction" }));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     await user.click(
       screen.getByRole("button", {
         name: "Confirm staff for Correct opening float",
@@ -522,6 +526,49 @@ describe("RegisterSessionViewContent", () => {
     expect(await screen.findByRole("status")).toHaveTextContent(
       "Opening float corrected.",
     );
+  });
+
+  it("exits the opening float correction workflow without submitting", async () => {
+    const user = userEvent.setup();
+    const onCorrectOpeningFloat = vi.fn();
+
+    render(
+      <RegisterSessionViewContent
+        actorUserId="user-1"
+        currency="USD"
+        isLoading={false}
+        onAuthenticateStaff={vi.fn()}
+        onCorrectOpeningFloat={onCorrectOpeningFloat}
+        onRecordDeposit={vi.fn()}
+        onReviewCloseout={vi.fn()}
+        onSubmitCloseout={vi.fn()}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            status: "active",
+          },
+        }}
+        storeId="store-1"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Correct opening float" }),
+    );
+    await user.type(
+      screen.getByLabelText("Opening float correction reason"),
+      "Wrong till count.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Correct opening float" }),
+    ).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByLabelText("Opening float correction reason"),
+    ).not.toBeInTheDocument();
+    expect(onCorrectOpeningFloat).not.toHaveBeenCalled();
   });
 
   it("does not offer opening float correction once closeout has started", () => {
@@ -585,7 +632,7 @@ describe("RegisterSessionViewContent", () => {
       screen.getByLabelText("Opening float correction reason"),
       "Correction from counted opening cash.",
     );
-    await user.click(screen.getByRole("button", { name: "Submit correction" }));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     await user.click(
       screen.getByRole("button", {
         name: "Confirm staff for Correct opening float",

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -927,6 +927,7 @@ export function RegisterSessionViewContent({
                         {canCorrectOpeningFloat ? (
                           <Button
                             className="w-full"
+                            disabled={isOpeningFloatCorrectionOpen}
                             onClick={() => {
                               setIsOpeningFloatCorrectionOpen(
                                 (value) => !value,
@@ -1128,16 +1129,29 @@ export function RegisterSessionViewContent({
                             </p>
                           ) : null}
 
-                          <LoadingButton
-                            disabled={isCorrectingOpeningFloat}
-                            isLoading={isCorrectingOpeningFloat}
-                            onClick={() =>
-                              void handleSubmitOpeningFloatCorrection()
-                            }
-                            type="button"
-                          >
-                            Submit correction
-                          </LoadingButton>
+                          <div className="flex flex-wrap items-center gap-3">
+                            <LoadingButton
+                              disabled={isCorrectingOpeningFloat}
+                              isLoading={isCorrectingOpeningFloat}
+                              onClick={() =>
+                                void handleSubmitOpeningFloatCorrection()
+                              }
+                              type="button"
+                            >
+                              Submit
+                            </LoadingButton>
+                            <Button
+                              disabled={isCorrectingOpeningFloat}
+                              onClick={() => {
+                                setIsOpeningFloatCorrectionOpen(false);
+                                setOpeningFloatCorrectionError("");
+                              }}
+                              type="button"
+                              variant="outline"
+                            >
+                              Cancel
+                            </Button>
+                          </div>
                         </div>
                       ) : null}
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.test.tsx
@@ -81,7 +81,9 @@ describe("RegisterSessionsViewContent", () => {
     );
 
     expect(screen.getByText("Register sessions")).toBeInTheDocument();
-    expect(screen.getByText("Open, closing, and closed drawers.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Open, closing, and closed drawers."),
+    ).toBeInTheDocument();
     expect(screen.getByText("2 sessions")).toBeInTheDocument();
     expect(screen.getByText("Register 3")).toBeInTheDocument();
     expect(screen.getByText("Register 2")).toBeInTheDocument();
@@ -91,8 +93,12 @@ describe("RegisterSessionsViewContent", () => {
     expect(screen.getByText("Ato K.")).toBeInTheDocument();
     expect(screen.getByText("GH₵9,690")).toBeInTheDocument();
     expect(screen.getByText("GH₵-200")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(screen.queryByText("Not closed")).not.toBeInTheDocument();
     expect(screen.getByText(expectedClosedAt)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Register 3 ACTIVE/i })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: /Register 3 ACTIVE/i }),
+    ).toHaveAttribute(
       "href",
       "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId?o=%252F",
     );

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx
@@ -94,7 +94,7 @@ export function RegisterSessionsViewContent({
         _id: session._id,
         closedAtLabel: session.closedAt
           ? formatTimestamp(session.closedAt)
-          : "Not closed",
+          : "-",
         countedCashLabel: formatCurrency(currency, session.countedCash),
         depositedLabel: formatCurrency(currency, session.totalDeposited),
         expectedCashLabel: formatCurrency(currency, session.expectedCash),

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -286,6 +286,16 @@ describe("CashierAuthDialog", () => {
     );
 
     await waitFor(() =>
+      expect(authenticateMutation).toHaveBeenCalledWith({
+        allowedRoles: ["cashier", "manager"],
+        allowActiveSessionsOnOtherTerminals: true,
+        pinHash: "hashed:123456",
+        storeId,
+        terminalId,
+        username: "frontdesk",
+      }),
+    );
+    await waitFor(() =>
       expect(expireMutation).toHaveBeenCalledWith({
         staffProfileId,
         terminalId,

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -55,6 +55,7 @@ export function CashierAuthDialog({
     const authenticationResult = await runCommand(() =>
       authenticateStaffCredentialForTerminal({
         allowedRoles: ["cashier", "manager"],
+        allowActiveSessionsOnOtherTerminals: args.mode === "recover",
         pinHash: args.pinHash,
         storeId,
         terminalId,
@@ -93,7 +94,7 @@ export function CashierAuthDialog({
         description: "Enter username and PIN before recording expenses.",
       }
     : {
-        title: "Register sign-in required",
+        title: "Sign in required",
         description: "Enter username and PIN before adding items.",
       };
   const recoveryLabel = isExpenseWorkflow
@@ -130,7 +131,9 @@ export function CashierAuthDialog({
         }
 
         const staffDisplayName = getStaffDisplayName(result);
-        return staffDisplayName ? `Signed in as ${staffDisplayName}.` : "Signed in.";
+        return staffDisplayName
+          ? `Signed in as ${staffDisplayName}.`
+          : "Signed in.";
       }}
       onAuthenticated={(result) => {
         onAuthenticated(result.staffProfileId);

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -91,18 +91,28 @@ vi.mock("./RegisterActionBar", () => ({
   }: {
     closeoutControl?: {
       canCloseout: boolean;
+      canCorrectOpeningFloat: boolean;
       onRequestCloseout: () => void;
+      onRequestOpeningFloatCorrection: () => void;
     } | null;
   }) => (
     <div>
       register-action-bar
       {closeoutControl ? (
-        <button
-          disabled={!closeoutControl.canCloseout}
-          onClick={closeoutControl.onRequestCloseout}
-        >
-          closeout-control
-        </button>
+        <>
+          <button
+            disabled={!closeoutControl.canCorrectOpeningFloat}
+            onClick={closeoutControl.onRequestOpeningFloatCorrection}
+          >
+            float-control
+          </button>
+          <button
+            disabled={!closeoutControl.canCloseout}
+            onClick={closeoutControl.onRequestCloseout}
+          >
+            closeout-control
+          </button>
+        </>
       ) : null}
     </div>
   ),
@@ -181,7 +191,9 @@ describe("POSRegisterView", () => {
       cashierCard: {},
       closeoutControl: {
         canCloseout: true,
+        canCorrectOpeningFloat: true,
         onRequestCloseout: vi.fn(),
+        onRequestOpeningFloatCorrection: vi.fn(),
       },
       authDialog: {
         open: false,
@@ -304,8 +316,12 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-customer-panel")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-customer-panel"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Drawer closed")).not.toBeInTheDocument();
   });
 
@@ -351,7 +367,9 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
   });
 
@@ -404,7 +422,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
     expect(screen.getByText("Cashier")).toBeInTheDocument();
     expect(screen.getByText("Unassigned")).toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the register shell around expense authentication", async () => {
@@ -456,7 +476,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
     expect(screen.getByText("Cashier")).toBeInTheDocument();
     expect(screen.getByText("Unassigned")).toBeInTheDocument();
-    expect(screen.queryByText("Ready for expense entry")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ready for expense entry"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps POS workflow behavior when expense completion data is present but mode is not set to expense", async () => {
@@ -502,7 +524,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.getByText("cart-items")).toBeInTheDocument();
-    expect(screen.queryByText("expense-completion-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("expense-completion-panel"),
+    ).not.toBeInTheDocument();
   });
 
   it("returns to product entry when a paid sale starts a new product search", async () => {
@@ -618,7 +642,9 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("Drawer closed")).toBeInTheDocument();
-    expect(screen.getByText("Open drawer to start selling")).toBeInTheDocument();
+    expect(
+      screen.getByText("Open drawer to start selling"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "Front Counter is closed. Enter the opening float before starting sales.",
@@ -696,10 +722,7 @@ describe("POSRegisterView", () => {
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
-    ).toHaveAttribute(
-      "href",
-      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls",
-    );
+    ).toHaveAttribute("href", "/$orgUrlSlug/store/$storeUrlSlug/cash-controls");
 
     await userEvent.click(screen.getByRole("button", { name: /sign out/i }));
 

--- a/packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, LockKeyhole } from "lucide-react";
+import { ArrowRightIcon, BanknoteIcon, LockKeyhole } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import type {
@@ -40,16 +40,28 @@ export function RegisterActionBar({
           hasTerminal={registerInfo.hasTerminal}
         />
         {closeoutControl ? (
-          <Button
-            className="h-10"
-            disabled={!closeoutControl.canCloseout}
-            onClick={closeoutControl.onRequestCloseout}
-            type="button"
-            variant="outline"
-          >
-            <LockKeyhole className="mr-2 h-4 w-4" />
-            Closeout
-          </Button>
+          <>
+            <Button
+              className="h-10"
+              disabled={!closeoutControl.canCorrectOpeningFloat}
+              onClick={closeoutControl.onRequestOpeningFloatCorrection}
+              type="button"
+              variant="outline"
+            >
+              <BanknoteIcon className="mr-2 h-4 w-4" />
+              Float
+            </Button>
+            <Button
+              className="h-10"
+              disabled={!closeoutControl.canCloseout}
+              onClick={closeoutControl.onRequestCloseout}
+              type="button"
+              variant="outline"
+            >
+              <LockKeyhole className="mr-2 h-4 w-4" />
+              Closeout
+            </Button>
+          </>
         ) : null}
         {!registerInfo.hasTerminal && (
           <Link

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -71,8 +71,117 @@ export function RegisterDrawerGate({
     event.preventDefault();
     void drawerGate.onSubmitCloseout?.();
   };
+  const handleOpeningFloatCorrectionSubmit = (
+    event: FormEvent<HTMLFormElement>,
+  ) => {
+    event.preventDefault();
+    void drawerGate.onSubmitOpeningFloatCorrection?.();
+  };
   const isCloseoutBlocked = drawerGate.mode === "closeoutBlocked";
+  const isOpeningFloatCorrection = drawerGate.mode === "openingFloatCorrection";
   const isRecovery = drawerGate.mode === "recovery";
+
+  if (isOpeningFloatCorrection) {
+    const currency = drawerGate.currency ?? "GHS";
+
+    return (
+      <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-stone-900">
+            Correct opening float
+          </h2>
+          <p className="text-sm text-stone-600">
+            Update the starting cash for register {drawerGate.registerNumber}.
+            This adjusts expected cash and records an audit event.
+          </p>
+        </div>
+
+        <form
+          className="mt-8 space-y-5"
+          onSubmit={handleOpeningFloatCorrectionSubmit}
+        >
+          <div className="rounded-lg border border-stone-200 bg-stone-50/70 p-4">
+            <dl className="grid grid-cols-2 gap-3 text-sm">
+              <div className="space-y-1">
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  Current float
+                </dt>
+                <dd className="font-mono text-stone-900">
+                  {formatCurrency(currency, drawerGate.currentOpeningFloat)}
+                </dd>
+              </div>
+              <div className="space-y-1">
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  Expected cash
+                </dt>
+                <dd className="font-mono text-stone-900">
+                  {formatCurrency(currency, drawerGate.expectedCash)}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-stone-700">
+              Corrected opening float ({currencyDisplaySymbol(currency)})
+            </span>
+            <Input
+              autoFocus
+              disabled={drawerGate.isCorrectingOpeningFloat}
+              inputMode="decimal"
+              onChange={(event) =>
+                drawerGate.onCorrectedOpeningFloatChange?.(event.target.value)
+              }
+              placeholder="0.00"
+              value={drawerGate.correctedOpeningFloat ?? ""}
+            />
+          </label>
+
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-stone-700">Reason</span>
+            <Textarea
+              disabled={drawerGate.isCorrectingOpeningFloat}
+              onChange={(event) =>
+                drawerGate.onCorrectionReasonChange?.(event.target.value)
+              }
+              placeholder="Add why the opening float is being corrected."
+              rows={3}
+              value={drawerGate.correctionReason ?? ""}
+            />
+          </label>
+
+          {drawerGate.errorMessage ? (
+            <p className="text-sm text-red-600" role="alert">
+              {drawerGate.errorMessage}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <LoadingButton
+              className="w-full sm:w-auto"
+              disabled={Boolean(drawerGate.isCorrectingOpeningFloat)}
+              isLoading={Boolean(drawerGate.isCorrectingOpeningFloat)}
+              type="submit"
+            >
+              Save correction
+            </LoadingButton>
+
+            <Button
+              className="w-full sm:w-auto"
+              disabled={drawerGate.isCorrectingOpeningFloat}
+              onClick={drawerGate.onCancelOpeningFloatCorrection}
+              type="button"
+              variant="outline"
+            >
+              Return to sale
+            </Button>
+
+            <CashControlsButton className="w-full sm:w-auto" />
+          </div>
+        </form>
+      </div>
+    );
+  }
 
   if (isCloseoutBlocked) {
     const currency = drawerGate.currency ?? "GHS";
@@ -108,7 +217,10 @@ export function RegisterDrawerGate({
                 >
                   {drawerGate.closeoutDraftVariance === undefined
                     ? "Pending count"
-                    : formatCurrency(currency, drawerGate.closeoutDraftVariance)}
+                    : formatCurrency(
+                        currency,
+                        drawerGate.closeoutDraftVariance,
+                      )}
                 </dd>
               </div>
             </dl>
@@ -165,7 +277,7 @@ export function RegisterDrawerGate({
               className="w-full sm:w-auto"
               disabled={Boolean(
                 drawerGate.isCloseoutSubmitting ||
-                  drawerGate.isReopeningCloseout,
+                drawerGate.isReopeningCloseout,
               )}
               isLoading={Boolean(drawerGate.isReopeningCloseout)}
               onClick={() => void drawerGate.onReopenRegister?.()}
@@ -224,7 +336,8 @@ export function RegisterDrawerGate({
       <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
         <label className="block space-y-2">
           <span className="text-sm font-medium text-stone-700">
-            Opening float ({currencyDisplaySymbol(drawerGate.currency ?? "GHS")})
+            Opening float ({currencyDisplaySymbol(drawerGate.currency ?? "GHS")}
+            )
           </span>
           <Input
             autoFocus

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -38,7 +38,18 @@ vi.mock("../../common/FadeIn", () => ({
 }));
 
 vi.mock("../../common/PageHeader", () => ({
-  SimplePageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+  ComposedPageHeader: ({
+    leadingContent,
+    trailingContent,
+  }: {
+    leadingContent: React.ReactNode;
+    trailingContent?: React.ReactNode;
+  }) => (
+    <header>
+      {leadingContent}
+      <div data-testid="header-trailing">{trailingContent}</div>
+    </header>
+  ),
 }));
 
 vi.mock("../../ui/badge", () => ({
@@ -63,6 +74,42 @@ vi.mock("../../ui/card", () => ({
 vi.mock("../../ui/input", () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
     <input {...props} />
+  ),
+}));
+
+vi.mock("../../ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children?: React.ReactNode;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  }) => (
+    <select
+      aria-label="Corrected payment method"
+      onChange={(event) => onValueChange?.(event.target.value)}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children?: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <option value="">{placeholder}</option>
   ),
 }));
 
@@ -102,6 +149,24 @@ vi.mock("../../traces/WorkflowTraceRouteLink", () => ({
       {children ? `:${children}` : ""}
     </span>
   ),
+}));
+
+vi.mock("../../ui/button", () => ({
+  Button: ({
+    asChild,
+    children,
+    ...props
+  }: {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
 }));
 
 describe("TransactionView", () => {
@@ -155,8 +220,11 @@ describe("TransactionView", () => {
 
     render(<TransactionView />);
 
+    expect(screen.getByTestId("header-trailing")).toContainElement(
+      screen.getByTestId("session-trace-link"),
+    );
     expect(screen.getByTestId("session-trace-link")).toHaveTextContent(
-      "pos_session:ses-001:Session trace",
+      "pos_session:ses-001:View trace",
     );
   });
 
@@ -326,6 +394,29 @@ describe("TransactionView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("uses a select for same-amount payment method corrections", async () => {
+    const user = userEvent.setup();
+    useParamsMock.mockReturnValue({ transactionId: "txn_8" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Correct" }));
+    await user.click(screen.getByRole("button", { name: "Payment method" }));
+
+    const paymentMethodSelect = screen.getByLabelText(
+      "Corrected payment method",
+    );
+    expect(paymentMethodSelect.tagName).toBe("SELECT");
+
+    await user.selectOptions(paymentMethodSelect, "card");
+
+    expect(paymentMethodSelect).toHaveValue("card");
+    expect(
+      screen.queryByPlaceholderText("cash, card, mobile_money..."),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders correction history when operational events are present", () => {
     useParamsMock.mockReturnValue({ transactionId: "txn_8" });
     useQueryMock.mockReturnValue({
@@ -352,6 +443,31 @@ describe("TransactionView", () => {
       screen.getByText("Customer called with receipt."),
     ).toBeInTheDocument();
     expect(screen.getByText(/by Ama M\./)).toBeInTheDocument();
+  });
+
+  it("tightens payment correction history labels", () => {
+    useParamsMock.mockReturnValue({ transactionId: "txn_10" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      correctionHistory: [
+        {
+          _id: "event-1",
+          actorStaffName: "Kwamina Mensah",
+          createdAt: Date.now() - 60_000,
+          eventType: "pos_transaction_payment_method_corrected",
+          message: "Corrected payment method for Transaction #754489.",
+          reason: "Wrong method selected.",
+        },
+      ],
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.getByText("Payment method corrected")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Corrected payment method for Transaction #754489."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/by Kwamina M\./)).toBeInTheDocument();
   });
 
   it("omits correction history when no events are present", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -6,6 +6,7 @@ import {
   Banknote,
   CheckCircle2,
   CreditCard,
+  ShieldAlert,
   WalletCards,
   Smartphone,
   User,
@@ -13,7 +14,7 @@ import {
 
 import View from "../../View";
 import { FadeIn } from "../../common/FadeIn";
-import { SimplePageHeader } from "../../common/PageHeader";
+import { ComposedPageHeader } from "../../common/PageHeader";
 import { api } from "~/convex/_generated/api";
 import { Badge } from "../../ui/badge";
 import { getRelativeTime } from "~/src/lib/utils";
@@ -29,6 +30,13 @@ import config from "~/src/config";
 import { formatStaffDisplayName } from "~/shared/staffDisplayName";
 import { Textarea } from "../../ui/textarea";
 import { Input } from "../../ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../ui/select";
 import { runCommand } from "~/src/lib/errors/runCommand";
 import type { CommandResult } from "~/shared/commandResult";
 import {
@@ -52,10 +60,37 @@ type CorrectionEvent = {
   reason?: string | null;
 };
 
+const PAYMENT_METHOD_OPTIONS = [
+  { label: "Cash", value: "cash" },
+  { label: "Card", value: "card" },
+  { label: "Mobile Money", value: "mobile_money" },
+] satisfies Array<{ label: string; value: PosPaymentMethod }>;
+
 function formatCorrectionEventType(eventType: string) {
   return eventType
     .replaceAll("_", " ")
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatCorrectionHistoryTitle(event: CorrectionEvent) {
+  switch (event.eventType) {
+    case "pos_transaction_payment_method_corrected":
+      return "Payment method corrected";
+    case "transaction_customer_corrected":
+    case "pos_transaction_customer_corrected":
+      return "Customer attribution corrected";
+    default:
+      return event.message ?? formatCorrectionEventType(event.eventType);
+  }
+}
+
+function formatCorrectionHistoryMeta(event: CorrectionEvent) {
+  const timestamp = getRelativeTime(event.createdAt);
+  const actorName = event.actorStaffName
+    ? formatStaffDisplayName({ fullName: event.actorStaffName })
+    : null;
+
+  return actorName ? `${timestamp} by ${actorName}` : timestamp;
 }
 
 function getTransactionCorrectionHistory(transaction: {
@@ -92,7 +127,9 @@ export function TransactionView() {
   const correctAuth = useMutation(
     api.operations.staffCredentials.authenticateStaffCredential,
   );
-  const correctCustomer = useMutation(api.inventory.pos.correctTransactionCustomer);
+  const correctCustomer = useMutation(
+    api.inventory.pos.correctTransactionCustomer,
+  );
   const correctPaymentMethod = useMutation(
     api.inventory.pos.correctTransactionPaymentMethod,
   );
@@ -228,15 +265,16 @@ export function TransactionView() {
 
     setCorrectionSubmitting(true);
     setCorrectionError(null);
-    const result = await runCommand(() =>
-      correctCustomer({
-        actorStaffProfileId: staff.staffProfileId,
-        customerProfileId: customerProfileIdInput.trim()
-          ? (customerProfileIdInput.trim() as Id<"customerProfile">)
-          : undefined,
-        reason,
-        transactionId: transactionId as Id<"posTransaction">,
-      }) as Promise<CommandResult<unknown>>,
+    const result = await runCommand(
+      () =>
+        correctCustomer({
+          actorStaffProfileId: staff.staffProfileId,
+          customerProfileId: customerProfileIdInput.trim()
+            ? (customerProfileIdInput.trim() as Id<"customerProfile">)
+            : undefined,
+          reason,
+          transactionId: transactionId as Id<"posTransaction">,
+        }) as Promise<CommandResult<unknown>>,
     );
     setCorrectionSubmitting(false);
 
@@ -256,7 +294,7 @@ export function TransactionView() {
       return;
     }
 
-    const paymentMethod = paymentMethodInput.trim();
+    const paymentMethod = paymentMethodInput as PosPaymentMethod;
     const reason = paymentCorrectionReason.trim();
     if (!paymentMethod) {
       setCorrectionError("Choose the corrected payment method.");
@@ -269,13 +307,14 @@ export function TransactionView() {
 
     setCorrectionSubmitting(true);
     setCorrectionError(null);
-    const result = await runCommand(() =>
-      correctPaymentMethod({
-        actorStaffProfileId: staff.staffProfileId,
-        paymentMethod,
-        reason,
-        transactionId: transactionId as Id<"posTransaction">,
-      }) as Promise<CommandResult<unknown>>,
+    const result = await runCommand(
+      () =>
+        correctPaymentMethod({
+          actorStaffProfileId: staff.staffProfileId,
+          paymentMethod,
+          reason,
+          transactionId: transactionId as Id<"posTransaction">,
+        }) as Promise<CommandResult<unknown>>,
     );
     setCorrectionSubmitting(false);
 
@@ -315,8 +354,21 @@ export function TransactionView() {
   return (
     <View
       header={
-        <SimplePageHeader
-          title={`Transaction #${transaction.transactionNumber}`}
+        <ComposedPageHeader
+          leadingContent={
+            <p className="text-sm">
+              Transaction #{transaction.transactionNumber}
+            </p>
+          }
+          trailingContent={
+            transaction.sessionTraceId ? (
+              <Button asChild size="sm" type="button" variant="ghost">
+                <WorkflowTraceRouteLink traceId={transaction.sessionTraceId}>
+                  View trace
+                </WorkflowTraceRouteLink>
+              </Button>
+            ) : null
+          }
         />
       }
     >
@@ -351,9 +403,9 @@ export function TransactionView() {
         open={Boolean(pendingCorrection)}
       />
       <FadeIn className="h-full">
-        <div className="container mx-auto h-full min-h-0 p-6">
+        <div className="container mx-auto h-full min-h-0 px-6 pb-16 pt-6">
           <div className="grid h-full min-h-0 gap-8 xl:grid-cols-[380px,minmax(0,1fr)]">
-            <div className="space-y-6">
+            <div className="space-y-6 pb-16">
               <section className="overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised shadow-surface">
                 <CardHeader className="space-y-4 pb-4">
                   <div className="flex flex-wrap items-center justify-between gap-3">
@@ -367,60 +419,87 @@ export function TransactionView() {
                         {getRelativeTime(transaction.completedAt)}
                       </p>
                     </Badge>
-                    {transaction.sessionTraceId ? (
-                      <div className="flex flex-wrap items-center gap-3">
-                        <WorkflowTraceRouteLink
-                          traceId={transaction.sessionTraceId}
-                        >
-                          Session trace
-                        </WorkflowTraceRouteLink>
-                      </div>
-                    ) : null}
                   </div>
                 </CardHeader>
-                <CardContent className="space-y-4 border-t border-border/70 pt-4 text-sm">
-                  {isCompletedTransaction ? (
-                    <Button
-                      className="w-full"
-                      onClick={() => {
-                        setCorrectionPanelOpen((value) => !value);
-                        setSelectedCorrection(null);
-                      }}
-                      type="button"
-                      variant="outline"
-                    >
-                      Correct
-                    </Button>
-                  ) : null}
+                <CardContent className="border-t border-border/70 p-0 text-sm">
+                  <dl className="divide-y divide-border/70">
+                    {transaction.cashier ? (
+                      <div className="flex items-center gap-3 px-6 py-4">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[calc(var(--radius)*0.85)] bg-muted text-muted-foreground">
+                          <User className="w-4 h-4" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                            Cashier
+                          </dt>
+                          <dd className="mt-1 truncate font-medium text-foreground">
+                            {formatStaffDisplayName(transaction.cashier)}
+                          </dd>
+                        </div>
+                      </div>
+                    ) : null}
 
-                  {transaction.cashier && (
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-3 px-6 py-4">
                       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[calc(var(--radius)*0.85)] bg-muted text-muted-foreground">
-                        <User className="w-4 h-4" />
+                        <PaymentIcon className="w-4 h-4" />
                       </div>
-                      <div>
-                        <p className="font-medium">
-                          {formatStaffDisplayName(transaction.cashier)}
-                        </p>
-                        <p className="text-xs text-muted-foreground">Cashier</p>
+                      <div className="min-w-0 flex-1">
+                        <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                          Payment
+                        </dt>
+                        <dd className="mt-1 truncate font-medium capitalize text-foreground">
+                          {paymentMethodLabel}
+                        </dd>
                       </div>
                     </div>
-                  )}
 
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[calc(var(--radius)*0.85)] bg-muted text-muted-foreground">
-                      <PaymentIcon className="w-4 h-4" />
-                    </div>
-                    <div>
-                      <p className="font-medium capitalize">
-                        {paymentMethodLabel}
-                      </p>
-                    </div>
-                  </div>
+                    {(transaction.customer || transaction.customerInfo) && (
+                      <div className="px-6 py-4">
+                        <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                          Customer
+                        </dt>
+                        <dd className="mt-1 font-medium text-foreground">
+                          {transaction.customer?.name ||
+                            transaction.customerInfo?.name ||
+                            "Walk-in customer"}
+                        </dd>
+                        {(transaction.customer?.email ||
+                          transaction.customer?.phone ||
+                          transaction.customerInfo?.email ||
+                          transaction.customerInfo?.phone) && (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {transaction.customer?.email ||
+                              transaction.customerInfo?.email}
+                            {(transaction.customer?.email ||
+                              transaction.customerInfo?.email) &&
+                            (transaction.customer?.phone ||
+                              transaction.customerInfo?.phone)
+                              ? " • "
+                              : ""}
+                            {transaction.customer?.phone ||
+                              transaction.customerInfo?.phone}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </dl>
 
-                  <div>
+                  <div className="grid gap-3 border-t border-border/70 bg-muted/20 p-6 sm:grid-cols-2">
+                    {isCompletedTransaction ? (
+                      <Button
+                        className="w-full"
+                        onClick={() => {
+                          setCorrectionPanelOpen((value) => !value);
+                          setSelectedCorrection(null);
+                        }}
+                        type="button"
+                        variant={correctionPanelOpen ? "workflow" : "outline"}
+                      >
+                        Correct
+                      </Button>
+                    ) : null}
+
                     <Button
-                      variant="outline"
                       className="w-full"
                       onClick={() =>
                         window.open(
@@ -429,38 +508,11 @@ export function TransactionView() {
                           "noreferrer",
                         )
                       }
+                      variant="outline"
                     >
                       View receipt
                     </Button>
                   </div>
-
-                  {(transaction.customer || transaction.customerInfo) && (
-                    <div className="flex flex-col gap-1">
-                      <p className="font-medium">Customer</p>
-                      <p className="text-sm">
-                        {transaction.customer?.name ||
-                          transaction.customerInfo?.name ||
-                          "Walk-in customer"}
-                      </p>
-                      {(transaction.customer?.email ||
-                        transaction.customer?.phone ||
-                        transaction.customerInfo?.email ||
-                        transaction.customerInfo?.phone) && (
-                        <p className="text-xs text-muted-foreground">
-                          {transaction.customer?.email ||
-                            transaction.customerInfo?.email}
-                          {(transaction.customer?.email ||
-                            transaction.customerInfo?.email) &&
-                          (transaction.customer?.phone ||
-                            transaction.customerInfo?.phone)
-                            ? " • "
-                            : ""}
-                          {transaction.customer?.phone ||
-                            transaction.customerInfo?.phone}
-                        </p>
-                      )}
-                    </div>
-                  )}
 
                   {/* {transaction.notes && (
                     <div className="space-y-1">
@@ -474,171 +526,233 @@ export function TransactionView() {
               </section>
 
               {correctionPanelOpen ? (
-                <section className="space-y-4 overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised p-4 shadow-surface">
-                  <div className="space-y-1">
-                    <h2 className="font-display text-xl font-semibold text-foreground">
-                      Transaction correction
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                      Choose the correction type. Completed sale totals stay
-                      locked.
-                    </p>
+                <section className="overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised shadow-surface">
+                  <div className="border-b border-border/70 px-5 py-4">
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[calc(var(--radius)*0.85)] bg-muted text-muted-foreground">
+                        <ShieldAlert className="h-4 w-4" />
+                      </div>
+                      <div className="space-y-1">
+                        <h2 className="font-display text-lg font-semibold text-foreground">
+                          Transaction correction
+                        </h2>
+                        <p className="text-sm leading-6 text-muted-foreground">
+                          Correct metadata or payment labels here. Use guided
+                          workflows for sale totals and item changes.
+                        </p>
+                      </div>
+                    </div>
                   </div>
 
-                  <div className="grid gap-2">
-                    <Button
-                      className="justify-start"
-                      onClick={() => setSelectedCorrection("customer")}
-                      type="button"
-                      variant={
-                        selectedCorrection === "customer"
-                          ? "default"
-                          : "outline"
-                      }
-                    >
-                      Customer attribution
-                    </Button>
-                    <Button
-                      className="justify-start"
-                      onClick={() => setSelectedCorrection("payment_method")}
-                      type="button"
-                      variant={
-                        selectedCorrection === "payment_method"
-                          ? "default"
-                          : "outline"
-                      }
-                    >
-                      Payment method
-                    </Button>
-                    <Button
-                      className="justify-start"
-                      onClick={() => setSelectedCorrection("line_items")}
-                      type="button"
-                      variant={
-                        selectedCorrection === "line_items"
-                          ? "default"
-                          : "outline"
-                      }
-                    >
-                      Items or quantities
-                    </Button>
-                    <Button
-                      className="justify-start"
-                      onClick={() => setSelectedCorrection("amounts")}
-                      type="button"
-                      variant={
-                        selectedCorrection === "amounts" ? "default" : "outline"
-                      }
-                    >
-                      Amounts or totals
-                    </Button>
-                    <Button
-                      className="justify-start"
-                      onClick={() => setSelectedCorrection("discounts")}
-                      type="button"
-                      variant={
-                        selectedCorrection === "discounts"
-                          ? "default"
-                          : "outline"
-                      }
-                    >
-                      Discounts
-                    </Button>
-                  </div>
+                  <div className="space-y-5 p-5">
+                    <div className="space-y-2">
+                      <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                        Direct corrections
+                      </p>
+                      <div className="grid gap-2">
+                        <Button
+                          aria-label="Customer attribution"
+                          className="h-auto justify-start whitespace-normal px-3 py-3 text-left"
+                          onClick={() => setSelectedCorrection("customer")}
+                          type="button"
+                          variant={
+                            selectedCorrection === "customer"
+                              ? "workflow-soft"
+                              : "outline"
+                          }
+                        >
+                          <span className="grid gap-1">
+                            <span>Customer attribution</span>
+                            <span className="text-xs font-normal opacity-75">
+                              Change walk-in or customer assignment.
+                            </span>
+                          </span>
+                        </Button>
+                        {selectedCorrection === "customer" ? (
+                          <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
+                            <p className="text-sm font-medium text-foreground">
+                              Customer correction
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              Staff sign-in and customer lookup will update
+                              attribution only.
+                            </p>
+                            <Input
+                              aria-label="Corrected customer profile ID"
+                              className="border-input bg-background"
+                              onChange={(event) =>
+                                setCustomerProfileIdInput(event.target.value)
+                              }
+                              placeholder="Customer profile ID, or leave blank for walk-in."
+                              value={customerProfileIdInput}
+                            />
+                            <Textarea
+                              aria-label="Customer correction reason"
+                              className="min-h-[80px] border-input bg-background"
+                              onChange={(event) =>
+                                setCustomerCorrectionReason(event.target.value)
+                              }
+                              placeholder="Reason for customer attribution correction."
+                              value={customerCorrectionReason}
+                            />
+                            <Button
+                              disabled={correctionSubmitting}
+                              onClick={() =>
+                                requestCorrectionSubmit("customer")
+                              }
+                              type="button"
+                            >
+                              Submit customer correction
+                            </Button>
+                          </div>
+                        ) : null}
+                        <Button
+                          aria-label="Payment method"
+                          className="h-auto justify-start whitespace-normal px-3 py-3 text-left"
+                          onClick={() =>
+                            setSelectedCorrection("payment_method")
+                          }
+                          type="button"
+                          variant={
+                            selectedCorrection === "payment_method"
+                              ? "workflow-soft"
+                              : "outline"
+                          }
+                        >
+                          <span className="grid gap-1">
+                            <span>Payment method</span>
+                            <span className="text-xs font-normal opacity-75">
+                              Same-amount method correction only.
+                            </span>
+                          </span>
+                        </Button>
+                        {showPaymentMethodDirectFlow ? (
+                          <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
+                            <p className="text-sm font-medium text-foreground">
+                              Same-amount payment method correction
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              Staff sign-in will keep the paid amount unchanged
+                              and update the method history.
+                            </p>
+                            <Select
+                              onValueChange={(value) =>
+                                setPaymentMethodInput(value)
+                              }
+                              value={paymentMethodInput}
+                            >
+                              <SelectTrigger
+                                aria-label="Corrected payment method"
+                                className="border-input bg-background"
+                              >
+                                <SelectValue placeholder="Choose payment method" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {PAYMENT_METHOD_OPTIONS.map((option) => (
+                                  <SelectItem
+                                    key={option.value}
+                                    value={option.value}
+                                  >
+                                    {option.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <Textarea
+                              aria-label="Payment method correction reason"
+                              className="min-h-[80px] border-input bg-background"
+                              onChange={(event) =>
+                                setPaymentCorrectionReason(event.target.value)
+                              }
+                              placeholder="Reason for payment method correction."
+                              value={paymentCorrectionReason}
+                            />
+                            <Button
+                              disabled={correctionSubmitting}
+                              onClick={() =>
+                                requestCorrectionSubmit("payment_method")
+                              }
+                              type="button"
+                            >
+                              Submit payment correction
+                            </Button>
+                          </div>
+                        ) : selectedCorrection === "payment_method" ? (
+                          <div className="rounded-lg border border-amber-200 bg-amber-50/40 p-4 text-sm text-muted-foreground">
+                            Multi-payment corrections need review before
+                            editing payment records.
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
 
-                  {selectedCorrection === "customer" ? (
-                    <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
-                      <p className="text-sm font-medium text-foreground">
-                        Customer correction
+                    <div className="space-y-2 border-t border-border/70 pt-4">
+                      <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                        Guided routes
                       </p>
-                      <p className="text-sm text-muted-foreground">
-                        Staff sign-in and customer lookup will update
-                        attribution only.
+                      <div className="grid gap-2">
+                        <Button
+                          aria-label="Items or quantities"
+                          className="h-auto justify-start whitespace-normal px-3 py-2.5 text-left"
+                          onClick={() => setSelectedCorrection("line_items")}
+                          type="button"
+                          variant={
+                            selectedCorrection === "line_items"
+                              ? "workflow-soft"
+                              : "outline"
+                          }
+                        >
+                          Items or quantities
+                        </Button>
+                        <Button
+                          aria-label="Amounts or totals"
+                          className="h-auto justify-start whitespace-normal px-3 py-2.5 text-left"
+                          onClick={() => setSelectedCorrection("amounts")}
+                          type="button"
+                          variant={
+                            selectedCorrection === "amounts"
+                              ? "workflow-soft"
+                              : "outline"
+                          }
+                        >
+                          Amounts or totals
+                        </Button>
+                        <Button
+                          aria-label="Discounts"
+                          className="h-auto justify-start whitespace-normal px-3 py-2.5 text-left"
+                          onClick={() => setSelectedCorrection("discounts")}
+                          type="button"
+                          variant={
+                            selectedCorrection === "discounts"
+                              ? "workflow-soft"
+                              : "outline"
+                          }
+                        >
+                          Discounts
+                        </Button>
+                      </div>
+                    </div>
+
+                    {selectedCorrection &&
+                    !["customer", "payment_method"].includes(
+                      selectedCorrection,
+                    ) ? (
+                      <div className="rounded-lg border border-amber-200 bg-amber-50/40 p-4 text-sm text-muted-foreground">
+                        Use refund, exchange, or manager review for item,
+                        amount, total, or discount corrections.
+                      </div>
+                    ) : null}
+                    {correctionError ? (
+                      <p className="text-sm text-destructive">
+                        {correctionError}
                       </p>
-                      <Input
-                        aria-label="Corrected customer profile ID"
-                        className="border-input bg-background"
-                        onChange={(event) =>
-                          setCustomerProfileIdInput(event.target.value)
-                        }
-                        placeholder="Customer profile ID, or leave blank for walk-in."
-                        value={customerProfileIdInput}
-                      />
-                      <Textarea
-                        aria-label="Customer correction reason"
-                        className="min-h-[80px] border-input bg-background"
-                        onChange={(event) =>
-                          setCustomerCorrectionReason(event.target.value)
-                        }
-                        placeholder="Reason for customer attribution correction."
-                        value={customerCorrectionReason}
-                      />
-                      <Button
-                        disabled={correctionSubmitting}
-                        onClick={() => requestCorrectionSubmit("customer")}
-                        type="button"
-                      >
-                        Submit customer correction
-                      </Button>
-                    </div>
-                  ) : showPaymentMethodDirectFlow ? (
-                    <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
-                      <p className="text-sm font-medium text-foreground">
-                        Same-amount payment method correction
-                      </p>
-                      <p className="text-sm text-muted-foreground">
-                        Staff sign-in will keep the paid amount unchanged and
-                        update the method history.
-                      </p>
-                      <Input
-                        aria-label="Corrected payment method"
-                        className="border-input bg-background"
-                        onChange={(event) =>
-                          setPaymentMethodInput(event.target.value)
-                        }
-                        placeholder="cash, card, mobile_money..."
-                        value={paymentMethodInput}
-                      />
-                      <Textarea
-                        aria-label="Payment method correction reason"
-                        className="min-h-[80px] border-input bg-background"
-                        onChange={(event) =>
-                          setPaymentCorrectionReason(event.target.value)
-                        }
-                        placeholder="Reason for payment method correction."
-                        value={paymentCorrectionReason}
-                      />
-                      <Button
-                        disabled={correctionSubmitting}
-                        onClick={() =>
-                          requestCorrectionSubmit("payment_method")
-                        }
-                        type="button"
-                      >
-                        Submit payment correction
-                      </Button>
-                    </div>
-                  ) : selectedCorrection === "payment_method" ? (
-                    <div className="rounded-lg border border-amber-200 bg-amber-50/40 p-4 text-sm text-muted-foreground">
-                      Multi-payment corrections need review before editing
-                      payment records.
-                    </div>
-                  ) : selectedCorrection ? (
-                    <div className="rounded-lg border border-amber-200 bg-amber-50/40 p-4 text-sm text-muted-foreground">
-                      Use refund, exchange, or manager review for item, amount,
-                      total, or discount corrections.
-                    </div>
-                  ) : null}
-                  {correctionError ? (
-                    <p className="text-sm text-destructive">
-                      {correctionError}
-                    </p>
-                  ) : null}
+                    ) : null}
+                  </div>
                 </section>
               ) : null}
 
               {correctionHistory.length > 0 ? (
-                <section className="space-y-3 overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised p-4 shadow-surface">
+                <section className="space-y-4 overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised p-5 shadow-surface">
                   <div className="space-y-1">
                     <h2 className="font-display text-xl font-semibold text-foreground">
                       Correction history
@@ -650,21 +764,19 @@ export function TransactionView() {
                   <div className="space-y-3">
                     {correctionHistory.map((event) => (
                       <div
-                        className="rounded-lg border border-border bg-muted/20 p-3"
+                        className="space-y-2 rounded-lg border border-border bg-muted/20 p-4"
                         key={event._id}
                       >
-                        <p className="text-sm font-medium text-foreground">
-                          {event.message ??
-                            formatCorrectionEventType(event.eventType)}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {getRelativeTime(event.createdAt)}
-                          {event.actorStaffName
-                            ? ` by ${formatStaffDisplayName({ fullName: event.actorStaffName })}`
-                            : ""}
-                        </p>
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium leading-5 text-foreground">
+                            {formatCorrectionHistoryTitle(event)}
+                          </p>
+                          <p className="text-xs leading-4 text-muted-foreground">
+                            {formatCorrectionHistoryMeta(event)}
+                          </p>
+                        </div>
                         {event.reason ? (
-                          <p className="mt-1 text-sm text-muted-foreground">
+                          <p className="border-t border-border/70 pt-3 text-sm leading-5 text-muted-foreground">
                             {event.reason}
                           </p>
                         ) : null}

--- a/packages/athena-webapp/src/components/ui/button.test.tsx
+++ b/packages/athena-webapp/src/components/ui/button.test.tsx
@@ -17,4 +17,24 @@ describe("Button", () => {
     expect(button).toHaveClass("h-9");
     expect(button).toHaveClass("bg-secondary");
   });
+
+  it("renders semantic action variants", () => {
+    render(
+      <>
+        <Button variant="workflow">Correct</Button>
+        <Button variant="workflow-soft">Selected correction</Button>
+        <Button variant="utility">View receipt</Button>
+      </>
+    );
+
+    expect(screen.getByRole("button", { name: "Correct" })).toHaveClass(
+      "bg-action-workflow",
+    );
+    expect(
+      screen.getByRole("button", { name: "Selected correction" }),
+    ).toHaveClass("bg-action-workflow-soft");
+    expect(screen.getByRole("button", { name: "View receipt" })).toHaveClass(
+      "text-action-neutral",
+    );
+  });
 });

--- a/packages/athena-webapp/src/components/ui/button.tsx
+++ b/packages/athena-webapp/src/components/ui/button.tsx
@@ -9,7 +9,14 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-signal text-signal-foreground hover:bg-signal/90",
+        default:
+          "bg-action-commit text-action-commit-foreground hover:bg-action-commit/90",
+        workflow:
+          "bg-action-workflow text-action-workflow-foreground hover:bg-action-workflow/90",
+        "workflow-soft":
+          "border border-action-workflow-border bg-action-workflow-soft text-action-workflow hover:bg-action-workflow-soft/75",
+        utility:
+          "border border-border bg-background text-action-neutral hover:bg-action-neutral-soft hover:text-action-neutral",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
@@ -17,7 +24,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-signal underline-offset-4 hover:underline",
+        link: "text-action-commit underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/packages/athena-webapp/src/components/ui/primitives.test.tsx
+++ b/packages/athena-webapp/src/components/ui/primitives.test.tsx
@@ -39,7 +39,7 @@ describe("primitive sizing and token semantics", () => {
     expect(card).toHaveClass("shadow-surface")
   })
 
-  it("uses the signal token for primary actions and badges", () => {
+  it("uses action tokens for primary actions and signal tokens for badges", () => {
     render(
       <>
         <Button>Save sale</Button>
@@ -48,8 +48,8 @@ describe("primitive sizing and token semantics", () => {
     )
 
     expect(screen.getByRole("button", { name: "Save sale" })).toHaveClass(
-      "bg-signal",
-      "text-signal-foreground",
+      "bg-action-commit",
+      "text-action-commit-foreground",
     )
     expect(screen.getByText("Ready")).toHaveClass(
       "bg-signal",

--- a/packages/athena-webapp/src/components/ui/sidebar.tsx
+++ b/packages/athena-webapp/src/components/ui/sidebar.tsx
@@ -260,7 +260,11 @@ const Sidebar = React.forwardRef<
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
               ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
-              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
+              : cn(
+                  "group-data-[collapsible=icon]:w-[--sidebar-width-icon]",
+                  "group-data-[side=left]:border-r group-data-[side=left]:border-sidebar-border",
+                  "group-data-[side=right]:border-l group-data-[side=right]:border-sidebar-border"
+                ),
             className
           )}
           {...props}

--- a/packages/athena-webapp/src/index.css
+++ b/packages/athena-webapp/src/index.css
@@ -26,8 +26,8 @@
     --card-foreground: 222 28% 16%;
     --popover: 40 42% 99%;
     --popover-foreground: 222 28% 16%;
-    --primary: 26 73% 48%;
-    --primary-foreground: 35 100% 97%;
+    --primary: 338 62% 43%;
+    --primary-foreground: 336 100% 98%;
     --secondary: 210 21% 92%;
     --secondary-foreground: 222 28% 16%;
     --muted: 36 30% 91%;
@@ -45,8 +45,16 @@
     --surface-raised: 0 0% 100%;
     --shell: 223 34% 14%;
     --shell-foreground: 35 42% 95%;
-    --signal: 26 73% 48%;
-    --signal-foreground: 35 100% 97%;
+    --signal: 338 62% 43%;
+    --signal-foreground: 336 100% 98%;
+    --action-commit: 338 62% 43%;
+    --action-commit-foreground: 336 100% 98%;
+    --action-workflow: 232 42% 45%;
+    --action-workflow-foreground: 232 100% 98%;
+    --action-workflow-soft: 232 58% 96%;
+    --action-workflow-border: 232 38% 82%;
+    --action-neutral: 225 18% 35%;
+    --action-neutral-soft: 225 20% 96%;
     --success: 151 42% 34%;
     --success-foreground: 145 60% 96%;
     --warning: 35 79% 52%;
@@ -54,8 +62,8 @@
     --danger: 4 71% 54%;
     --danger-foreground: 0 0% 98%;
 
-    --chart-1: 26 73% 48%;
-    --chart-2: 205 56% 38%;
+    --chart-1: 338 62% 43%;
+    --chart-2: 232 42% 45%;
     --chart-3: 156 40% 34%;
     --chart-4: 37 82% 59%;
     --chart-5: 278 34% 48%;
@@ -99,7 +107,7 @@
     --card-foreground: 36 34% 95%;
     --popover: 223 24% 14%;
     --popover-foreground: 36 34% 95%;
-    --primary: 31 91% 67%;
+    --primary: 336 72% 68%;
     --primary-foreground: 222 30% 12%;
     --secondary: 223 19% 18%;
     --secondary-foreground: 36 34% 95%;
@@ -118,8 +126,16 @@
     --surface-raised: 223 20% 17%;
     --shell: 222 38% 8%;
     --shell-foreground: 36 30% 94%;
-    --signal: 31 91% 67%;
+    --signal: 336 72% 68%;
     --signal-foreground: 222 30% 12%;
+    --action-commit: 336 72% 68%;
+    --action-commit-foreground: 222 30% 12%;
+    --action-workflow: 235 64% 72%;
+    --action-workflow-foreground: 222 30% 12%;
+    --action-workflow-soft: 232 24% 22%;
+    --action-workflow-border: 233 36% 44%;
+    --action-neutral: 225 18% 76%;
+    --action-neutral-soft: 225 17% 22%;
     --success: 151 44% 42%;
     --success-foreground: 145 56% 94%;
     --warning: 38 92% 61%;
@@ -127,8 +143,8 @@
     --danger: 6 79% 64%;
     --danger-foreground: 0 0% 98%;
 
-    --chart-1: 31 91% 67%;
-    --chart-2: 194 64% 63%;
+    --chart-1: 336 72% 68%;
+    --chart-2: 235 64% 72%;
     --chart-3: 157 43% 46%;
     --chart-4: 40 94% 66%;
     --chart-5: 281 58% 70%;

--- a/packages/athena-webapp/src/lib/errors/operatorMessages.test.ts
+++ b/packages/athena-webapp/src/lib/errors/operatorMessages.test.ts
@@ -40,6 +40,10 @@ describe("toOperatorMessage", () => {
       "This sale is already assigned to a different cash drawer.",
       "Sale assigned to a different drawer. Open that drawer before continuing.",
     ],
+    [
+      "A session is active for this cashier on a different terminal",
+      "Cashier already has an active session on another terminal.",
+    ],
   ])("normalizes POS drawer command copy: %s", (backendMessage, operatorCopy) => {
     expect(toOperatorMessage(backendMessage)).toBe(operatorCopy);
   });

--- a/packages/athena-webapp/src/lib/errors/operatorMessages.ts
+++ b/packages/athena-webapp/src/lib/errors/operatorMessages.ts
@@ -8,6 +8,10 @@ const OPERATOR_MESSAGE_REWRITES: Array<[RegExp, string]> = [
     "Sign-in already active on another terminal. Sign out there before starting here.",
   ],
   [
+    /^A session is active for this cashier on a different terminal\.?$/i,
+    "Cashier already has an active session on another terminal.",
+  ],
+  [
     /^A register session is already open for this terminal\.?$/i,
     "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
   ],

--- a/packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts
+++ b/packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts
@@ -29,6 +29,7 @@ function state(
     cashier,
     activeRegisterSession: null,
     activeSession: null,
+    activeSessionConflict: null,
     resumableSession: null,
     ...overrides,
   };
@@ -43,6 +44,7 @@ describe("bootstrapRegister", () => {
         cashier: null,
         activeRegisterSession: null,
         activeSession: null,
+        activeSessionConflict: null,
         resumableSession: null,
       },
     });

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -63,12 +63,19 @@ export interface PosRegisterSessionDto {
   workflowTraceId?: string;
 }
 
+export interface PosActiveSessionConflictDto {
+  kind: "activeOnOtherTerminal";
+  message: string;
+  terminalId?: string;
+}
+
 export interface PosRegisterStateDto {
   phase: PosRegisterPhase;
   terminal: PosTerminalDto | null;
   cashier: PosCashierDto | null;
   activeRegisterSession: PosCashDrawerDto | null;
   activeSession: PosRegisterSessionDto | null;
+  activeSessionConflict: PosActiveSessionConflictDto | null;
   resumableSession: PosRegisterSessionDto | null;
 }
 
@@ -80,6 +87,7 @@ export interface PosRegisterBootstrapDto {
   cashier: PosCashierDto | null;
   activeRegisterSession: PosCashDrawerDto | null;
   activeSession: PosRegisterSessionDto | null;
+  activeSessionConflict: PosActiveSessionConflictDto | null;
   resumableSession: PosRegisterSessionDto | null;
 }
 

--- a/packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts
+++ b/packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts
@@ -26,6 +26,7 @@ export function bootstrapRegister(input: {
     cashier: registerState.cashier,
     activeRegisterSession: registerState.activeRegisterSession,
     activeSession: registerState.activeSession,
+    activeSessionConflict: registerState.activeSessionConflict,
     resumableSession: registerState.resumableSession,
   };
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts
@@ -10,6 +10,7 @@ describe("mapRegisterStateDto", () => {
       cashier: { _id: "cashier-1", firstName: "Ama", lastName: "K" },
       activeRegisterSession: null,
       activeSession: null,
+      activeSessionConflict: null,
       resumableSession: null,
     });
 
@@ -31,6 +32,7 @@ describe("mapRegisterStateDto", () => {
         openedAt: 1710000000000,
       },
       activeSession: null,
+      activeSessionConflict: null,
       resumableSession: {
         _id: "session-1",
         sessionNumber: "POS-001",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts
@@ -20,6 +20,9 @@ export function mapRegisterStateDto(
       ? { ...dto.activeRegisterSession }
       : null,
     activeSession: dto.activeSession ? { ...dto.activeSession } : null,
+    activeSessionConflict: dto.activeSessionConflict
+      ? { ...dto.activeSessionConflict }
+      : null,
     resumableSession: dto.resumableSession ? { ...dto.resumableSession } : null,
   };
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -128,12 +128,19 @@ export interface RegisterCashierCardState {
 }
 
 export interface RegisterDrawerGateState {
-  mode: "initialSetup" | "recovery" | "closeoutBlocked";
+  mode:
+    | "initialSetup"
+    | "recovery"
+    | "closeoutBlocked"
+    | "openingFloatCorrection";
   isRecovery?: boolean;
   registerLabel: string;
   registerNumber: string;
   currency?: string;
+  currentOpeningFloat?: number;
   openingFloat?: string;
+  correctedOpeningFloat?: string;
+  correctionReason?: string;
   closeoutCountedCash?: string;
   closeoutDraftVariance?: number;
   closeoutNotes?: string;
@@ -142,12 +149,17 @@ export interface RegisterDrawerGateState {
   notes?: string;
   errorMessage: string | null;
   isCloseoutSubmitting?: boolean;
+  isCorrectingOpeningFloat?: boolean;
   isReopeningCloseout?: boolean;
   isSubmitting?: boolean;
   onCloseoutCountedCashChange?: (value: string) => void;
   onCloseoutNotesChange?: (value: string) => void;
+  onCorrectedOpeningFloatChange?: (value: string) => void;
+  onCorrectionReasonChange?: (value: string) => void;
   onOpeningFloatChange?: (value: string) => void;
   onNotesChange?: (value: string) => void;
+  onCancelOpeningFloatCorrection?: () => void;
+  onSubmitOpeningFloatCorrection?: () => Promise<void>;
   onSubmitCloseout?: () => Promise<void>;
   onReopenRegister?: () => Promise<void>;
   onSubmit?: () => Promise<void>;
@@ -156,7 +168,9 @@ export interface RegisterDrawerGateState {
 
 export interface RegisterCloseoutControlState {
   canCloseout: boolean;
+  canCorrectOpeningFloat: boolean;
   onRequestCloseout: () => void;
+  onRequestOpeningFloatCorrection: () => void;
 }
 
 export interface RegisterAuthDialogState {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -25,6 +25,7 @@ const mockRemoveItem = vi.fn();
 const mockBindSessionToRegisterSession = vi.fn();
 const mockSubmitRegisterSessionCloseout = vi.fn();
 const mockReopenRegisterSessionCloseout = vi.fn();
+const mockCorrectRegisterSessionOpeningFloat = vi.fn();
 const mockNavigateBack = vi.fn();
 
 let mockActiveStore: { _id: Id<"store">; currency: string } | null;
@@ -53,6 +54,11 @@ let mockRegisterState:
         workflowTraceId?: string;
       } | null;
       activeSession: { _id: string; sessionNumber: string } | null;
+      activeSessionConflict?: {
+        kind: "activeOnOtherTerminal";
+        message: string;
+        terminalId?: string;
+      } | null;
       resumableSession: { _id: string; sessionNumber: string } | null;
     }
   | undefined;
@@ -209,6 +215,7 @@ describe("useRegisterViewModel", () => {
         workflowTraceId: "register_session:drawer-1",
       },
       activeSession: { _id: "session-1", sessionNumber: "POS-0001" },
+      activeSessionConflict: null,
       resumableSession: null,
     };
     mockActiveSession = {
@@ -250,12 +257,17 @@ describe("useRegisterViewModel", () => {
 
     mockUseQuery.mockImplementation(() => mockCashier);
     mockUseMutation.mockReset();
-    mockUseMutation.mockImplementation(() => {
-      const callIndex = mockUseMutation.mock.calls.length;
-      return callIndex % 2 === 1
-        ? mockSubmitRegisterSessionCloseout
-        : mockReopenRegisterSessionCloseout;
-    });
+    mockUseMutation.mockImplementation(
+      () => (args: Record<string, unknown>) => {
+        if ("countedCash" in args) {
+          return mockSubmitRegisterSessionCloseout(args);
+        }
+        if ("correctedOpeningFloat" in args) {
+          return mockCorrectRegisterSessionOpeningFloat(args);
+        }
+        return mockReopenRegisterSessionCloseout(args);
+      },
+    );
     mockSubmitRegisterSessionCloseout.mockReset();
     mockSubmitRegisterSessionCloseout.mockResolvedValue(
       ok({
@@ -266,6 +278,12 @@ describe("useRegisterViewModel", () => {
     mockReopenRegisterSessionCloseout.mockResolvedValue(
       ok({
         action: "reopened",
+      }),
+    );
+    mockCorrectRegisterSessionOpeningFloat.mockReset();
+    mockCorrectRegisterSessionOpeningFloat.mockResolvedValue(
+      ok({
+        action: "corrected",
       }),
     );
     mockStartSession.mockReset();
@@ -554,6 +572,114 @@ describe("useRegisterViewModel", () => {
       "Return to sale",
     );
     expect(result.current.productEntry.disabled).toBe(true);
+  });
+
+  it("routes register actions through the active-terminal conflict gate", async () => {
+    mockActiveSession = null;
+    mockRegisterState = {
+      ...mockRegisterState!,
+      activeSession: null,
+      activeSessionConflict: {
+        kind: "activeOnOtherTerminal",
+        message: "A session is active for this cashier on a different terminal",
+        terminalId: "terminal-2",
+      },
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    expect(result.current.sessionPanel?.hasExpiredSession).toBe(false);
+    expect(result.current.sessionPanel?.disableNewSession).toBe(false);
+    expect(result.current.closeoutControl?.canCloseout).toBe(true);
+    expect(result.current.closeoutControl?.canCorrectOpeningFloat).toBe(true);
+
+    await act(async () => {
+      await result.current.sessionPanel?.onStartNewSession();
+      result.current.closeoutControl?.onRequestCloseout();
+      result.current.closeoutControl?.onRequestOpeningFloatCorrection();
+    });
+
+    expect(result.current.drawerGate).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Cashier already has an active session on another terminal.",
+    );
+  });
+
+  it("starts a new active sale after other-terminal sessions have expired", async () => {
+    mockActiveSession = null;
+    mockRegisterState = {
+      ...mockRegisterState!,
+      phase: "readyToStart",
+      activeSession: null,
+      activeSessionConflict: null,
+    };
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockStartSession).toHaveBeenCalledWith({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        staffProfileId: "staff-1",
+        registerNumber: "1",
+        registerSessionId: "drawer-1",
+      });
+    });
+    expect(result.current.sessionPanel?.hasExpiredSession).toBe(false);
+  });
+
+  it("corrects the opening float from the active POS register", async () => {
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    expect(result.current.closeoutControl?.canCorrectOpeningFloat).toBe(true);
+
+    act(() => {
+      result.current.closeoutControl?.onRequestOpeningFloatCorrection();
+    });
+
+    expect(result.current.drawerGate?.mode).toBe("openingFloatCorrection");
+    expect(result.current.drawerGate?.currentOpeningFloat).toBe(5_000);
+    expect(result.current.drawerGate?.correctedOpeningFloat).toBe("50");
+    expect(result.current.productEntry.disabled).toBe(true);
+
+    act(() => {
+      result.current.drawerGate?.onCorrectedOpeningFloatChange?.("45.00");
+      result.current.drawerGate?.onCorrectionReasonChange?.("Cashier typo");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmitOpeningFloatCorrection?.();
+    });
+
+    expect(mockCorrectRegisterSessionOpeningFloat).toHaveBeenCalledWith({
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-1",
+      correctedOpeningFloat: 4_500,
+      reason: "Cashier typo",
+      registerSessionId: "drawer-1",
+      storeId: "store-1",
+    });
+    expect(toast.success).toHaveBeenCalledWith("Opening float corrected");
   });
 
   it("reopens a closing register session from the POS drawer gate", async () => {
@@ -1291,15 +1417,15 @@ describe("useRegisterViewModel", () => {
         "item-1" as Id<"posSessionItem">,
         2,
       );
-      await result.current.cart.onRemoveItem(
-        "item-1" as Id<"posSessionItem">,
-      );
+      await result.current.cart.onRemoveItem("item-1" as Id<"posSessionItem">);
       await result.current.cart.onClearCart();
     });
 
     expect(mockAddItem).not.toHaveBeenCalled();
     expect(mockRemoveItem).not.toHaveBeenCalled();
-    expect(mockReleaseSessionInventoryHoldsAndDeleteItems).not.toHaveBeenCalled();
+    expect(
+      mockReleaseSessionInventoryHoldsAndDeleteItems,
+    ).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       "Drawer closed. Open the drawer before updating this sale.",
     );

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -146,15 +146,24 @@ export function useRegisterViewModel(): RegisterViewModel {
   >(null);
   const [drawerOpeningFloat, setDrawerOpeningFloat] = useState("");
   const [drawerNotes, setDrawerNotes] = useState("");
+  const [correctedOpeningFloat, setCorrectedOpeningFloat] = useState("");
+  const [openingFloatCorrectionReason, setOpeningFloatCorrectionReason] =
+    useState("");
   const [closeoutCountedCash, setCloseoutCountedCash] = useState("");
   const [closeoutNotes, setCloseoutNotes] = useState("");
   const [drawerErrorMessage, setDrawerErrorMessage] = useState<string | null>(
     null,
   );
   const [isOpeningDrawer, setIsOpeningDrawer] = useState(false);
+  const [isCorrectingOpeningFloat, setIsCorrectingOpeningFloat] =
+    useState(false);
   const [isSubmittingCloseout, setIsSubmittingCloseout] = useState(false);
   const [isReopeningCloseout, setIsReopeningCloseout] = useState(false);
   const [isCloseoutRequested, setIsCloseoutRequested] = useState(false);
+  const [
+    isOpeningFloatCorrectionRequested,
+    setIsOpeningFloatCorrectionRequested,
+  ] = useState(false);
   const [completedTransactionData, setCompletedTransactionData] =
     useState<RegisterViewModel["checkout"]["completedTransactionData"]>(null);
   const bootstrapInitialized = useRef(false);
@@ -216,6 +225,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     limit: 10,
   });
   const cashier = registerState?.cashier ?? null;
+  const activeSessionConflict = registerState?.activeSessionConflict ?? null;
 
   const {
     startSession: startSessionCommand,
@@ -230,6 +240,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const reopenRegisterSessionCloseout = useMutation(
     api.cashControls.closeouts.reopenRegisterSessionCloseout,
   );
+  const correctRegisterSessionOpeningFloat = useMutation(
+    api.cashControls.closeouts.correctRegisterSessionOpeningFloat,
+  );
   const {
     resumeSession,
     bindSessionToRegisterSession,
@@ -241,9 +254,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   } = useConvexSessionActions();
   const voidSessionRef = useRef<typeof voidSession>(voidSession);
 
-  const activeCartItems = activeSession?.cartItems ?? [];
-  if (activeSession?._id) {
-    unmountSessionRef.current = activeSession._id as Id<"posSession">;
+  const operableActiveSession = activeSession;
+  const activeCartItems = operableActiveSession?.cartItems ?? [];
+  if (operableActiveSession?._id) {
+    unmountSessionRef.current = operableActiveSession._id as Id<"posSession">;
     unmountSessionCartItemCountRef.current = activeCartItems.length;
   }
   voidSessionRef.current = voidSession;
@@ -253,15 +267,15 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const hasActiveCustomerDetails = hasCustomerDetails(customerInfo);
   const hasActiveCartDraft = activeCartItems.length > 0;
-  const hasActivePosSession = Boolean(activeSession?._id);
+  const hasActivePosSession = Boolean(operableActiveSession?._id);
   const activeSessionNeedsRegisterBinding = Boolean(
-    activeSession?._id && !activeSession.registerSessionId,
+    operableActiveSession?._id && !operableActiveSession.registerSessionId,
   );
   const activeSessionHasMismatchedRegisterBinding = Boolean(
-    activeSession?._id &&
-    activeSession.registerSessionId &&
+    operableActiveSession?._id &&
+    operableActiveSession.registerSessionId &&
     activeRegisterSessionId &&
-    activeSession.registerSessionId !== activeRegisterSessionId,
+    operableActiveSession.registerSessionId !== activeRegisterSessionId,
   );
   const activeSessionHasBlockedRegisterBinding =
     activeSessionNeedsRegisterBinding ||
@@ -301,8 +315,17 @@ export function useRegisterViewModel(): RegisterViewModel {
   const activeCloseoutRegisterSession =
     closeoutBlockedRegisterSession ??
     (isCloseoutRequested ? usableActiveRegisterSession : null);
-  const drawerGateMode: "initialSetup" | "recovery" | "closeoutBlocked" =
-    hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
+  const activeOpeningFloatCorrectionRegisterSession =
+    isOpeningFloatCorrectionRequested && usableActiveRegisterSession
+      ? usableActiveRegisterSession
+      : null;
+  const drawerGateMode:
+    | "initialSetup"
+    | "recovery"
+    | "closeoutBlocked"
+    | "openingFloatCorrection" = activeOpeningFloatCorrectionRegisterSession
+    ? "openingFloatCorrection"
+    : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
       ? "closeoutBlocked"
       : hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding
         ? "recovery"
@@ -318,6 +341,25 @@ export function useRegisterViewModel(): RegisterViewModel {
     );
     checkoutStateVersionRef.current = nextVersion;
     return nextVersion;
+  }, []);
+
+  const guardActiveSessionConflict = useCallback(() => {
+    if (!activeSessionConflict) {
+      return false;
+    }
+
+    presentOperatorError(activeSessionConflict.message);
+    return true;
+  }, [activeSessionConflict]);
+
+  const resetDrawerWorkflowState = useCallback(() => {
+    setIsCloseoutRequested(false);
+    setIsOpeningFloatCorrectionRequested(false);
+    setCloseoutCountedCash("");
+    setCloseoutNotes("");
+    setCorrectedOpeningFloat("");
+    setOpeningFloatCorrectionReason("");
+    setDrawerErrorMessage(null);
   }, []);
 
   const resetDraftState = useCallback(
@@ -390,18 +432,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     };
   }, []);
 
-  const handleSessionExpired = useCallback(() => {
-    logger.warn(
-      "[POS] Session expired, clearing cashier and local draft state",
-      {
-        sessionId: activeSession?._id,
-      },
-    );
-    requestBootstrap();
-    syncedSessionId.current = null;
-    resetDraftState();
-  }, [activeSession?._id, requestBootstrap, resetDraftState]);
-
   useEffect(() => {
     requestBootstrap();
   }, [
@@ -413,7 +443,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   useEffect(() => {
-    const sessionId = activeSession?._id ?? null;
+    const sessionId = operableActiveSession?._id ?? null;
     if (sessionId === syncedSessionId.current) {
       return;
     }
@@ -431,10 +461,10 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     checkoutStateVersionRef.current = 0;
-    setCustomerInfo(mapSessionCustomer(activeSession?.customer ?? null));
+    setCustomerInfo(mapSessionCustomer(operableActiveSession?.customer ?? null));
     setPaymentState(
       combinePaymentsByMethod(
-        (activeSession?.payments ?? []).map((payment) => ({
+        (operableActiveSession?.payments ?? []).map((payment) => ({
           id: createPaymentId(),
           method: payment.method as PosPaymentMethod,
           amount: payment.amount,
@@ -442,36 +472,21 @@ export function useRegisterViewModel(): RegisterViewModel {
         })),
       ),
     );
-    setShowCustomerPanel(Boolean(activeSession?.customer));
+    setShowCustomerPanel(Boolean(operableActiveSession?.customer));
     setIsTransactionCompleted(false);
     setCompletedOrderNumber(null);
     setCompletedTransactionData(null);
   }, [
-    activeSession?._id,
-    activeSession?.customer,
-    activeSession?.payments,
+    operableActiveSession?._id,
+    operableActiveSession?.customer,
+    operableActiveSession?.payments,
     isTransactionCompleted,
     setPaymentState,
   ]);
 
-  useEffect(() => {
-    if (!activeSession?.expiresAt) {
-      return;
-    }
-
-    const timeUntilExpiry = activeSession.expiresAt - Date.now();
-    if (timeUntilExpiry <= 0) {
-      handleSessionExpired();
-      return;
-    }
-
-    const timeoutId = setTimeout(handleSessionExpired, timeUntilExpiry);
-    return () => clearTimeout(timeoutId);
-  }, [activeSession?._id, activeSession?.expiresAt, handleSessionExpired]);
-
   const ensureSessionId = useCallback(async () => {
-    if (activeSession?._id) {
-      return activeSession._id as Id<"posSession">;
+    if (operableActiveSession?._id) {
+      return operableActiveSession._id as Id<"posSession">;
     }
 
     if (registerState?.activeSession?._id) {
@@ -509,7 +524,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     bootstrapInitialized.current = true;
     return result.data.sessionId;
   }, [
-    activeSession?._id,
+    operableActiveSession?._id,
     activeRegisterSessionId,
     activeStore?._id,
     staffProfileId,
@@ -567,11 +582,11 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const commitCustomerInfoBestEffort = useCallback(
     async (nextCustomerInfo: CustomerInfo) => {
-      if (!activeSession?._id || !staffProfileId) {
+      if (!operableActiveSession?._id || !staffProfileId) {
         return;
       }
 
-      const sessionId = activeSession._id as Id<"posSession">;
+      const sessionId = operableActiveSession._id as Id<"posSession">;
       const totals = {
         subtotal: activeTotals.subtotal,
         tax: activeTotals.tax,
@@ -614,7 +629,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       await customerCommitQueueRef.current;
     },
     [
-      activeSession?._id,
+      operableActiveSession?._id,
       activeTotals.subtotal,
       activeTotals.tax,
       activeTotals.total,
@@ -636,7 +651,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       amount?: number;
       previousAmount?: number;
     }) => {
-      if (!activeSession?._id || !staffProfileId) {
+      if (!operableActiveSession?._id || !staffProfileId) {
         return;
       }
 
@@ -644,7 +659,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         logger.warn(
           "[POS] Skipped checkout sync while drawer recovery is required",
           {
-            sessionId: activeSession._id,
+            sessionId: operableActiveSession._id,
             stage: args.stage,
           },
         );
@@ -652,7 +667,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       const result = await syncSessionCheckoutState({
-        sessionId: activeSession._id as Id<"posSession">,
+        sessionId: operableActiveSession._id as Id<"posSession">,
         staffProfileId,
         checkoutStateVersion: args.checkoutStateVersion,
         payments: args.nextPayments.map(({ id, ...payment }) => payment),
@@ -664,14 +679,14 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       if (result.kind !== "ok") {
         logger.warn("[POS] Failed to sync checkout state", {
-          sessionId: activeSession._id,
+          sessionId: operableActiveSession._id,
           stage: args.stage,
           error: result.error.message,
         });
       }
     },
     [
-      activeSession?._id,
+      operableActiveSession?._id,
       activeSessionHasBlockedRegisterBinding,
       staffProfileId,
       syncSessionCheckoutState,
@@ -705,14 +720,14 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const holdCurrentSession = useCallback(
     async (reason?: string) => {
-      if (!activeSession || !staffProfileId) {
+      if (!operableActiveSession || !staffProfileId) {
         toast.error(
           "No sale in progress. Start a sale before placing it on hold.",
         );
         return false;
       }
 
-      const persisted = await persistSessionMetadata(activeSession);
+      const persisted = await persistSessionMetadata(operableActiveSession);
       if (!persisted) {
         return false;
       }
@@ -722,7 +737,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           holdSession: holdSessionCommand,
         },
         command: {
-          sessionId: activeSession._id as Id<"posSession">,
+          sessionId: operableActiveSession._id as Id<"posSession">,
           staffProfileId,
           reason,
         },
@@ -740,7 +755,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       return true;
     },
     [
-      activeSession,
+      operableActiveSession,
       staffProfileId,
       holdSessionCommand,
       persistSessionMetadata,
@@ -749,13 +764,13 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
 
   const voidCurrentSession = useCallback(async () => {
-    if (!activeSession) {
+    if (!operableActiveSession) {
       toast.error("No sale in progress. Start a sale before clearing it.");
       return false;
     }
 
     const result = await voidSession({
-      sessionId: activeSession._id as Id<"posSession">,
+      sessionId: operableActiveSession._id as Id<"posSession">,
     });
 
     if (result.kind !== "ok") {
@@ -768,7 +783,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
     toast.success("Sale cleared.");
     return true;
-  }, [activeSession, resetDraftState, voidSession]);
+  }, [operableActiveSession, resetDraftState, voidSession]);
 
   const handleResumeSession = useCallback(
     async (sessionId: Id<"posSession">) => {
@@ -779,8 +794,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         return;
       }
 
-      if (activeSession && activeSession._id !== sessionId) {
-        const hasDraftState = activeSession.cartItems.length > 0;
+      if (operableActiveSession && operableActiveSession._id !== sessionId) {
+        const hasDraftState = operableActiveSession.cartItems.length > 0;
         const handled = hasDraftState
           ? await holdCurrentSession(
               "Auto-held before resuming a different session",
@@ -809,7 +824,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       toast.success("Sale resumed.");
     },
     [
-      activeSession,
+      operableActiveSession,
       staffProfileId,
       holdCurrentSession,
       resumeSession,
@@ -819,6 +834,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
 
   const handleStartNewSession = useCallback(async () => {
+    if (guardActiveSessionConflict()) {
+      return;
+    }
+
     if (!activeStore?._id || !terminal?._id || !staffProfileId) {
       toast.error("Register sign-in required. Sign in before starting a sale.");
       return;
@@ -829,8 +848,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    if (activeSession) {
-      const hasDraftState = activeSession.cartItems.length > 0;
+    if (operableActiveSession) {
+      const hasDraftState = operableActiveSession.cartItems.length > 0;
       const handled = hasDraftState
         ? await holdCurrentSession("Auto-held for new session")
         : true;
@@ -864,11 +883,12 @@ export function useRegisterViewModel(): RegisterViewModel {
     bootstrapInitialized.current = true;
     toast.success("Sale started.");
   }, [
-    activeSession,
+    operableActiveSession,
     activeRegisterSessionId,
     activeStore?._id,
     staffProfileId,
     customerInfo,
+    guardActiveSessionConflict,
     holdCurrentSession,
     registerNumber,
     resetDraftState,
@@ -1058,17 +1078,92 @@ export function useRegisterViewModel(): RegisterViewModel {
     user?._id,
   ]);
 
+  const handleSubmitOpeningFloatCorrection = useCallback(async () => {
+    if (!activeStore?._id || !user?._id || !staffProfileId) {
+      setDrawerErrorMessage(
+        "Register sign-in required. Sign in before correcting opening float.",
+      );
+      return;
+    }
+
+    const registerSessionId =
+      activeOpeningFloatCorrectionRegisterSession?._id as
+        | Id<"registerSession">
+        | undefined;
+
+    if (!registerSessionId) {
+      setDrawerErrorMessage(
+        "Opening float correction unavailable. Refresh the register and try again.",
+      );
+      return;
+    }
+
+    const parsedOpeningFloat = parseDisplayAmountInput(correctedOpeningFloat);
+    if (parsedOpeningFloat === undefined || parsedOpeningFloat < 0) {
+      setDrawerErrorMessage(
+        "Corrected opening float required. Enter a non-negative amount.",
+      );
+      return;
+    }
+
+    const reason = trimOptional(openingFloatCorrectionReason);
+    if (!reason) {
+      setDrawerErrorMessage("Reason required. Add why the float changed.");
+      return;
+    }
+
+    setDrawerErrorMessage(null);
+    setIsCorrectingOpeningFloat(true);
+
+    const result = await runCommand(() =>
+      correctRegisterSessionOpeningFloat({
+        actorStaffProfileId: staffProfileId,
+        actorUserId: user._id,
+        correctedOpeningFloat: parsedOpeningFloat,
+        reason,
+        registerSessionId,
+        storeId: activeStore._id,
+      }),
+    );
+
+    setIsCorrectingOpeningFloat(false);
+
+    if (result.kind !== "ok") {
+      setDrawerErrorMessage(toOperatorMessage(result.error.message));
+      return;
+    }
+
+    setCorrectedOpeningFloat("");
+    setOpeningFloatCorrectionReason("");
+    setIsOpeningFloatCorrectionRequested(false);
+    requestBootstrap();
+    toast.success(
+      result.data?.action === "unchanged"
+        ? "Opening float unchanged"
+        : "Opening float corrected",
+    );
+  }, [
+    activeOpeningFloatCorrectionRegisterSession?._id,
+    activeStore?._id,
+    correctedOpeningFloat,
+    correctRegisterSessionOpeningFloat,
+    openingFloatCorrectionReason,
+    requestBootstrap,
+    staffProfileId,
+    user?._id,
+  ]);
+
   useEffect(() => {
     if (
-      !activeSession?._id ||
-      activeSession.registerSessionId ||
+      !operableActiveSession?._id ||
+      operableActiveSession.registerSessionId ||
       !activeRegisterSessionId ||
       !staffProfileId
     ) {
       return;
     }
 
-    const requestKey = `${activeSession._id}:${activeRegisterSessionId}`;
+    const requestKey = `${operableActiveSession._id}:${activeRegisterSessionId}`;
     if (drawerBindingRequestRef.current === requestKey) {
       return;
     }
@@ -1077,7 +1172,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     void (async () => {
       const result = await bindSessionToRegisterSession({
-        sessionId: activeSession._id as Id<"posSession">,
+        sessionId: operableActiveSession._id as Id<"posSession">,
         staffProfileId,
         registerSessionId: activeRegisterSessionId,
       });
@@ -1092,8 +1187,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     })();
   }, [
     activeRegisterSessionId,
-    activeSession?._id,
-    activeSession?.registerSessionId,
+    operableActiveSession?._id,
+    operableActiveSession?.registerSessionId,
     bindSessionToRegisterSession,
     requestBootstrap,
     staffProfileId,
@@ -1275,7 +1370,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleUpdateQuantity = useCallback(
     async (itemId: Id<"posSessionItem">, quantity: number) => {
-      if (!activeSession || !staffProfileId) {
+      if (!operableActiveSession || !staffProfileId) {
         return;
       }
 
@@ -1286,7 +1381,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         return;
       }
 
-      const item = activeSession.cartItems.find(
+      const item = operableActiveSession.cartItems.find(
         (candidate) => candidate.id === itemId,
       );
       if (!item) {
@@ -1295,7 +1390,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       if (quantity <= 0) {
         const result = await removeItem({
-          sessionId: activeSession._id as Id<"posSession">,
+          sessionId: operableActiveSession._id as Id<"posSession">,
           staffProfileId,
           itemId,
         });
@@ -1317,7 +1412,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           addItem: addItemCommand,
         },
         command: {
-          sessionId: activeSession._id as Id<"posSession">,
+          sessionId: operableActiveSession._id as Id<"posSession">,
           staffProfileId,
           productId: item.productId,
           productSkuId: item.skuId,
@@ -1339,7 +1434,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
     },
     [
-      activeSession,
+      operableActiveSession,
       activeSessionHasBlockedRegisterBinding,
       addItemCommand,
       removeItem,
@@ -1349,7 +1444,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleRemoveItem = useCallback(
     async (itemId: Id<"posSessionItem">) => {
-      if (!activeSession || !staffProfileId) {
+      if (!operableActiveSession || !staffProfileId) {
         return;
       }
 
@@ -1361,7 +1456,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       const result = await removeItem({
-        sessionId: activeSession._id as Id<"posSession">,
+        sessionId: operableActiveSession._id as Id<"posSession">,
         staffProfileId,
         itemId,
       });
@@ -1371,7 +1466,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
     },
     [
-      activeSession,
+      operableActiveSession,
       activeSessionHasBlockedRegisterBinding,
       removeItem,
       staffProfileId,
@@ -1379,7 +1474,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
 
   const handleClearCart = useCallback(async () => {
-    if (!activeSession || !staffProfileId) {
+    if (!operableActiveSession || !staffProfileId) {
       return;
     }
 
@@ -1390,7 +1485,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     const checkoutStateVersion = allocateCheckoutStateVersion();
     const result = await releaseSessionInventoryHoldsAndDeleteItems({
-      sessionId: activeSession._id as Id<"posSession">,
+      sessionId: operableActiveSession._id as Id<"posSession">,
       staffProfileId,
       checkoutStateVersion,
     });
@@ -1403,7 +1498,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     setPaymentState([]);
     toast.success("Sale cleared.");
   }, [
-    activeSession,
+    operableActiveSession,
     activeSessionHasBlockedRegisterBinding,
     allocateCheckoutStateVersion,
     releaseSessionInventoryHoldsAndDeleteItems,
@@ -1525,8 +1620,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
 
   const handleNavigateBack = useCallback(async () => {
-    if (activeSession) {
-      const hasDraftState = activeSession.cartItems.length > 0;
+    if (operableActiveSession) {
+      const hasDraftState = operableActiveSession.cartItems.length > 0;
 
       const handled = hasDraftState
         ? await holdCurrentSession("Navigating away from register")
@@ -1540,7 +1635,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     resetDraftState();
     navigateBack();
   }, [
-    activeSession,
+    operableActiveSession,
     holdCurrentSession,
     voidCurrentSession,
     navigateBack,
@@ -1548,8 +1643,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleCashierSignOut = useCallback(async () => {
-    if (activeSession) {
-      const hasDraftState = activeSession.cartItems.length > 0;
+    if (operableActiveSession) {
+      const hasDraftState = operableActiveSession.cartItems.length > 0;
 
       const handled = hasDraftState
         ? await holdCurrentSession("Signing out")
@@ -1562,7 +1657,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     resetDraftState();
   }, [
-    activeSession,
+    operableActiveSession,
     customerInfo,
     holdCurrentSession,
     resetDraftState,
@@ -1570,14 +1665,14 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleCompleteTransaction = useCallback(async () => {
-    if (!activeSession || !staffProfileId) {
+    if (!operableActiveSession || !staffProfileId) {
       toast.error("No sale in progress. Start a sale before taking payment.");
       return false;
     }
 
     const currentPayments = paymentsRef.current;
 
-    const persisted = await persistSessionMetadata(activeSession);
+    const persisted = await persistSessionMetadata(operableActiveSession);
     if (!persisted) {
       return false;
     }
@@ -1587,7 +1682,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         completeTransaction: completeTransactionCommand,
       },
       command: {
-        sessionId: activeSession._id as Id<"posSession">,
+        sessionId: operableActiveSession._id as Id<"posSession">,
         staffProfileId,
         payments: currentPayments.map((payment) => ({
           method: payment.method,
@@ -1630,7 +1725,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     return true;
   }, [
     activeCartItems,
-    activeSession,
+    operableActiveSession,
     activeTotals.subtotal,
     activeTotals.tax,
     activeTotals.total,
@@ -1762,9 +1857,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const header = useMemo(
     () =>
       buildRegisterHeaderState({
-        isSessionActive: isRegisterSessionActive(activeSession),
+        isSessionActive: isRegisterSessionActive(operableActiveSession),
       }),
-    [activeSession],
+    [operableActiveSession],
   );
 
   const registerInfo = useMemo(
@@ -1782,13 +1877,13 @@ export function useRegisterViewModel(): RegisterViewModel {
   const sessionPanel =
     activeStore?._id && terminal?._id && staffProfileId
       ? {
-          activeSessionNumber: activeSession?.sessionNumber ?? null,
-          activeSessionTraceId: activeSession?.workflowTraceId ?? null,
-          hasExpiredSession: Boolean(
-            activeSession?.expiresAt && activeSession.expiresAt < Date.now(),
+          activeSessionNumber: operableActiveSession?.sessionNumber ?? null,
+          activeSessionTraceId: operableActiveSession?.workflowTraceId ?? null,
+          hasExpiredSession: false,
+          canHoldSession: Boolean(operableActiveSession) && hasActiveCartDraft,
+          disableNewSession: Boolean(
+            operableActiveSession?.status === "active",
           ),
-          canHoldSession: Boolean(activeSession) && hasActiveCartDraft,
-          disableNewSession: Boolean(activeSession?.status === "active"),
           heldSessions:
             heldSessions?.map((session) => ({
               _id: session._id as Id<"posSession">,
@@ -1836,85 +1931,146 @@ export function useRegisterViewModel(): RegisterViewModel {
           onSignOut: handleCashierSignOut,
         }
       : null;
-  const parsedCloseoutCountedCash = parseDisplayAmountInput(closeoutCountedCash);
+  const parsedCloseoutCountedCash =
+    parseDisplayAmountInput(closeoutCountedCash);
   const shouldShowDrawerGate = Boolean(
-    requiresDrawerGate || activeCloseoutRegisterSession,
+    requiresDrawerGate ||
+    activeCloseoutRegisterSession ||
+    activeOpeningFloatCorrectionRegisterSession,
   );
 
   const drawerGate =
     activeStore?._id && terminal?._id && staffProfileId && shouldShowDrawerGate
-      ? drawerGateMode === "closeoutBlocked"
+      ? drawerGateMode === "openingFloatCorrection"
         ? {
             mode: drawerGateMode,
-            isRecovery: closeoutBlockedGateIsRecovery,
             registerLabel: terminal.displayName,
             registerNumber,
             currency: activeStore.currency,
-            closeoutCountedCash,
-            closeoutDraftVariance:
-              parsedCloseoutCountedCash !== undefined &&
-              activeCloseoutRegisterSession
-                ? parsedCloseoutCountedCash -
-                  activeCloseoutRegisterSession.expectedCash
-                : undefined,
-            closeoutNotes,
-            closeoutSecondaryActionLabel: closeoutBlockedRegisterSession
-              ? "Reopen register"
-              : "Return to sale",
-            expectedCash: activeCloseoutRegisterSession?.expectedCash,
+            currentOpeningFloat:
+              activeOpeningFloatCorrectionRegisterSession?.openingFloat,
+            correctedOpeningFloat,
+            correctionReason: openingFloatCorrectionReason,
+            expectedCash:
+              activeOpeningFloatCorrectionRegisterSession?.expectedCash,
             errorMessage: drawerErrorMessage,
-            isCloseoutSubmitting: isSubmittingCloseout,
-            isReopeningCloseout,
-            onCloseoutCountedCashChange: (value: string) => {
-              setCloseoutCountedCash(value);
+            isCorrectingOpeningFloat,
+            onCancelOpeningFloatCorrection: () => {
+              setCorrectedOpeningFloat("");
+              setOpeningFloatCorrectionReason("");
+              setIsOpeningFloatCorrectionRequested(false);
               setDrawerErrorMessage(null);
             },
-            onCloseoutNotesChange: (value: string) => {
-              setCloseoutNotes(value);
+            onCorrectedOpeningFloatChange: (value: string) => {
+              setCorrectedOpeningFloat(value);
               setDrawerErrorMessage(null);
             },
-            onSubmitCloseout: handleSubmitRegisterCloseout,
-            onReopenRegister: handleReopenRegisterCloseout,
+            onCorrectionReasonChange: (value: string) => {
+              setOpeningFloatCorrectionReason(value);
+              setDrawerErrorMessage(null);
+            },
+            onSubmitOpeningFloatCorrection: handleSubmitOpeningFloatCorrection,
             onSignOut: handleCashierSignOut,
           }
-        : {
-            mode: drawerGateMode,
-            registerLabel: terminal.displayName,
-            registerNumber,
-            currency: activeStore.currency,
-            openingFloat: drawerOpeningFloat,
-            notes: drawerNotes,
-            errorMessage:
-              drawerErrorMessage ??
-              (activeSessionHasMismatchedRegisterBinding
-                ? "Sale assigned to a different drawer. Open that drawer before continuing."
-                : null),
-            isSubmitting: isOpeningDrawer,
-            onOpeningFloatChange: (value: string) => {
-              setDrawerOpeningFloat(value);
-              setDrawerErrorMessage(null);
-            },
-            onNotesChange: (value: string) => {
-              setDrawerNotes(value);
-              setDrawerErrorMessage(null);
-            },
-            onSubmit: handleOpenDrawer,
-            onSignOut: handleCashierSignOut,
-          }
+        : drawerGateMode === "closeoutBlocked"
+          ? {
+              mode: drawerGateMode,
+              isRecovery: closeoutBlockedGateIsRecovery,
+              registerLabel: terminal.displayName,
+              registerNumber,
+              currency: activeStore.currency,
+              closeoutCountedCash,
+              closeoutDraftVariance:
+                parsedCloseoutCountedCash !== undefined &&
+                activeCloseoutRegisterSession
+                  ? parsedCloseoutCountedCash -
+                    activeCloseoutRegisterSession.expectedCash
+                  : undefined,
+              closeoutNotes,
+              closeoutSecondaryActionLabel: closeoutBlockedRegisterSession
+                ? "Reopen register"
+                : "Return to sale",
+              expectedCash: activeCloseoutRegisterSession?.expectedCash,
+              errorMessage: drawerErrorMessage,
+              isCloseoutSubmitting: isSubmittingCloseout,
+              isReopeningCloseout,
+              onCloseoutCountedCashChange: (value: string) => {
+                setCloseoutCountedCash(value);
+                setDrawerErrorMessage(null);
+              },
+              onCloseoutNotesChange: (value: string) => {
+                setCloseoutNotes(value);
+                setDrawerErrorMessage(null);
+              },
+              onSubmitCloseout: handleSubmitRegisterCloseout,
+              onReopenRegister: handleReopenRegisterCloseout,
+              onSignOut: handleCashierSignOut,
+            }
+          : {
+              mode: drawerGateMode,
+              registerLabel: terminal.displayName,
+              registerNumber,
+              currency: activeStore.currency,
+              openingFloat: drawerOpeningFloat,
+              notes: drawerNotes,
+              errorMessage:
+                drawerErrorMessage ??
+                (activeSessionHasMismatchedRegisterBinding
+                  ? "Sale assigned to a different drawer. Open that drawer before continuing."
+                  : null),
+              isSubmitting: isOpeningDrawer,
+              onOpeningFloatChange: (value: string) => {
+                setDrawerOpeningFloat(value);
+                setDrawerErrorMessage(null);
+              },
+              onNotesChange: (value: string) => {
+                setDrawerNotes(value);
+                setDrawerErrorMessage(null);
+              },
+              onSubmit: handleOpenDrawer,
+              onSignOut: handleCashierSignOut,
+            }
       : null;
   const closeoutControl =
     activeStore?._id && terminal?._id && staffProfileId
       ? {
           canCloseout: Boolean(
             usableActiveRegisterSession &&
-              !requiresDrawerGate &&
-              !hasActiveCartDraft &&
-              payments.length === 0 &&
-              !isTransactionCompleted,
+            !requiresDrawerGate &&
+            !isOpeningFloatCorrectionRequested &&
+            !hasActiveCartDraft &&
+            payments.length === 0 &&
+            !isTransactionCompleted,
+          ),
+          canCorrectOpeningFloat: Boolean(
+            usableActiveRegisterSession &&
+            !requiresDrawerGate &&
+            !isCloseoutRequested &&
+            !isTransactionCompleted,
           ),
           onRequestCloseout: () => {
+            if (guardActiveSessionConflict()) {
+              return;
+            }
+
             setProductSearchQuery("");
             setIsCloseoutRequested(true);
+            setIsOpeningFloatCorrectionRequested(false);
+            setDrawerErrorMessage(null);
+          },
+          onRequestOpeningFloatCorrection: () => {
+            if (guardActiveSessionConflict()) {
+              return;
+            }
+
+            if (usableActiveRegisterSession) {
+              setCorrectedOpeningFloat(
+                String(usableActiveRegisterSession.openingFloat / 100),
+              );
+            }
+            setProductSearchQuery("");
+            setIsCloseoutRequested(false);
+            setIsOpeningFloatCorrectionRequested(true);
             setDrawerErrorMessage(null);
           },
         }

--- a/packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx
+++ b/packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx
@@ -1,0 +1,429 @@
+import type { CSSProperties } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { cn } from "@/lib/utils";
+
+import {
+  StorybookCallout,
+  StorybookSection,
+  StorybookShell,
+} from "../storybook-shell";
+
+type AppColorTokenStyle = CSSProperties & Record<`--app-${string}`, string>;
+
+const APP_COLOR_TOKENS: AppColorTokenStyle = {
+  "--app-canvas": "42 44% 98%",
+  "--app-surface": "0 0% 100%",
+  "--app-surface-subtle": "38 34% 94%",
+  "--app-border": "218 17% 86%",
+  "--app-text": "222 28% 16%",
+  "--app-text-muted": "219 12% 39%",
+  "--app-shell": "223 34% 14%",
+  "--app-shell-text": "35 42% 95%",
+
+  "--app-action-commit": "338 62% 43%",
+  "--app-action-commit-text": "336 100% 98%",
+  "--app-action-workflow": "232 42% 45%",
+  "--app-action-workflow-text": "232 100% 98%",
+  "--app-action-workflow-soft": "232 58% 96%",
+  "--app-action-workflow-border": "232 38% 82%",
+  "--app-action-neutral": "215 18% 37%",
+  "--app-action-neutral-soft": "220 20% 96%",
+
+  "--app-success": "151 42% 34%",
+  "--app-success-soft": "146 48% 94%",
+  "--app-warning": "35 79% 52%",
+  "--app-warning-soft": "39 92% 93%",
+  "--app-danger": "4 71% 54%",
+  "--app-danger-soft": "4 84% 96%",
+  "--app-info": "205 56% 38%",
+  "--app-info-soft": "204 68% 95%",
+
+  "--app-data-1": "338 62% 43%",
+  "--app-data-2": "232 42% 45%",
+  "--app-data-3": "156 40% 34%",
+  "--app-data-4": "37 82% 59%",
+  "--app-data-5": "278 34% 48%",
+};
+
+type ColorRole = {
+  name: string;
+  token: string;
+  value: string;
+  textToken?: string;
+  description: string;
+  use: string;
+};
+
+const CORE_ROLES: ColorRole[] = [
+  {
+    name: "Canvas",
+    token: "--background",
+    value: "42 44% 98%",
+    description: "The default app page background.",
+    use: "Workspace backgrounds, app shell content area.",
+  },
+  {
+    name: "Surface",
+    token: "--surface-raised",
+    value: "0 0% 100%",
+    description: "Primary elevated working surface.",
+    use: "Cards, forms, rails, dialogs, popovers.",
+  },
+  {
+    name: "Subtle Surface",
+    token: "--surface-muted",
+    value: "38 34% 94%",
+    description: "Quiet surface for grouped controls.",
+    use: "Table headers, nested panels, inactive rows.",
+  },
+  {
+    name: "Border",
+    token: "--border",
+    value: "218 17% 86%",
+    description: "Low-contrast structural boundary.",
+    use: "Cards, dividers, inputs, table rows.",
+  },
+  {
+    name: "Text",
+    token: "--foreground",
+    value: "222 28% 16%",
+    description: "Primary reading color.",
+    use: "Headings, body text, critical values.",
+  },
+  {
+    name: "Muted Text",
+    token: "--muted-foreground",
+    value: "219 12% 39%",
+    description: "Secondary text without disappearing.",
+    use: "Labels, helper text, timestamps, metadata.",
+  },
+];
+
+const ACTION_ROLES: ColorRole[] = [
+  {
+    name: "Commit",
+    token: "--action-commit",
+    value: "338 62% 43%",
+    textToken: "--action-commit-foreground",
+    description: "Final or high-consequence action.",
+    use: "Submit correction, complete sale, close drawer, confirm.",
+  },
+  {
+    name: "Workflow",
+    token: "--action-workflow",
+    value: "232 42% 45%",
+    textToken: "--action-workflow-foreground",
+    description: "Enter, inspect, or navigate a reversible tool state.",
+    use: "Correct, view trace, selected correction, lookup workflows.",
+  },
+  {
+    name: "Neutral",
+    token: "--action-neutral",
+    value: "215 18% 37%",
+    description: "Useful but secondary utility action.",
+    use: "View receipt, cancel, exit, dismiss.",
+  },
+];
+
+const STATUS_ROLES: ColorRole[] = [
+  {
+    name: "Success",
+    token: "--success",
+    value: "151 42% 34%",
+    description: "Completed or healthy state.",
+    use: "Completed sale, active session, successful sync.",
+  },
+  {
+    name: "Warning",
+    token: "--warning",
+    value: "35 79% 52%",
+    description: "Attention without failure.",
+    use: "Pending counts, variance review, degraded workflow.",
+  },
+  {
+    name: "Danger",
+    token: "--danger",
+    value: "4 71% 54%",
+    description: "Failed, destructive, or blocking state.",
+    use: "Voids, destructive actions, negative variance.",
+  },
+  {
+    name: "Info",
+    token: "--info",
+    value: "205 56% 38%",
+    description: "Operational context and review states.",
+    use: "Trace metadata, informative banners, workflow notes.",
+  },
+];
+
+const DATA_ROLES: ColorRole[] = [
+  { name: "Data 1", token: "--chart-1", value: "338 62% 43%", description: "Primary business measure.", use: "Revenue or primary metric." },
+  { name: "Data 2", token: "--chart-2", value: "232 42% 45%", description: "Secondary comparison measure.", use: "Orders, sessions, or conversion." },
+  { name: "Data 3", token: "--chart-3", value: "156 40% 34%", description: "Positive operational measure.", use: "Completion, retention, stock health." },
+  { name: "Data 4", token: "--chart-4", value: "37 82% 59%", description: "Attention measure.", use: "Pending, review, variance." },
+  { name: "Data 5", token: "--chart-5", value: "278 34% 48%", description: "Tertiary distinction.", use: "Optional segment in dense charts." },
+];
+
+function TokenScope({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-[calc(var(--radius)*1.35)] bg-[hsl(var(--app-canvas))] p-5 text-[hsl(var(--app-text))]"
+      style={APP_COLOR_TOKENS}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Swatch({ role }: { role: ColorRole }) {
+  return (
+    <div className="rounded-lg border border-[hsl(var(--app-border))] bg-[hsl(var(--app-surface))] p-3">
+      <div
+        className="h-16 rounded-md border border-black/5"
+        style={{ background: `hsl(${role.value})` }}
+      />
+      <div className="mt-3 space-y-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="text-sm font-semibold">{role.name}</p>
+          <code className="text-[11px] text-[hsl(var(--app-text-muted))]">
+            {role.token}
+          </code>
+        </div>
+        <p className="text-xs text-[hsl(var(--app-text-muted))]">{role.value}</p>
+        <p className="text-xs leading-5 text-[hsl(var(--app-text-muted))]">
+          {role.use}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SwatchGrid({ roles }: { roles: ColorRole[] }) {
+  return (
+    <TokenScope>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {roles.map((role) => (
+          <Swatch key={role.token} role={role} />
+        ))}
+      </div>
+    </TokenScope>
+  );
+}
+
+function AppButton({
+  children,
+  tone,
+}: {
+  children: string;
+  tone: "commit" | "workflow" | "workflowSoft" | "neutral" | "danger";
+}) {
+  const className =
+    tone === "commit"
+      ? "border-[hsl(var(--app-action-commit))] bg-[hsl(var(--app-action-commit))] text-[hsl(var(--app-action-commit-text))] hover:bg-[hsl(var(--app-action-commit)/0.9)]"
+      : tone === "workflow"
+        ? "border-[hsl(var(--app-action-workflow))] bg-[hsl(var(--app-action-workflow))] text-[hsl(var(--app-action-workflow-text))] hover:bg-[hsl(var(--app-action-workflow)/0.9)]"
+        : tone === "workflowSoft"
+          ? "border-[hsl(var(--app-action-workflow-border))] bg-[hsl(var(--app-action-workflow-soft))] text-[hsl(var(--app-action-workflow))] hover:bg-[hsl(var(--app-action-workflow-soft)/0.74)]"
+          : tone === "danger"
+            ? "border-[hsl(var(--app-danger))] bg-[hsl(var(--app-danger))] text-white hover:bg-[hsl(var(--app-danger)/0.9)]"
+            : "border-[hsl(var(--app-border))] bg-[hsl(var(--app-surface))] text-[hsl(var(--app-action-neutral))] hover:bg-[hsl(var(--app-action-neutral-soft))]";
+
+  return (
+    <button
+      className={cn(
+        "inline-flex h-10 items-center justify-center rounded-md border px-4 text-sm font-medium transition-colors",
+        className,
+      )}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+function StatusPill({
+  label,
+  tone,
+}: {
+  label: string;
+  tone: "success" | "warning" | "danger" | "info";
+}) {
+  const className = {
+    success:
+      "border-[hsl(var(--app-success)/0.2)] bg-[hsl(var(--app-success-soft))] text-[hsl(var(--app-success))]",
+    warning:
+      "border-[hsl(var(--app-warning)/0.28)] bg-[hsl(var(--app-warning-soft))] text-[hsl(var(--app-warning))]",
+    danger:
+      "border-[hsl(var(--app-danger)/0.24)] bg-[hsl(var(--app-danger-soft))] text-[hsl(var(--app-danger))]",
+    info: "border-[hsl(var(--app-info)/0.22)] bg-[hsl(var(--app-info-soft))] text-[hsl(var(--app-info))]",
+  }[tone];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex rounded-full border px-3 py-1 text-xs font-semibold",
+        className,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ProductFitExample() {
+  return (
+    <TokenScope>
+      <div className="grid gap-5 lg:grid-cols-[320px_1fr]">
+        <div className="overflow-hidden rounded-xl border border-[hsl(var(--app-border))] bg-[hsl(var(--app-surface))]">
+          <div className="space-y-4 border-b border-[hsl(var(--app-border))] p-5">
+            <StatusPill label="Completed · 2 hours ago" tone="success" />
+            <dl className="grid gap-4 text-sm">
+              <div>
+                <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-[hsl(var(--app-text-muted))]">
+                  Cashier
+                </dt>
+                <dd className="mt-1 font-medium">Kwamina M.</dd>
+              </div>
+              <div>
+                <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-[hsl(var(--app-text-muted))]">
+                  Payment
+                </dt>
+                <dd className="mt-1 font-medium">Mobile Money</dd>
+              </div>
+            </dl>
+            <div className="grid grid-cols-2 gap-3">
+              <AppButton tone="workflow">Correct</AppButton>
+              <AppButton tone="neutral">View receipt</AppButton>
+            </div>
+          </div>
+          <div className="space-y-4 p-5">
+            <h3 className="text-lg font-semibold">Transaction correction</h3>
+            <div className="space-y-2">
+              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-[hsl(var(--app-text-muted))]">
+                Direct corrections
+              </p>
+              <AppButton tone="workflowSoft">Customer attribution</AppButton>
+              <div className="rounded-lg border border-[hsl(var(--app-border))] bg-[hsl(var(--app-surface-subtle))] p-4">
+                <p className="text-sm font-medium">Customer correction</p>
+                <p className="mt-1 text-sm leading-6 text-[hsl(var(--app-text-muted))]">
+                  Staff sign-in and customer lookup will update attribution only.
+                </p>
+                <div className="mt-3">
+                  <AppButton tone="commit">Submit customer correction</AppButton>
+                </div>
+              </div>
+              <AppButton tone="neutral">Payment method</AppButton>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[hsl(var(--app-border))] bg-[hsl(var(--app-surface))] p-5">
+          <div className="flex flex-wrap gap-2">
+            <StatusPill label="Active" tone="success" />
+            <StatusPill label="Needs count" tone="warning" />
+            <StatusPill label="Variance" tone="danger" />
+            <StatusPill label="Trace available" tone="info" />
+          </div>
+          <div className="mt-6 grid h-48 grid-cols-5 items-end gap-3 rounded-lg bg-[hsl(var(--app-surface-subtle))] p-4">
+            {DATA_ROLES.map((role, index) => (
+              <div
+                key={role.token}
+                className="rounded-t-md"
+                style={{
+                  background: `hsl(${role.value})`,
+                  height: `${42 + index * 12}%`,
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </TokenScope>
+  );
+}
+
+function AppColorSystemPage() {
+  return (
+    <StorybookShell
+      eyebrow="Foundations"
+      title="App Color System"
+      description="Storybook-only proposal for the semantic colors Athena should use across product UI before any product token changes."
+    >
+      <StorybookSection
+        title="System rule"
+        description="Colors should communicate role before mood. A user should be able to tell whether something is a surface, a workflow action, a final commit, a status, or a data series without decoding the local feature."
+      >
+        <div className="grid gap-4 md:grid-cols-3">
+          <StorybookCallout title="Foundation">
+            Neutral surfaces and text do most of the work. They should stay calm,
+            readable, and consistent across admin workflows.
+          </StorybookCallout>
+          <StorybookCallout title="Actions">
+            Split reversible workflow actions from final commit actions. This
+            keeps orange from becoming the only way to say “important.”
+          </StorybookCallout>
+          <StorybookCallout title="Status and data">
+            Status colors describe state. Chart colors describe comparison. They
+            can share hues, but not component meaning.
+          </StorybookCallout>
+        </div>
+      </StorybookSection>
+
+      <StorybookSection
+        title="Core neutrals"
+        description="The app should feel quiet and operational before any accent appears."
+      >
+        <SwatchGrid roles={CORE_ROLES} />
+      </StorybookSection>
+
+      <StorybookSection
+        title="Action roles"
+        description="This is the core change: keep warm signal for final commits, add a cooler workflow role for reversible mode changes and selections."
+      >
+        <SwatchGrid roles={ACTION_ROLES} />
+        <TokenScope>
+          <div className="flex flex-wrap gap-2">
+            <AppButton tone="commit">Submit correction</AppButton>
+            <AppButton tone="workflow">Correct</AppButton>
+            <AppButton tone="workflowSoft">Selected correction</AppButton>
+            <AppButton tone="neutral">View receipt</AppButton>
+            <AppButton tone="danger">Void transaction</AppButton>
+          </div>
+        </TokenScope>
+      </StorybookSection>
+
+      <StorybookSection
+        title="Status roles"
+        description="Status tokens should be constrained to state labels, banners, and operational feedback."
+      >
+        <SwatchGrid roles={STATUS_ROLES} />
+      </StorybookSection>
+
+      <StorybookSection
+        title="Data roles"
+        description="Chart colors remain a separate sequence so reports do not overload action or status semantics."
+      >
+        <SwatchGrid roles={DATA_ROLES} />
+      </StorybookSection>
+
+      <StorybookSection
+        title="Product fit"
+        description="The same palette applied to the POS correction problem and a compact operational chart."
+      >
+        <ProductFitExample />
+      </StorybookSection>
+    </StorybookShell>
+  );
+}
+
+const meta = {
+  title: "Foundations/App Color System",
+  component: AppColorSystemPage,
+} satisfies Meta<typeof AppColorSystemPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};

--- a/packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx
+++ b/packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx
@@ -55,5 +55,8 @@ describe("AthenaFoundationsPage", () => {
     expect(indexCss).toContain("--sidebar-border: 220 16% 88%;");
     expect(indexCss).toContain("--border: 220 16% 88%;");
     expect(indexCss).toContain("--input: 220 16% 88%;");
+    expect(indexCss).toContain("--action-commit: 338 62% 43%;");
+    expect(indexCss).toContain("--action-workflow: 232 42% 45%;");
+    expect(indexCss).toContain("--action-workflow-soft: 232 58% 96%;");
   });
 });

--- a/packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx
+++ b/packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx
@@ -28,6 +28,9 @@ function ControlsShowcase() {
         <div className="grid gap-4">
           <div className="flex flex-wrap gap-2">
             <Button>Primary</Button>
+            <Button variant="workflow">Workflow</Button>
+            <Button variant="workflow-soft">Selected workflow</Button>
+            <Button variant="utility">Utility</Button>
             <Button variant="secondary">Secondary</Button>
             <Button variant="outline">Outline</Button>
             <Button variant="ghost">Ghost</Button>

--- a/packages/athena-webapp/tailwind.config.js
+++ b/packages/athena-webapp/tailwind.config.js
@@ -87,6 +87,16 @@ export default {
           DEFAULT: "hsl(var(--signal))",
           foreground: "hsl(var(--signal-foreground))",
         },
+        action: {
+          commit: "hsl(var(--action-commit))",
+          "commit-foreground": "hsl(var(--action-commit-foreground))",
+          workflow: "hsl(var(--action-workflow))",
+          "workflow-foreground": "hsl(var(--action-workflow-foreground))",
+          "workflow-soft": "hsl(var(--action-workflow-soft))",
+          "workflow-border": "hsl(var(--action-workflow-border))",
+          neutral: "hsl(var(--action-neutral))",
+          "neutral-soft": "hsl(var(--action-neutral-soft))",
+        },
         success: {
           DEFAULT: "hsl(var(--success))",
           foreground: "hsl(var(--success-foreground))",

--- a/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
@@ -106,12 +106,15 @@ function SummaryItem({
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center space-x-4">
-        <div className="h-12 w-12 rounded-lg overflow-hidden">
+        <div className="relative">
           <img
             src={item.productImage || fallbackImageUrl || placeholder}
             alt={item.productName || "product image"}
-            className="aspect-square object-cover rounded-lg"
+            className="w-12 h-12 aspect-square object-cover rounded-lg"
           />
+          <div className="absolute -top-2 -right-2 bg-background/90 text-primary text-xs font-medium w-4 h-4 rounded-full shadow-md flex items-center justify-center">
+            {item.quantity}
+          </div>
         </div>
         <div className="space-y-2">
           <p className="text-sm font-medium">{getProductName(item)}</p>
@@ -142,7 +145,7 @@ function SummaryItem({
           )}
         </div>
       </div>
-      <p className="text-xs text-muted-foreground">{`x ${item.quantity}`}</p>
+      {/* <p className="text-xs text-muted-foreground">{`x ${item.quantity}`}</p> */}
     </div>
   );
 }

--- a/packages/storefront-webapp/src/components/checkout/BillingDetails.tsx
+++ b/packages/storefront-webapp/src/components/checkout/BillingDetails.tsx
@@ -236,7 +236,7 @@ export const BillingDetailsForm = () => {
             {!hasEnteredBillingDetails && user?.billingAddress && (
               <div className="ml-auto flex items-center gap-2">
                 <Checkbox
-                  className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+                  className="h-4 w-4 text-primary border-gray-300"
                   onCheckedChange={(e) => handleUseBillingAddressOnFile(e)}
                 />
                 <label htmlFor="same-as-delivery" className="text-sm">
@@ -253,7 +253,7 @@ export const BillingDetailsForm = () => {
                   checkoutState.billingDetails?.billingAddressSameAsDelivery
                 )}
                 onCheckedChange={(e) => toggleSameAsDelivery(e)}
-                className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+                className="h-4 w-4 text-primary border-gray-300"
               />
               <label htmlFor="same-as-delivery" className="text-sm">
                 Same as delivery address
@@ -328,7 +328,7 @@ export const BillingDetailsForm = () => {
                         </FormLabel>
                         <FormControl>
                           <select
-                            className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                            className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                             value={field.value}
                             onChange={(e) => {
                               const selectedValue = e.target.value;

--- a/packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx
@@ -103,7 +103,7 @@ export const BillingDetailsSection = ({ form }: CheckoutFormSectionProps) => {
         {!hasEnteredBillingDetails && user?.billingAddress && (
           <div className="ml-auto flex items-center gap-2">
             <Checkbox
-              className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+              className="h-4 w-4 text-primary border-gray-300"
               onCheckedChange={(e) => handleUseBillingAddressOnFile(e)}
             />
             <label htmlFor="same-as-delivery" className="text-sm">
@@ -121,7 +121,7 @@ export const BillingDetailsSection = ({ form }: CheckoutFormSectionProps) => {
             )}
             disabled={checkoutState.didEnterDeliveryDetails == false}
             onCheckedChange={(e) => toggleSameAsDelivery(e)}
-            className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+            className="h-4 w-4 text-primary border-gray-300"
           />
           <label htmlFor="same-as-delivery" className="text-sm">
             Same as delivery address
@@ -192,7 +192,7 @@ export const BillingDetailsSection = ({ form }: CheckoutFormSectionProps) => {
                     </FormLabel>
                     <FormControl>
                       <select
-                        className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                        className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                         value={field.value}
                         onChange={(e) => {
                           const selectedValue = e.target.value;
@@ -338,7 +338,7 @@ export const BillingDetailsSection = ({ form }: CheckoutFormSectionProps) => {
                           </FormLabel>
                           <FormControl>
                             <select
-                              className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                              className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                               value={field.value}
                               onChange={(e) => {
                                 const selectedValue = e.target.value;

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
@@ -83,7 +83,7 @@ export const CountryFields = ({ form }: CheckoutFormSectionProps) => {
               </FormLabel>
               <FormControl>
                 <select
-                  className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                  className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                   value={field.value}
                   onChange={(e) => {
                     const selectedValue = e.target.value;
@@ -137,7 +137,7 @@ const RegionFields = ({ form }: CheckoutFormSectionProps) => {
                 </FormLabel>
                 <FormControl>
                   <select
-                    className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                    className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                     value={field.value}
                     onChange={(e) => {
                       const region = e.target.value;
@@ -307,7 +307,7 @@ const StateFields = ({ form }: CheckoutFormSectionProps) => {
               </FormLabel>
               <FormControl>
                 <select
-                  className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                  className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                   value={field.value}
                   onChange={(e) => {
                     const selectedValue = e.target.value;
@@ -569,7 +569,7 @@ const GhanaAddressLocaleFields = ({
               !isEnteringNewNeighborhood ? (
                 <FormControl>
                   <select
-                    className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                    className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                     value={field.value}
                     onChange={(e) => {
                       updateState({

--- a/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
@@ -321,7 +321,7 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
                 <Checkbox
                   checked={didAcceptStoreTerms}
                   onCheckedChange={(e) => handleAcceptedTerms("store-terms", e)}
-                  className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+                  className="h-4 w-4 text-primary border-gray-300"
                 />
                 <label
                   htmlFor="terms"
@@ -341,7 +341,7 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
                 <Checkbox
                   checked={didAcceptCommsTerms}
                   onCheckedChange={(e) => handleAcceptedTerms("comms-terms", e)}
-                  className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+                  className="h-4 w-4 text-primary border-gray-300"
                 />
                 <label htmlFor="terms" className="text-sm">
                   I agree to receive communications via email and/or SMS to any

--- a/packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx
+++ b/packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx
@@ -224,7 +224,7 @@ export const DeliveryDetailsForm = ({
                     </FormLabel>
                     <FormControl>
                       <select
-                        className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                        className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                         value={field.value}
                         onChange={(e) => {
                           const selectedValue = e.target.value;
@@ -297,7 +297,7 @@ export const DeliveryDetailsForm = ({
                       </FormLabel>
                       <FormControl>
                         <select
-                          className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary text-sm"
+                          className="block w-full px-3 py-8 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:border-primary text-sm"
                           value={field.value}
                           onChange={(e) => {
                             const region = e.target.value;

--- a/packages/storefront-webapp/src/components/ui/badge.tsx
+++ b/packages/storefront-webapp/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none",
   {
     variants: {
       variant: {

--- a/packages/storefront-webapp/src/components/ui/button.tsx
+++ b/packages/storefront-webapp/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/packages/storefront-webapp/src/components/ui/checkbox.tsx
+++ b/packages/storefront-webapp/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}

--- a/packages/storefront-webapp/src/components/ui/dialog.tsx
+++ b/packages/storefront-webapp/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/storefront-webapp/src/components/ui/input-otp.tsx
+++ b/packages/storefront-webapp/src/components/ui/input-otp.tsx
@@ -40,7 +40,7 @@ const InputOTPSlot = React.forwardRef<
       ref={ref}
       className={cn(
         "relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
-        isActive && "z-10 ring-2 ring-ring ring-offset-background",
+        isActive && "z-10",
         className
       )}
       {...props}

--- a/packages/storefront-webapp/src/components/ui/input-with-end-button.tsx
+++ b/packages/storefront-webapp/src/components/ui/input-with-end-button.tsx
@@ -37,7 +37,7 @@ export default function InputWithEndButton({
           onClick={onButtonClick}
           type="button"
           disabled={isLoading}
-          className="inline-flex items-center rounded-e-lg border border-input bg-background px-3 text-sm font-medium text-foreground outline-offset-2 transition-colors hover:bg-accent2 hover:text-white focus:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring/70 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center rounded-e-lg border border-input bg-background px-3 text-sm font-medium text-foreground outline-offset-2 transition-colors hover:bg-accent2 hover:text-white focus:z-10 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {!isLoading && buttonText}
           {isLoading && (

--- a/packages/storefront-webapp/src/components/ui/input.tsx
+++ b/packages/storefront-webapp/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/packages/storefront-webapp/src/components/ui/radio-group.tsx
+++ b/packages/storefront-webapp/src/components/ui/radio-group.tsx
@@ -26,7 +26,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/packages/storefront-webapp/src/components/ui/select.tsx
+++ b/packages/storefront-webapp/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/packages/storefront-webapp/src/components/ui/sheet.tsx
+++ b/packages/storefront-webapp/src/components/ui/sheet.tsx
@@ -64,7 +64,7 @@ const SheetContent = React.forwardRef<
       onOpenAutoFocus={(e) => e.preventDefault()}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/packages/storefront-webapp/src/components/ui/tabs.tsx
+++ b/packages/storefront-webapp/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 focus-visible:outline-none",
       className
     )}
     {...props}

--- a/packages/storefront-webapp/src/components/ui/textarea.tsx
+++ b/packages/storefront-webapp/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/packages/storefront-webapp/src/components/ui/toggle.tsx
+++ b/packages/storefront-webapp/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- deliver the local main storefront checkout controls and POS correction workflow work
- harden POS register recovery so signing out from other registers immediately expires other-terminal sessions, releases holds, and lets the new terminal become active
- align register action gating, cash-control correction UI, operator copy, design tokens, tests, and graphify artifacts with the delivered local state

## Test Plan
- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/useRegisterViewModel.test.ts convex/inventory/posSessions.trace.test.ts src/components/pos/CashierAuthDialog.test.tsx convex/pos/application/getRegisterState.test.ts src/lib/errors/operatorMessages.test.ts convex/operations/staffCredentials.test.ts`
- `bun run --filter '@athena/webapp' test -- src/components/ui/primitives.test.tsx`
- `bun run --filter '@athena/webapp' build`
- `git push -u origin HEAD` pre-push suite: graphify check, architecture checks, full webapp tests, changed Convex lint, TypeScript, webapp build, Storybook build, storefront tests, behavior scenarios, inferential review
