### PR TITLE
[V26-430]: Auto-repair generated harness docs before validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ It targets repo-root `scripts/*.test.ts` files only (excluding cloned worktree t
 Use `bun run harness:test -- --dry-run` to print the selected files without executing tests.
 The repo pins Bun via `package.json` (`bun@1.1.29` today), and GitHub Actions reads that same repo-declared version so CI and local harness runs stay aligned.
 
-`pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild` and stages the tracked graphify outputs before the commit is finalized, so the pushed ref includes the refreshed graph artifacts.
+`pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`, then stages the tracked generated harness docs and graphify outputs before the commit is finalized, so the pushed ref includes refreshed generated artifacts.
+`bun run pr:athena` starts with that same generated-artifact repair step before the blocking harness checks, so deterministic generated-doc drift is repaired locally instead of failing as stale docs.
 `pre-push:review` starts with `bun run graphify:check` before the rest of the local validation suite. If tracked graphify artifacts are stale, the hook runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops so you can review and commit the repaired graphify artifacts before pushing again.
 If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs, the hook runs `bun run harness:generate` once, retries the blocked step on the repaired tree, and:
 - Blocks so you can review, commit, and push the repaired generated docs instead of sending a stale ref to CI.
@@ -222,7 +223,7 @@ Use [the packages agent router](./packages/AGENTS.md) plus each package's `AGENT
 
 Use `bun run graphify:check` as the freshness gate for tracked graphify artifacts.
 
-Use `bun run graphify:rebuild` as the repair path when the check reports stale artifacts. The rebuild command uses the interpreter recorded in `.graphify_python` (default `python3` in this repo). Local `pre-commit:generated-artifacts` runs this repair step and stages the tracked graphify outputs before the commit is finalized. `pre-push:review` can also run this repair once for stale tracked graphify artifacts, reruns `bun run graphify:check`, and then blocks until you commit the repaired tracked artifacts.
+Use `bun run graphify:rebuild` as the repair path when the check reports stale artifacts. The rebuild command uses the interpreter recorded in `.graphify_python` (default `python3` in this repo). Local `pre-commit:generated-artifacts` runs this repair step with `bun run harness:generate` and stages the tracked graphify outputs plus generated harness docs before the commit is finalized. `pre-push:review` can also run this repair once for stale tracked graphify artifacts, reruns `bun run graphify:check`, and then blocks until you commit the repaired tracked artifacts.
 
 If you need to repair the local graphify setup, install the repo-pinned runtime with `python3 -m pip install -r .graphify-requirements.txt`.
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -3224,7 +3224,7 @@ Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts()
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -35165,13 +35165,13 @@
     },
     {
       "_src": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
-      "_tgt": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "_tgt": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "source": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L60",
+      "source_location": "L73",
       "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "weight": 1
     },
@@ -40919,7 +40919,7 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_test_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L69",
+      "source_location": "L105",
       "target": "pre_commit_generated_artifacts_test_log",
       "weight": 1
     },
@@ -40931,7 +40931,7 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_test_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L62",
+      "source_location": "L91",
       "target": "pre_commit_generated_artifacts_test_spawn",
       "weight": 1
     },
@@ -40943,20 +40943,20 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L45",
+      "source_location": "L56",
       "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "weight": 1
     },
     {
       "_src": "scripts_pre_commit_generated_artifacts_ts",
-      "_tgt": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "_tgt": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L20",
-      "target": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "source_location": "L29",
+      "target": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "weight": 1
     },
     {
@@ -67030,7 +67030,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L26"
+      "source_location": "L30"
     },
     {
       "community": 427,
@@ -67039,7 +67039,7 @@
       "label": "spawn()",
       "norm_label": "spawn()",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L18"
+      "source_location": "L22"
     },
     {
       "community": 427,
@@ -67057,16 +67057,16 @@
       "label": "runPreCommitGeneratedArtifacts()",
       "norm_label": "runprecommitgeneratedartifacts()",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L45"
+      "source_location": "L56"
     },
     {
       "community": 428,
       "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
-      "label": "stageTrackedGraphifyArtifacts()",
-      "norm_label": "stagetrackedgraphifyartifacts()",
+      "id": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
+      "label": "stageTrackedGeneratedArtifacts()",
+      "norm_label": "stagetrackedgeneratedartifacts()",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L20"
+      "source_location": "L29"
     },
     {
       "community": 428,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "harness:test": "bun scripts/harness-test.ts",
     "pre-commit:generated-artifacts": "bun scripts/pre-commit-generated-artifacts.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
+    "pr:athena": "bun run pre-commit:generated-artifacts && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage": "bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun scripts/coverage-summary.mjs"
   },

--- a/scripts/pre-commit-generated-artifacts.test.ts
+++ b/scripts/pre-commit-generated-artifacts.test.ts
@@ -3,15 +3,19 @@ import { describe, expect, it } from "vitest";
 
 import { GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
 import {
+  TRACKED_GENERATED_HARNESS_DOCS,
   TRACKED_GRAPHIFY_ARTIFACTS,
   runPreCommitGeneratedArtifacts,
 } from "./pre-commit-generated-artifacts";
 
 describe("runPreCommitGeneratedArtifacts", () => {
-  it("rebuilds graphify artifacts before staging tracked graphify outputs", async () => {
+  it("regenerates harness docs and graphify artifacts before staging tracked outputs", async () => {
     const steps: string[] = [];
 
     await runPreCommitGeneratedArtifacts("/repo", {
+      runHarnessGenerate: async () => {
+        steps.push("harness:generate");
+      },
       runGraphifyRebuild: async () => {
         steps.push("graphify:rebuild");
       },
@@ -28,15 +32,18 @@ describe("runPreCommitGeneratedArtifacts", () => {
     });
 
     expect(steps).toEqual([
+      "harness:generate",
+      `git add -- ${TRACKED_GENERATED_HARNESS_DOCS.join(" ")}`,
       "graphify:rebuild",
       `git add -- ${TRACKED_GRAPHIFY_ARTIFACTS.join(" ")}`,
     ]);
   });
 
-  it("stages only tracked graphify artifacts", async () => {
+  it("stages only tracked generated artifacts", async () => {
     const commands: string[][] = [];
 
     await runPreCommitGeneratedArtifacts("/repo", {
+      runHarnessGenerate: async () => {},
       runGraphifyRebuild: async () => {},
       spawn(command) {
         commands.push(command);
@@ -51,15 +58,44 @@ describe("runPreCommitGeneratedArtifacts", () => {
     });
 
     expect(commands).toEqual([
+      ["git", "add", "--", ...TRACKED_GENERATED_HARNESS_DOCS],
       ["git", "add", "--", ...TRACKED_GRAPHIFY_ARTIFACTS],
     ]);
   });
 
-  it("fails clearly when staging repaired graphify artifacts fails", async () => {
+  it("fails clearly when staging repaired harness docs fails", async () => {
     await expect(
       runPreCommitGeneratedArtifacts("/repo", {
+        runHarnessGenerate: async () => {},
         runGraphifyRebuild: async () => {},
         spawn() {
+          return {
+            exited: Promise.resolve(1),
+            stderr: new Response("git add harness docs failed").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      })
+    ).rejects.toThrow("git add harness docs failed");
+  });
+
+  it("fails clearly when staging repaired graphify artifacts fails", async () => {
+    let spawnCount = 0;
+
+    await expect(
+      runPreCommitGeneratedArtifacts("/repo", {
+        runHarnessGenerate: async () => {},
+        runGraphifyRebuild: async () => {},
+        spawn() {
+          spawnCount += 1;
+          if (spawnCount === 1) {
+            return {
+              exited: Promise.resolve(0),
+              stderr: new Response("").body,
+            };
+          }
           return {
             exited: Promise.resolve(1),
             stderr: new Response("git add failed").body,

--- a/scripts/pre-commit-generated-artifacts.ts
+++ b/scripts/pre-commit-generated-artifacts.ts
@@ -1,5 +1,13 @@
+import { HARNESS_APP_REGISTRY } from "./harness-app-registry";
+import { writeGeneratedHarnessDocs } from "./harness-generate";
 import { TRACKED_GRAPHIFY_ARTIFACTS } from "./graphify-check";
 import { runGraphifyRebuild } from "./graphify-rebuild";
+
+const TRACKED_GENERATED_HARNESS_DOCS = [
+  ...new Set(
+    HARNESS_APP_REGISTRY.flatMap((app) => app.harnessDocs.generatedDocs)
+  ),
+].sort((left, right) => left.localeCompare(right));
 
 type SpawnedProcess = {
   exited: Promise<number>;
@@ -10,6 +18,7 @@ type PreCommitGeneratedArtifactsLogger = Pick<Console, "log">;
 
 type PreCommitGeneratedArtifactsOptions = {
   runGraphifyRebuild?: (rootDir: string) => Promise<void>;
+  runHarnessGenerate?: (rootDir: string) => Promise<void>;
   spawn?: (
     command: string[],
     options: { cwd: string; stdout: "inherit"; stderr: "pipe" }
@@ -17,11 +26,13 @@ type PreCommitGeneratedArtifactsOptions = {
   logger?: PreCommitGeneratedArtifactsLogger;
 };
 
-async function stageTrackedGraphifyArtifacts(
+async function stageTrackedGeneratedArtifacts(
   rootDir: string,
-  spawn: NonNullable<PreCommitGeneratedArtifactsOptions["spawn"]>
+  spawn: NonNullable<PreCommitGeneratedArtifactsOptions["spawn"]>,
+  paths: string[],
+  label: string
 ) {
-  const command = ["git", "add", "--", ...TRACKED_GRAPHIFY_ARTIFACTS];
+  const command = ["git", "add", "--", ...paths];
   const proc = spawn(command, {
     cwd: rootDir,
     stdout: "inherit",
@@ -38,7 +49,7 @@ async function stageTrackedGraphifyArtifacts(
     : "";
   throw new Error(
     stderr ||
-      `Failed to stage tracked graphify artifacts (exit ${exitCode}): ${command.join(" ")}`
+      `Failed to stage tracked ${label} artifacts (exit ${exitCode}): ${command.join(" ")}`
   );
 }
 
@@ -48,6 +59,8 @@ export async function runPreCommitGeneratedArtifacts(
 ) {
   const logger = options.logger ?? console;
   const rebuild = options.runGraphifyRebuild ?? runGraphifyRebuild;
+  const generateHarnessDocs =
+    options.runHarnessGenerate ?? writeGeneratedHarnessDocs;
   const spawn =
     options.spawn ??
     ((command, spawnOptions) =>
@@ -55,12 +68,26 @@ export async function runPreCommitGeneratedArtifacts(
         ...spawnOptions,
       }));
 
+  logger.log("[pre-commit] Refreshing generated harness docs...");
+  await generateHarnessDocs(rootDir);
+  await stageTrackedGeneratedArtifacts(
+    rootDir,
+    spawn,
+    TRACKED_GENERATED_HARNESS_DOCS,
+    "harness doc"
+  );
+
   logger.log("[pre-commit] Refreshing tracked graphify artifacts...");
   await rebuild(rootDir);
-  await stageTrackedGraphifyArtifacts(rootDir, spawn);
+  await stageTrackedGeneratedArtifacts(
+    rootDir,
+    spawn,
+    TRACKED_GRAPHIFY_ARTIFACTS,
+    "graphify"
+  );
 }
 
-export { TRACKED_GRAPHIFY_ARTIFACTS };
+export { TRACKED_GENERATED_HARNESS_DOCS, TRACKED_GRAPHIFY_ARTIFACTS };
 
 if (import.meta.main) {
   runPreCommitGeneratedArtifacts(process.cwd()).catch((error: unknown) => {

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -768,6 +768,9 @@ describe("repo harness ergonomics", () => {
       scripts?: Record<string, string>;
     };
 
+    expect(packageJson.scripts?.["pr:athena"]).toContain(
+      "bun run pre-commit:generated-artifacts"
+    );
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:test");
     expect(packageJson.scripts?.["pr:athena"]).toContain(
       "bun run harness:review --base origin/main"
@@ -793,7 +796,10 @@ describe("repo harness ergonomics", () => {
     const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
 
     expect(readme).toContain(
-      "`pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild`"
+      "`pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`"
+    );
+    expect(readme).toContain(
+      "`bun run pr:athena` starts with that same generated-artifact repair step"
     );
     expect(readme).toContain(
       "If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs"
@@ -807,6 +813,7 @@ describe("repo harness ergonomics", () => {
     );
     expect(readme).toContain("bun run graphify:check");
     expect(readme).toContain("bun run graphify:rebuild");
+    expect(readme).toContain("bun run harness:generate");
     expect(readme).toContain(".graphify_python");
     expect(readme).toContain(".graphify-requirements.txt");
     expect(readme).toContain("graphify-out/GRAPH_REPORT.md");


### PR DESCRIPTION
## Summary
- Extend `pre-commit:generated-artifacts` so it also runs `harness:generate` and stages tracked generated harness docs.
- Run the generated-artifact repair path at the start of `pr:athena`, before `harness:check` can fail on deterministic stale generated docs.
- Update harness tooling tests and README guidance for the new repair behavior.

## Linear
- Closes V26-430
- https://linear.app/v26-labs/issue/V26-430/evaluate-auto-repair-for-stale-generated-harness-docs-in-prathena

## Validation
- `bun test scripts/pre-commit-generated-artifacts.test.ts scripts/pre-push-review.test.ts scripts/harness-check.test.ts scripts/harness-generate.test.ts`
- `bun run pre-commit:generated-artifacts`
- `bun run harness:check && bun run graphify:check && git diff --check`
- `bun run pr:athena`
- `git push -u origin HEAD` pre-push review
