### PR TITLE
[V26-340]: Bootstrap worktrees with Athena Convex env

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4099 nodes · 3696 edges · 1476 communities detected
+- 4100 nodes · 3699 edges · 1476 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1950,16 +1950,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 109 - "Community 109"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 110 - "Community 110"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 111 - "Community 111"
+### Community 110 - "Community 110"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 111 - "Community 111"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 112 - "Community 112"
 Cohesion: 0.52
@@ -2183,7 +2183,7 @@ Nodes (0):
 
 ### Community 167 - "Community 167"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.4
@@ -2198,12 +2198,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 171 - "Community 171"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 172 - "Community 172"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 172 - "Community 172"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.4
@@ -2215,7 +2215,7 @@ Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 176 - "Community 176"
 Cohesion: 0.5
@@ -2314,8 +2314,8 @@ Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 200 - "Community 200"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.5
@@ -2326,12 +2326,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 204 - "Community 204"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 204 - "Community 204"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.5
@@ -2342,64 +2342,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 207 - "Community 207"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 208 - "Community 208"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 214 - "Community 214"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 216 - "Community 216"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 220 - "Community 220"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 221 - "Community 221"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.5
@@ -2410,24 +2410,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 224 - "Community 224"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 225 - "Community 225"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 227 - "Community 227"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 228 - "Community 228"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.5
@@ -2446,12 +2446,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 234 - "Community 234"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 234 - "Community 234"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.5
@@ -2462,12 +2462,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 237 - "Community 237"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 238 - "Community 238"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 238 - "Community 238"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.5
@@ -2498,68 +2498,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 247 - "Community 247"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 247 - "Community 247"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 249 - "Community 249"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 250 - "Community 250"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 251 - "Community 251"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 254 - "Community 254"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 261 - "Community 261"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 262 - "Community 262"
 Cohesion: 0.5
@@ -2586,56 +2586,56 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 270 - "Community 270"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 272 - "Community 272"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 273 - "Community 273"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 275 - "Community 275"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 277 - "Community 277"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 278 - "Community 278"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 280 - "Community 280"
-Cohesion: 0.67
-Nodes (2): createFixtureRepo(), runGit()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1547 files · ~0 words
+- 1548 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4095 nodes · 3692 edges · 1475 communities detected
+- 4099 nodes · 3696 edges · 1476 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1485,6 +1485,7 @@
 - [[_COMMUNITY_Community 1472|Community 1472]]
 - [[_COMMUNITY_Community 1473|Community 1473]]
 - [[_COMMUNITY_Community 1474|Community 1474]]
+- [[_COMMUNITY_Community 1475|Community 1475]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1949,16 +1950,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 109 - "Community 109"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 110 - "Community 110"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 111 - "Community 111"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 112 - "Community 112"
 Cohesion: 0.52
@@ -2634,7 +2635,7 @@ Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): createFixtureRepo(), runGit()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
@@ -2686,35 +2687,35 @@ Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 297 - "Community 297"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 297 - "Community 297"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 299 - "Community 299"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 300 - "Community 300"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 300 - "Community 300"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
@@ -2725,36 +2726,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 308 - "Community 308"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 309 - "Community 309"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
@@ -2769,24 +2770,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.67
@@ -2794,31 +2795,31 @@ Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 322 - "Community 322"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 323 - "Community 323"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 326 - "Community 326"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 326 - "Community 326"
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.67
@@ -2873,84 +2874,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 340 - "Community 340"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 341 - "Community 341"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 359 - "Community 359"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
@@ -2978,11 +2979,11 @@ Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
@@ -2997,16 +2998,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 371 - "Community 371"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 372 - "Community 372"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 372 - "Community 372"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 373 - "Community 373"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
@@ -3018,15 +3019,15 @@ Nodes (0):
 
 ### Community 376 - "Community 376"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 378 - "Community 378"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.67
@@ -3037,56 +3038,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 381 - "Community 381"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 383 - "Community 383"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 388 - "Community 388"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 389 - "Community 389"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 390 - "Community 390"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 391 - "Community 391"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 392 - "Community 392"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 393 - "Community 393"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.67
@@ -3097,12 +3098,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 397 - "Community 397"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 397 - "Community 397"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
@@ -3113,12 +3114,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 400 - "Community 400"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 401 - "Community 401"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 401 - "Community 401"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.67
@@ -3193,16 +3194,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 421 - "Community 421"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 422 - "Community 422"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 1.0
@@ -3217,20 +3218,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 426 - "Community 426"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts()
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
@@ -7412,2098 +7413,2102 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1475 - "Community 1475"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 429`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 430`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 431`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 432`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 433`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 434`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 435`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 436`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 437`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 438`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 439`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 440`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 441`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 442`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 443`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 444`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 445`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 446`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 447`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 448`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 449`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 450`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 451`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 452`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 453`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 454`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 455`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 456`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 457`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 458`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 459`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 460`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 461`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 462`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 463`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 464`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 465`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 466`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 467`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 468`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 469`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 470`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 471`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 472`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 473`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 474`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 475`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 476`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 477`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 478`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 479`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 480`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 481`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 482`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 483`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 484`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 485`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 486`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 487`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 488`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 489`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 490`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 491`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 492`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 493`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 494`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 495`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 496`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 497`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 498`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 499`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 500`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 501`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 502`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 503`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 504`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 505`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 506`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 507`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 508`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 509`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 510`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 511`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 512`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 513`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 514`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 515`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 516`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 517`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 518`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 519`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 520`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 521`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 522`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 523`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 524`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 525`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 526`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 527`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 528`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 529`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 530`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 531`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 532`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 533`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 534`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 535`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 536`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 537`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 538`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 539`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 540`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 541`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 542`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 543`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 544`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 545`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 546`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 547`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 548`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 549`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 550`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 551`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 552`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 553`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 554`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 555`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 556`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 557`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 558`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 559`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 560`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 561`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 562`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 563`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 564`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 565`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 566`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 567`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 568`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 569`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 570`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 571`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 572`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 573`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 574`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 575`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 576`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 577`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 578`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 579`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 580`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 581`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 582`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 583`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 584`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 585`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 586`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 587`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 588`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 589`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 590`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 591`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 592`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 593`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 594`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 595`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 596`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 597`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 598`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 599`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 600`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 601`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 602`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 603`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 604`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 605`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 606`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 607`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 608`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 609`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 610`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 611`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 612`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 613`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 614`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 615`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 616`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 617`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 618`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 619`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 620`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `use-mobile.test.tsx`, `notifyViewportWidth()`
+- **Thin community `Community 621`** (2 nodes): `use-mobile.test.tsx`, `notifyViewportWidth()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 622`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 623`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 624`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 625`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 626`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 627`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 628`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 629`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 630`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 631`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 632`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 633`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 634`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 635`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 636`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 637`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 638`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 639`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 640`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 641`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 642`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 643`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 644`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 645`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 646`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 647`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 648`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 649`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 650`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 651`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 652`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 653`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 654`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 655`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 656`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 657`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
+- **Thin community `Community 658`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 659`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 660`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 661`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 662`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 663`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 664`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 665`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 666`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 667`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 668`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 669`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 670`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 671`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 672`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 673`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 674`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 675`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 676`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 677`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 678`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 679`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 680`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 681`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 682`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 683`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 684`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 685`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 686`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 687`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 688`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 689`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 690`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 691`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 692`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 693`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 694`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 695`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 696`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 697`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 698`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 699`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 700`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 701`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 702`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 703`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 704`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 705`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 706`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 707`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 708`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 709`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 710`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 711`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 712`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 713`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 714`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 715`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 716`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 717`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 718`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 719`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 720`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 721`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 722`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 723`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 724`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 725`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 726`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 727`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 728`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 729`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 730`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 731`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 732`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 733`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 734`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 735`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 736`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 737`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 738`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 739`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 740`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 741`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 742`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 743`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 744`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 745`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 746`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 747`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 748`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 749`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 750`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 751`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 752`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 753`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 754`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 755`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 756`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 757`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 758`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 759`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 760`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 761`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 762`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 763`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 764`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 765`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 766`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 767`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 768`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 769`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 770`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 771`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 772`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 773`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 774`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 775`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 776`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 777`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 778`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 779`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 780`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 781`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 782`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 783`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 784`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 785`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 786`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 787`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 788`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 789`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 790`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 791`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 792`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 793`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 794`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 795`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 796`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 797`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `api.d.ts`
+- **Thin community `Community 798`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `api.js`
+- **Thin community `Community 799`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 800`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `server.d.ts`
+- **Thin community `Community 801`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `server.js`
+- **Thin community `Community 802`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `app.ts`
+- **Thin community `Community 803`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `auth.config.js`
+- **Thin community `Community 804`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `auth.ts`
+- **Thin community `Community 805`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 806`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 807`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `countries.ts`
+- **Thin community `Community 808`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `email.ts`
+- **Thin community `Community 809`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `ghana.ts`
+- **Thin community `Community 810`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `payment.ts`
+- **Thin community `Community 811`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `crons.ts`
+- **Thin community `Community 812`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 813`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 814`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 815`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 816`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `env.ts`
+- **Thin community `Community 817`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `analytics.ts`
+- **Thin community `Community 818`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `auth.ts`
+- **Thin community `Community 819`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 820`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `colors.ts`
+- **Thin community `Community 821`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `index.ts`
+- **Thin community `Community 822`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `organizations.ts`
+- **Thin community `Community 823`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `products.ts`
+- **Thin community `Community 824`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 825`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `stores.ts`
+- **Thin community `Community 826`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `bag.ts`
+- **Thin community `Community 827`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `guest.ts`
+- **Thin community `Community 828`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `index.ts`
+- **Thin community `Community 829`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `me.ts`
+- **Thin community `Community 830`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `offers.ts`
+- **Thin community `Community 831`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 832`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `paystack.ts`
+- **Thin community `Community 833`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 834`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `reviews.ts`
+- **Thin community `Community 835`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `rewards.ts`
+- **Thin community `Community 836`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 837`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `security.test.ts`
+- **Thin community `Community 838`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `storefront.ts`
+- **Thin community `Community 839`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `upsells.ts`
+- **Thin community `Community 840`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `user.ts`
+- **Thin community `Community 841`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 842`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `index.ts`
+- **Thin community `Community 843`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `health.test.ts`
+- **Thin community `Community 844`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `http.ts`
+- **Thin community `Community 845`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 846`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 847`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 848`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `categories.ts`
+- **Thin community `Community 849`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `colors.ts`
+- **Thin community `Community 850`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 851`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 852`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 853`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 854`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 855`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `organizations.ts`
+- **Thin community `Community 856`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `pos.ts`
+- **Thin community `Community 857`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 858`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 859`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `productSku.ts`
+- **Thin community `Community 860`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 861`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 862`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 863`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 864`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 865`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 866`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 867`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 868`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 869`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 870`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `client.test.ts`
+- **Thin community `Community 871`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `config.test.ts`
+- **Thin community `Community 872`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 873`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `types.ts`
+- **Thin community `Community 874`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 875`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 876`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 877`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 878`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 879`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 880`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 881`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `dto.ts`
+- **Thin community `Community 882`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 883`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 884`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 885`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `types.ts`
+- **Thin community `Community 886`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 887`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 888`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `catalog.ts`
+- **Thin community `Community 889`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `customers.ts`
+- **Thin community `Community 890`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `register.ts`
+- **Thin community `Community 891`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `terminals.ts`
+- **Thin community `Community 892`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `schema.ts`
+- **Thin community `Community 893`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 894`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 895`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 896`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 897`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `category.ts`
+- **Thin community `Community 898`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `color.ts`
+- **Thin community `Community 899`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 900`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 901`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `index.ts`
+- **Thin community `Community 902`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 903`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `organization.ts`
+- **Thin community `Community 904`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 905`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `product.ts`
+- **Thin community `Community 906`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 907`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 908`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `store.ts`
+- **Thin community `Community 909`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 910`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `index.ts`
+- **Thin community `Community 911`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 912`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 913`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 914`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 915`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 916`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `index.ts`
+- **Thin community `Community 917`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 918`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 919`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 920`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 921`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 922`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 923`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 924`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 925`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 926`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `customer.ts`
+- **Thin community `Community 927`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 928`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 929`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 930`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 931`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `index.ts`
+- **Thin community `Community 932`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `posSession.ts`
+- **Thin community `Community 933`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 934`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 935`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 936`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 937`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `index.ts`
+- **Thin community `Community 938`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 939`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 940`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 941`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 942`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 943`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `index.ts`
+- **Thin community `Community 944`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 945`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 946`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 947`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 948`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `vendor.ts`
+- **Thin community `Community 949`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `analytics.ts`
+- **Thin community `Community 950`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `bag.ts`
+- **Thin community `Community 951`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 952`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 953`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 954`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `guest.ts`
+- **Thin community `Community 955`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `index.ts`
+- **Thin community `Community 956`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `offer.ts`
+- **Thin community `Community 957`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 958`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 959`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `review.ts`
+- **Thin community `Community 960`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `rewards.ts`
+- **Thin community `Community 961`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 962`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 963`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 964`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 965`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 966`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 967`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 968`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `bag.ts`
+- **Thin community `Community 969`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 970`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `customer.ts`
+- **Thin community `Community 971`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `guest.ts`
+- **Thin community `Community 972`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 973`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 974`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `payment.ts`
+- **Thin community `Community 975`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 976`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 977`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 978`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `users.ts`
+- **Thin community `Community 979`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `payment.ts`
+- **Thin community `Community 980`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 981`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 982`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 983`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 984`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `index.ts`
+- **Thin community `Community 985`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 986`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 987`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `auth.ts`
+- **Thin community `Community 988`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 989`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 990`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 991`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 992`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 993`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 994`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 995`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 996`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 997`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 998`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 999`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `constants.ts`
+- **Thin community `Community 1000`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1003`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `types.ts`
+- **Thin community `Community 1004`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1005`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1006`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1007`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1008`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1012`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1015`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1016`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1017`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1018`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1020`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1021`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1022`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1024`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `constants.ts`
+- **Thin community `Community 1025`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1026`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1027`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1028`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data.ts`
+- **Thin community `Community 1029`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1030`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1032`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1033`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1036`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 1038`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1039`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `constants.ts`
+- **Thin community `Community 1040`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1043`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `data.ts`
+- **Thin community `Community 1044`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1045`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1046`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 1047`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1048`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1049`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1050`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1051`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1052`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1053`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1054`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1055`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `constants.ts`
+- **Thin community `Community 1056`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1057`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1058`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1059`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1060`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1061`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1062`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1063`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1064`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1065`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1066`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1067`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1068`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1069`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1070`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1071`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1072`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1073`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1074`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1075`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1077`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1078`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1079`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1080`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1081`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `constants.ts`
+- **Thin community `Community 1082`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1084`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1085`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `data.ts`
+- **Thin community `Community 1086`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `constants.ts`
+- **Thin community `Community 1088`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1090`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1091`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1092`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `data.ts`
+- **Thin community `Community 1093`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1094`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `constants.ts`
+- **Thin community `Community 1095`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1096`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1097`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1098`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1099`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data.ts`
+- **Thin community `Community 1100`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1101`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1102`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1103`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1104`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1105`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1106`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1107`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1108`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1109`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1110`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1111`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1112`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1113`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1114`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1115`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1116`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1117`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1118`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1119`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1120`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1121`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `types.ts`
+- **Thin community `Community 1122`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1123`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1124`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1125`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1126`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1127`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1128`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1129`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1130`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1131`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1132`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1133`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1134`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1135`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1137`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1138`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1139`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `data.ts`
+- **Thin community `Community 1140`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1141`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1142`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1143`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1144`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1145`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1146`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1147`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1148`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1149`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1150`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1151`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1152`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `constants.ts`
+- **Thin community `Community 1153`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1154`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1155`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1156`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data.ts`
+- **Thin community `Community 1157`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `types.ts`
+- **Thin community `Community 1158`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1159`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1160`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1161`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1162`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `index.tsx`
+- **Thin community `Community 1163`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1164`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1165`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1166`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1167`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1168`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `index.tsx`
+- **Thin community `Community 1169`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1170`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1171`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1172`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `button.tsx`
+- **Thin community `Community 1173`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1174`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `card.tsx`
+- **Thin community `Community 1175`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1176`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1177`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `command.tsx`
+- **Thin community `Community 1178`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1179`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1180`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1181`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `form.tsx`
+- **Thin community `Community 1182`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1183`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1184`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `input.tsx`
+- **Thin community `Community 1185`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1186`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1187`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1188`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1189`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1190`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `select.tsx`
+- **Thin community `Community 1191`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1192`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1193`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1194`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `table.tsx`
+- **Thin community `Community 1195`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1196`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1197`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1198`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1199`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1200`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1201`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1202`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1203`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `constants.ts`
+- **Thin community `Community 1204`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1205`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1206`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1207`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `data.ts`
+- **Thin community `Community 1208`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1209`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1210`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1211`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1212`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1213`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1214`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1215`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1216`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1217`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1218`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1219`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1220`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `index.ts`
+- **Thin community `Community 1221`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `config.ts`
+- **Thin community `Community 1222`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1223`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1225`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1226`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1228`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `aws.ts`
+- **Thin community `Community 1229`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `constants.ts`
+- **Thin community `Community 1230`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `countries.ts`
+- **Thin community `Community 1231`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1232`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1234`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1236`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1237`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `dto.ts`
+- **Thin community `Community 1238`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ports.ts`
+- **Thin community `Community 1239`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `constants.ts`
+- **Thin community `Community 1240`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1242`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `index.ts`
+- **Thin community `Community 1243`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `types.ts`
+- **Thin community `Community 1245`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1248`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
+- **Thin community `Community 1249`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1250`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `category.ts`
+- **Thin community `Community 1252`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `product.ts`
+- **Thin community `Community 1253`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `store.ts`
+- **Thin community `Community 1254`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1255`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `user.ts`
+- **Thin community `Community 1256`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1257`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1259`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1260`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `index.tsx`
+- **Thin community `Community 1261`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1262`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1263`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1264`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1265`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1266`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1267`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1268`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `index.tsx`
+- **Thin community `Community 1269`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1270`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1271`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1272`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `home.tsx`
+- **Thin community `Community 1273`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1274`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1275`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1276`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `index.tsx`
+- **Thin community `Community 1277`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1278`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1279`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1280`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1281`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `index.tsx`
+- **Thin community `Community 1282`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1283`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1284`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1285`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1286`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1287`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1288`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `index.tsx`
+- **Thin community `Community 1289`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1290`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1291`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1292`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1293`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1294`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1295`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `index.tsx`
+- **Thin community `Community 1296`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1297`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `new.tsx`
+- **Thin community `Community 1298`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `index.tsx`
+- **Thin community `Community 1299`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `new.tsx`
+- **Thin community `Community 1300`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1301`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1302`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `index.tsx`
+- **Thin community `Community 1303`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `new.tsx`
+- **Thin community `Community 1304`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `index.tsx`
+- **Thin community `Community 1305`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1306`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1307`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1308`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1309`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1310`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1311`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1312`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `index.tsx`
+- **Thin community `Community 1313`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1316`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1317`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1319`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1320`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1321`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1322`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1323`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1324`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1325`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1326`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1328`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1329`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1330`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1331`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1332`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `setup.ts`
+- **Thin community `Community 1335`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1337`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `types.ts`
+- **Thin community `Community 1338`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1339`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1340`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1341`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1342`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `types.ts`
+- **Thin community `Community 1344`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1345`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1346`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1349`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1350`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1352`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1353`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `schema.ts`
+- **Thin community `Community 1354`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1355`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1357`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1358`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1359`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1360`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1361`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1362`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1363`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `types.ts`
+- **Thin community `Community 1364`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1365`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1366`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1367`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1368`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1369`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1370`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1371`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `constants.ts`
+- **Thin community `Community 1372`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1373`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `About.tsx`
+- **Thin community `Community 1374`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1375`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1376`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1377`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1378`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1379`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1380`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1381`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1382`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1383`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `types.ts`
+- **Thin community `Community 1384`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1385`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1386`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1387`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1388`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1389`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1390`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1391`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1392`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1393`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1394`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1395`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `button.tsx`
+- **Thin community `Community 1396`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `card.tsx`
+- **Thin community `Community 1397`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1398`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `command.tsx`
+- **Thin community `Community 1399`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1400`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1401`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1402`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `form.tsx`
+- **Thin community `Community 1403`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1404`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1405`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1406`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1407`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `input.tsx`
+- **Thin community `Community 1408`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `label.tsx`
+- **Thin community `Community 1409`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1410`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1411`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1412`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `index.ts`
+- **Thin community `Community 1413`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `types.ts`
+- **Thin community `Community 1414`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1415`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1416`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1417`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1418`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `select.tsx`
+- **Thin community `Community 1419`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1420`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1421`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `table.tsx`
+- **Thin community `Community 1422`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1423`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1424`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1425`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1426`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1427`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `config.ts`
+- **Thin community `Community 1428`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1429`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1430`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1431`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `constants.ts`
+- **Thin community `Community 1432`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `countries.ts`
+- **Thin community `Community 1433`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1434`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1435`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1436`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `index.ts`
+- **Thin community `Community 1438`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `store.ts`
+- **Thin community `Community 1439`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `bag.ts`
+- **Thin community `Community 1440`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1441`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `category.ts`
+- **Thin community `Community 1442`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `organization.ts`
+- **Thin community `Community 1443`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `product.ts`
+- **Thin community `Community 1444`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `store.ts`
+- **Thin community `Community 1445`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1446`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `user.ts`
+- **Thin community `Community 1447`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `states.ts`
+- **Thin community `Community 1448`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1449`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1452`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1454`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1455`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `index.tsx`
+- **Thin community `Community 1456`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1457`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `index.tsx`
+- **Thin community `Community 1458`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1459`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1460`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1461`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1462`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1463`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `index.tsx`
+- **Thin community `Community 1464`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1465`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1466`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1467`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1468`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `index.js`
+- **Thin community `Community 1469`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1475`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -41140,6 +41140,42 @@
       "weight": 1
     },
     {
+      "_src": "scripts_worktree_manager_test_ts",
+      "_tgt": "worktree_manager_test_createfixturerepo",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_worktree_manager_test_ts",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L8",
+      "target": "worktree_manager_test_createfixturerepo",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_worktree_manager_test_ts",
+      "_tgt": "worktree_manager_test_rungit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_worktree_manager_test_ts",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L36",
+      "target": "worktree_manager_test_rungit",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_worktree_manager_test_ts",
+      "_tgt": "worktree_manager_test_runworktreemanager",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_worktree_manager_test_ts",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L45",
+      "target": "worktree_manager_test_runworktreemanager",
+      "weight": 1
+    },
+    {
       "_src": "searchcatalog_lookupbybarcode",
       "_tgt": "searchcatalog_mapskutocatalogresult",
       "confidence": "EXTRACTED",
@@ -44306,6 +44342,18 @@
       "source_location": "L50",
       "target": "workflowtraceroutelink_workflowtraceroutelink",
       "weight": 1
+    },
+    {
+      "_src": "worktree_manager_test_createfixturerepo",
+      "_tgt": "worktree_manager_test_rungit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "worktree_manager_test_createfixturerepo",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L27",
+      "target": "worktree_manager_test_rungit",
+      "weight": 1
     }
   ],
   "multigraph": false,
@@ -45411,6 +45459,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -45418,7 +45475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45427,7 +45484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45436,7 +45493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -45445,7 +45502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -45454,7 +45511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -45463,7 +45520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -45472,7 +45529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45481,21 +45538,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -45564,6 +45612,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -45571,7 +45628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -45580,7 +45637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45589,7 +45646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45598,7 +45655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -45607,7 +45664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45616,7 +45673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -45625,7 +45682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45634,21 +45691,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
       "source_location": "L1"
     },
     {
@@ -45717,6 +45765,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -45724,7 +45781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45733,7 +45790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45742,7 +45799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -45751,7 +45808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -45760,7 +45817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45769,7 +45826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45778,7 +45835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45787,21 +45844,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -45870,6 +45918,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -45877,7 +45934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45886,7 +45943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -45895,7 +45952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45904,7 +45961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45913,7 +45970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -45922,7 +45979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45931,7 +45988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -45940,21 +45997,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
       "norm_label": "assetscolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -46023,6 +46071,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -46030,7 +46087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46039,7 +46096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -46048,7 +46105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -46057,7 +46114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -46066,7 +46123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -46075,7 +46132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -46084,7 +46141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -46093,21 +46150,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
       "norm_label": "loginform.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -46176,6 +46224,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -46183,7 +46240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46192,7 +46249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46201,7 +46258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -46210,7 +46267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -46219,7 +46276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -46228,7 +46285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46237,7 +46294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46246,21 +46303,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1"
     },
     {
@@ -46329,6 +46377,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
       "norm_label": "cashcontrolsdashboard.auth.test.tsx",
@@ -46336,7 +46393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -46345,7 +46402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -46354,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -46363,7 +46420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -46372,7 +46429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
@@ -46381,7 +46438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -46390,7 +46447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -46399,21 +46456,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -46482,6 +46530,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
       "norm_label": "metriccard.tsx",
@@ -46489,7 +46546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -46498,7 +46555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
@@ -46507,7 +46564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -46516,7 +46573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -46525,7 +46582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -46534,7 +46591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -46543,7 +46600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -46552,21 +46609,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
@@ -46635,6 +46683,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
       "norm_label": "returnexchangeview.test.tsx",
@@ -46642,7 +46699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -46651,7 +46708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46660,7 +46717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46669,7 +46726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -46678,7 +46735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -46687,7 +46744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -46696,7 +46753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -46705,7 +46762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46714,7 +46771,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 1090,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46723,70 +46843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 1090,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46795,7 +46852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -46804,7 +46861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -46813,7 +46870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -46822,7 +46879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -46831,7 +46888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46840,7 +46897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46849,7 +46906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46858,21 +46915,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -47067,68 +47115,77 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -47137,7 +47194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -47146,7 +47203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -47155,7 +47212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -47164,7 +47221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -47173,7 +47230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -47182,7 +47239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -47191,7 +47248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -47200,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -47209,7 +47266,70 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 111,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 1110,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -47218,70 +47338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 1110,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -47290,7 +47347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -47299,7 +47356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -47308,7 +47365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -47317,7 +47374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -47326,7 +47383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -47335,7 +47392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -47344,7 +47401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -47353,21 +47410,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
       "norm_label": "registercheckoutpanel.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
-      "label": "HeldSessionsList.test.tsx",
-      "norm_label": "heldsessionslist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
       "source_location": "L1"
     },
     {
@@ -47436,6 +47484,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
+      "label": "HeldSessionsList.test.tsx",
+      "norm_label": "heldsessionslist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
       "norm_label": "transactionsview.test.tsx",
@@ -47443,7 +47500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -47452,7 +47509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -47461,7 +47518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -47470,7 +47527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -47479,7 +47536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -47488,7 +47545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -47497,7 +47554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -47506,21 +47563,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
       "norm_label": "categorylistview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "label": "ProductSubcategoryToggleGroup.tsx",
-      "norm_label": "productsubcategorytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
       "source_location": "L1"
     },
     {
@@ -47589,6 +47637,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
+      "label": "ProductSubcategoryToggleGroup.tsx",
+      "norm_label": "productsubcategorytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
       "norm_label": "products.tsx",
@@ -47596,7 +47653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -47605,7 +47662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -47614,7 +47671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -47623,7 +47680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -47632,7 +47689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -47641,7 +47698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -47650,7 +47707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -47659,21 +47716,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -47742,6 +47790,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
       "norm_label": "productcolumns.tsx",
@@ -47749,7 +47806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -47758,7 +47815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -47767,7 +47824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -47776,7 +47833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -47785,7 +47842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -47794,7 +47851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -47803,7 +47860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -47812,21 +47869,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -47886,6 +47934,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -47893,7 +47950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -47902,7 +47959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -47911,7 +47968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -47920,7 +47977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -47929,7 +47986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -47938,7 +47995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -47947,7 +48004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -47956,21 +48013,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
       "norm_label": "welcome-offer-card.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "label": "RatingStars.tsx",
-      "norm_label": "ratingstars.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1"
     },
     {
@@ -48030,6 +48078,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
+      "label": "RatingStars.tsx",
+      "norm_label": "ratingstars.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
       "norm_label": "reviewcard.tsx",
@@ -48037,7 +48094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -48046,7 +48103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -48055,7 +48112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -48064,7 +48121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -48073,7 +48130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -48082,7 +48139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -48091,7 +48148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -48100,21 +48157,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
-      "label": "WorkflowTraceView.test.tsx",
-      "norm_label": "workflowtraceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -48174,6 +48222,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
+      "label": "WorkflowTraceView.test.tsx",
+      "norm_label": "workflowtraceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -48181,7 +48238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -48190,7 +48247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -48199,7 +48256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -48208,7 +48265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -48217,7 +48274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -48226,7 +48283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -48235,7 +48292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -48244,21 +48301,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -48318,6 +48366,15 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -48325,7 +48382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -48334,7 +48391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -48343,7 +48400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -48352,7 +48409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -48361,7 +48418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -48370,7 +48427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -48379,7 +48436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -48388,21 +48445,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -48462,6 +48510,15 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -48469,7 +48526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -48478,7 +48535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -48487,7 +48544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -48496,7 +48553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -48505,7 +48562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -48514,7 +48571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -48523,7 +48580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -48532,21 +48589,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
@@ -48786,6 +48834,15 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
       "norm_label": "upload-button.tsx",
@@ -48793,7 +48850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -48802,7 +48859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -48811,7 +48868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -48820,7 +48877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -48829,7 +48886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -48838,7 +48895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -48847,7 +48904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -48856,21 +48913,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
@@ -48930,6 +48978,15 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -48937,7 +48994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -48946,7 +49003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -48955,7 +49012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -48964,7 +49021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -48973,7 +49030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -48982,7 +49039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -48991,7 +49048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -49000,21 +49057,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
       "norm_label": "userinsightssection.tsx",
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1"
     },
     {
@@ -49074,6 +49122,15 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -49081,7 +49138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -49090,7 +49147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -49099,7 +49156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -49108,7 +49165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -49117,7 +49174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -49126,7 +49183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -49135,7 +49192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -49144,21 +49201,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
@@ -49218,6 +49266,15 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
@@ -49225,7 +49282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -49234,7 +49291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -49243,7 +49300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -49252,7 +49309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -49261,7 +49318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -49270,7 +49327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -49279,7 +49336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -49288,21 +49345,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
       "norm_label": "ports.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
       "source_location": "L1"
     },
     {
@@ -49362,6 +49410,15 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
       "norm_label": "displayamounts.test.ts",
@@ -49369,7 +49426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -49378,7 +49435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -49387,7 +49444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -49396,7 +49453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -49405,7 +49462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -49414,7 +49471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -49423,7 +49480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -49432,21 +49489,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "label": "useExpenseRegisterViewModel.test.ts",
       "norm_label": "useexpenseregisterviewmodel.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
-      "label": "registerUiState.ts",
-      "norm_label": "registeruistate.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
       "source_location": "L1"
     },
     {
@@ -49506,6 +49554,15 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
+      "label": "registerUiState.ts",
+      "norm_label": "registeruistate.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
       "norm_label": "productutils.test.ts",
@@ -49513,7 +49570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -49522,7 +49579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -49531,7 +49588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -49540,7 +49597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -49549,7 +49606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -49558,7 +49615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -49567,7 +49624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -49576,21 +49633,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
       "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
@@ -49650,6 +49698,15 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
       "norm_label": "__root.tsx",
@@ -49657,7 +49714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -49666,7 +49723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -49675,7 +49732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -49684,7 +49741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -49693,7 +49750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -49702,7 +49759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -49711,7 +49768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -49720,21 +49777,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
       "norm_label": "bags.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
       "source_location": "L1"
     },
     {
@@ -49794,6 +49842,15 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
       "norm_label": "checkout-sessions.index.tsx",
@@ -49801,7 +49858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -49810,7 +49867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -49819,7 +49876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -49828,7 +49885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -49837,7 +49894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -49846,7 +49903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -49855,7 +49912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -49864,21 +49921,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "label": "all.index.tsx",
-      "norm_label": "all.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1"
     },
     {
@@ -49938,6 +49986,15 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
+      "label": "all.index.tsx",
+      "norm_label": "all.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
       "norm_label": "cancelled.index.tsx",
@@ -49945,7 +50002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -49954,7 +50011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -49963,7 +50020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -49972,7 +50029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -49981,7 +50038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -49990,7 +50047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -49999,7 +50056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -50008,21 +50065,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
       "norm_label": "expense-reports.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1"
     },
     {
@@ -50082,6 +50130,15 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
       "norm_label": "register.index.tsx",
@@ -50089,7 +50146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -50098,7 +50155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -50107,7 +50164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -50116,7 +50173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -50125,7 +50182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -50134,7 +50191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -50143,7 +50200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -50152,21 +50209,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
       "source_location": "L1"
     },
     {
@@ -50406,6 +50454,15 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
@@ -50413,7 +50470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -50422,7 +50479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -50431,7 +50488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -50440,7 +50497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -50449,7 +50506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -50458,7 +50515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -50467,7 +50524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -50476,21 +50533,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
       "norm_label": "appointments.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
       "source_location": "L1"
     },
     {
@@ -50550,6 +50598,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
       "norm_label": "intake.index.tsx",
@@ -50557,7 +50614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -50566,7 +50623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -50575,7 +50632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -50584,7 +50641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -50593,7 +50650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -50602,7 +50659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -50611,7 +50668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -50620,21 +50677,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
       "norm_label": "_layout.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "label": "StoresSettingsAccordion.tsx",
-      "norm_label": "storessettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1"
     },
     {
@@ -50694,6 +50742,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
+      "label": "StoresSettingsAccordion.tsx",
+      "norm_label": "storessettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
       "norm_label": "expensestore.ts",
@@ -50701,7 +50758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -50710,7 +50767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -50719,7 +50776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -50728,7 +50785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -50737,7 +50794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -50746,7 +50803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -50755,7 +50812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -50764,21 +50821,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
       "norm_label": "surfaces.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -50838,6 +50886,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
       "norm_label": "dataworkspace.stories.tsx",
@@ -50845,7 +50902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -50854,7 +50911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -50863,7 +50920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
@@ -50872,7 +50929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -50881,7 +50938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -50890,7 +50947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -50899,7 +50956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -50908,21 +50965,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
       "source_location": "L1"
     },
     {
@@ -50982,6 +51030,15 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
@@ -50989,7 +51046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -50998,7 +51055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -51007,7 +51064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -51016,7 +51073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -51025,7 +51082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -51034,7 +51091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -51043,7 +51100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -51052,21 +51109,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
       "norm_label": "productcard.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1"
     },
     {
@@ -51126,6 +51174,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
       "norm_label": "upsell.tsx",
@@ -51133,7 +51190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -51142,7 +51199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -51151,7 +51208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -51160,7 +51217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -51169,7 +51226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -51178,7 +51235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -51187,7 +51244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -51196,21 +51253,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
       "norm_label": "derivecheckoutstate.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -51270,6 +51318,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
       "norm_label": "checkoutformschema.ts",
@@ -51277,7 +51334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -51286,7 +51343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -51295,7 +51352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -51304,7 +51361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -51313,7 +51370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -51322,7 +51379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -51331,7 +51388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -51340,21 +51397,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
       "norm_label": "homehero.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1"
     },
     {
@@ -51414,6 +51462,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
       "norm_label": "homepagecontent.test.ts",
@@ -51421,7 +51478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -51430,7 +51487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -51439,7 +51496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -51448,7 +51505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -51457,7 +51514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -51466,7 +51523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -51475,7 +51532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -51484,21 +51541,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
       "norm_label": "productreviews.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1"
     },
     {
@@ -51558,6 +51606,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
       "norm_label": "errormessage.tsx",
@@ -51565,7 +51622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -51574,7 +51631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -51583,7 +51640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -51592,7 +51649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -51601,7 +51658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -51610,7 +51667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -51619,7 +51676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -51628,21 +51685,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
       "norm_label": "shoppingbag.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
@@ -51702,6 +51750,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
       "norm_label": "maintenance.test.tsx",
@@ -51709,7 +51766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -51718,7 +51775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -51727,7 +51784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -51736,7 +51793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -51745,7 +51802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -51754,7 +51811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -51763,7 +51820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -51772,21 +51829,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1"
     },
     {
@@ -52026,6 +52074,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
@@ -52033,7 +52090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -52042,7 +52099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -52051,7 +52108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -52060,7 +52117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -52069,7 +52126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -52078,7 +52135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -52087,7 +52144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -52096,21 +52153,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
       "norm_label": "input.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
@@ -52170,6 +52218,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
       "norm_label": "leaveareviewmodalform.tsx",
@@ -52177,7 +52234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -52186,7 +52243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -52195,7 +52252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -52204,7 +52261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -52213,7 +52270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -52222,7 +52279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -52231,7 +52288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -52240,21 +52297,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
       "norm_label": "scroll-area.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1"
     },
     {
@@ -52314,6 +52362,15 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
       "norm_label": "separator.tsx",
@@ -52321,7 +52378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -52330,7 +52387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -52339,7 +52396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -52348,7 +52405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -52357,7 +52414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -52366,7 +52423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -52375,7 +52432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -52384,21 +52441,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
       "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -52458,6 +52506,15 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
@@ -52465,7 +52522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -52474,7 +52531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -52483,7 +52540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -52492,7 +52549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -52501,7 +52558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -52510,7 +52567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -52519,7 +52576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -52528,21 +52585,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
       "source_location": "L1"
     },
     {
@@ -52602,6 +52650,15 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
@@ -52609,7 +52666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -52618,7 +52675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -52627,7 +52684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -52636,7 +52693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -52645,7 +52702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -52654,7 +52711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -52663,7 +52720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -52672,21 +52729,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1"
     },
     {
@@ -52746,6 +52794,15 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
       "norm_label": "storefrontjourneyevents.test.ts",
@@ -52753,7 +52810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -52762,7 +52819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -52771,7 +52828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -52780,7 +52837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -52789,7 +52846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -52798,7 +52855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -52807,7 +52864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -52816,21 +52873,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1"
     },
     {
@@ -52890,6 +52938,15 @@
     {
       "community": 1460,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1461,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
       "norm_label": "shop.saved.index.tsx",
@@ -52897,7 +52954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -52906,7 +52963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -52915,7 +52972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -52924,7 +52981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -52933,7 +52990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -52942,7 +52999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -52951,7 +53008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -52960,21 +53017,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1"
     },
     {
@@ -53034,6 +53082,15 @@
     {
       "community": 1470,
       "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1471,
+      "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
       "norm_label": "harness-app-registry.test.ts",
@@ -53041,7 +53098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1472,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -53050,7 +53107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1473,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -53059,7 +53116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1474,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -53068,7 +53125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1475,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -60846,6 +60903,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "scripts_worktree_manager_test_ts",
+      "label": "worktree-manager.test.ts",
+      "norm_label": "worktree-manager.test.ts",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "worktree_manager_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "worktree_manager_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "worktree_manager_test_runworktreemanager",
+      "label": "runWorktreeManager()",
+      "norm_label": "runworktreemanager()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
@@ -60853,7 +60946,7 @@
       "source_location": "L14"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -60862,7 +60955,7 @@
       "source_location": "L10"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -60871,7 +60964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -60880,7 +60973,7 @@
       "source_location": "L98"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -60889,7 +60982,7 @@
       "source_location": "L33"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -60898,7 +60991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -60907,7 +61000,7 @@
       "source_location": "L85"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -60916,7 +61009,7 @@
       "source_location": "L31"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -60925,7 +61018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -60934,7 +61027,7 @@
       "source_location": "L12"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -60943,7 +61036,7 @@
       "source_location": "L21"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -60952,7 +61045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -60961,7 +61054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -60970,7 +61063,7 @@
       "source_location": "L5"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -60979,7 +61072,7 @@
       "source_location": "L12"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -60988,7 +61081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -60997,7 +61090,7 @@
       "source_location": "L14"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -61006,7 +61099,7 @@
       "source_location": "L10"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -61015,7 +61108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61024,7 +61117,7 @@
       "source_location": "L6"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -61033,7 +61126,7 @@
       "source_location": "L9"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -61042,7 +61135,7 @@
       "source_location": "L43"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -61051,7 +61144,7 @@
       "source_location": "L11"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -61060,7 +61153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -61069,7 +61162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -61078,40 +61171,13 @@
       "source_location": "L26"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
       "source_location": "L118"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "staffprofiles_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L92"
     },
     {
       "community": 29,
@@ -61260,6 +61326,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "staffprofiles_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
       "norm_label": "staffroles.ts",
@@ -61267,7 +61360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -61276,7 +61369,7 @@
       "source_location": "L21"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -61285,7 +61378,7 @@
       "source_location": "L31"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -61294,7 +61387,7 @@
       "source_location": "L7"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -61303,7 +61396,7 @@
       "source_location": "L109"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -61312,7 +61405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -61321,7 +61414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -61330,7 +61423,7 @@
       "source_location": "L18"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -61339,7 +61432,7 @@
       "source_location": "L9"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -61348,7 +61441,7 @@
       "source_location": "L8"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -61357,7 +61450,7 @@
       "source_location": "L9"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -61366,7 +61459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -61375,7 +61468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -61384,7 +61477,7 @@
       "source_location": "L7"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -61393,7 +61486,7 @@
       "source_location": "L29"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -61402,7 +61495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -61411,7 +61504,7 @@
       "source_location": "L13"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -61420,7 +61513,7 @@
       "source_location": "L45"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -61429,7 +61522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -61438,7 +61531,7 @@
       "source_location": "L36"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -61447,7 +61540,7 @@
       "source_location": "L13"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -61456,7 +61549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -61465,7 +61558,7 @@
       "source_location": "L14"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -61474,7 +61567,7 @@
       "source_location": "L18"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -61483,7 +61576,7 @@
       "source_location": "L17"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -61492,40 +61585,13 @@
       "source_location": "L61"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
       "norm_label": "appointments.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
     },
     {
       "community": 3,
@@ -61944,6 +62010,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
       "norm_label": "receiving.test.ts",
@@ -61951,7 +62044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -61960,7 +62053,7 @@
       "source_location": "L20"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -61969,7 +62062,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -61978,7 +62071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -61987,7 +62080,7 @@
       "source_location": "L12"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -61996,7 +62089,7 @@
       "source_location": "L7"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -62005,7 +62098,7 @@
       "source_location": "L25"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -62014,7 +62107,7 @@
       "source_location": "L21"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -62023,7 +62116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -62032,7 +62125,7 @@
       "source_location": "L7"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -62041,7 +62134,7 @@
       "source_location": "L14"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -62050,7 +62143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -62059,7 +62152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -62068,7 +62161,7 @@
       "source_location": "L45"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -62077,7 +62170,7 @@
       "source_location": "L37"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -62086,7 +62179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -62095,7 +62188,7 @@
       "source_location": "L10"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -62104,7 +62197,7 @@
       "source_location": "L44"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -62113,7 +62206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -62122,7 +62215,7 @@
       "source_location": "L84"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -62131,7 +62224,7 @@
       "source_location": "L100"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -62140,7 +62233,7 @@
       "source_location": "L5"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -62149,7 +62242,7 @@
       "source_location": "L25"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -62158,7 +62251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -62167,7 +62260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -62176,40 +62269,13 @@
       "source_location": "L35"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
       "norm_label": "normalizeworkflowtracelookupvalue()",
       "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
       "source_location": "L25"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_view_tsx",
-      "label": "View.tsx",
-      "norm_label": "view.tsx",
-      "source_file": "packages/athena-webapp/src/components/View.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_view_tsx",
-      "label": "View.tsx",
-      "norm_label": "view.tsx",
-      "source_file": "packages/storefront-webapp/src/components/View.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "view_view",
-      "label": "View()",
-      "norm_label": "view()",
-      "source_file": "packages/storefront-webapp/src/components/View.tsx",
-      "source_location": "L4"
     },
     {
       "community": 31,
@@ -62340,6 +62406,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_view_tsx",
+      "label": "View.tsx",
+      "norm_label": "view.tsx",
+      "source_file": "packages/athena-webapp/src/components/View.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_view_tsx",
+      "label": "View.tsx",
+      "norm_label": "view.tsx",
+      "source_file": "packages/storefront-webapp/src/components/View.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "view_view",
+      "label": "View()",
+      "norm_label": "view()",
+      "source_file": "packages/storefront-webapp/src/components/View.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
       "norm_label": "productavailability.tsx",
@@ -62347,7 +62440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -62356,7 +62449,7 @@
       "source_location": "L19"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -62365,7 +62458,7 @@
       "source_location": "L5"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -62374,7 +62467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -62383,7 +62476,7 @@
       "source_location": "L19"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -62392,7 +62485,7 @@
       "source_location": "L11"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -62401,7 +62494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -62410,7 +62503,7 @@
       "source_location": "L22"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -62419,7 +62512,7 @@
       "source_location": "L8"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -62428,7 +62521,7 @@
       "source_location": "L21"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -62437,7 +62530,7 @@
       "source_location": "L13"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -62446,7 +62539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -62455,7 +62548,7 @@
       "source_location": "L100"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -62464,7 +62557,7 @@
       "source_location": "L10"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -62473,7 +62566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -62482,7 +62575,7 @@
       "source_location": "L100"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -62491,7 +62584,7 @@
       "source_location": "L10"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -62500,7 +62593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -62509,7 +62602,7 @@
       "source_location": "L15"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -62518,7 +62611,7 @@
       "source_location": "L39"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -62527,7 +62620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -62536,7 +62629,7 @@
       "source_location": "L3"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -62545,7 +62638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -62554,7 +62647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -62563,7 +62656,7 @@
       "source_location": "L53"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -62572,39 +62665,12 @@
       "source_location": "L65"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
       "norm_label": "bestsellers.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
     },
     {
@@ -62736,6 +62802,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
       "norm_label": "videoplayer.tsx",
@@ -62743,7 +62836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -62752,7 +62845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -62761,7 +62854,7 @@
       "source_location": "L9"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -62770,7 +62863,7 @@
       "source_location": "L295"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -62779,7 +62872,7 @@
       "source_location": "L285"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -62788,7 +62881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -62797,7 +62890,7 @@
       "source_location": "L70"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -62806,7 +62899,7 @@
       "source_location": "L227"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -62815,7 +62908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -62824,7 +62917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -62833,7 +62926,7 @@
       "source_location": "L71"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -62842,7 +62935,7 @@
       "source_location": "L9"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -62851,7 +62944,7 @@
       "source_location": "L100"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -62860,7 +62953,7 @@
       "source_location": "L95"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -62869,7 +62962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
@@ -62878,7 +62971,7 @@
       "source_location": "L33"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -62887,7 +62980,7 @@
       "source_location": "L24"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -62896,7 +62989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -62905,7 +62998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -62914,7 +63007,7 @@
       "source_location": "L115"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -62923,7 +63016,7 @@
       "source_location": "L82"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -62932,7 +63025,7 @@
       "source_location": "L28"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -62941,7 +63034,7 @@
       "source_location": "L34"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -62950,7 +63043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -62959,7 +63052,7 @@
       "source_location": "L36"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -62968,40 +63061,13 @@
       "source_location": "L32"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
       "norm_label": "heldsessionslist.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
-      "label": "TransactionView.test.tsx",
-      "norm_label": "transactionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "transactionview_test_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L148"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "transactionview_test_mocktransactionmutations",
-      "label": "mockTransactionMutations()",
-      "norm_label": "mocktransactionmutations()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L314"
     },
     {
       "community": 33,
@@ -63132,6 +63198,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
+      "label": "TransactionView.test.tsx",
+      "norm_label": "transactionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "transactionview_test_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L148"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "transactionview_test_mocktransactionmutations",
+      "label": "mockTransactionMutations()",
+      "norm_label": "mocktransactionmutations()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L314"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
       "norm_label": "productstatus.test.tsx",
@@ -63139,7 +63232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -63148,7 +63241,7 @@
       "source_location": "L8"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -63157,7 +63250,7 @@
       "source_location": "L18"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -63166,7 +63259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -63175,7 +63268,7 @@
       "source_location": "L65"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -63184,7 +63277,7 @@
       "source_location": "L20"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -63193,7 +63286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -63202,7 +63295,7 @@
       "source_location": "L16"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -63211,7 +63304,7 @@
       "source_location": "L60"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -63220,7 +63313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -63229,7 +63322,7 @@
       "source_location": "L45"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -63238,7 +63331,7 @@
       "source_location": "L19"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -63247,7 +63340,7 @@
       "source_location": "L128"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -63256,7 +63349,7 @@
       "source_location": "L40"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -63265,7 +63358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -63274,7 +63367,7 @@
       "source_location": "L24"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -63283,7 +63376,7 @@
       "source_location": "L20"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -63292,7 +63385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -63301,7 +63394,7 @@
       "source_location": "L25"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -63310,7 +63403,7 @@
       "source_location": "L17"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -63319,7 +63412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -63328,7 +63421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -63337,7 +63430,7 @@
       "source_location": "L59"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -63346,7 +63439,7 @@
       "source_location": "L50"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -63355,7 +63448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -63364,40 +63457,13 @@
       "source_location": "L225"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
       "norm_label": "serviceintakeviewcontent()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
       "source_location": "L80"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
-      "label": "StaffManagement.test.tsx",
-      "norm_label": "staffmanagement.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "staffmanagement_test_chooserole",
-      "label": "chooseRole()",
-      "norm_label": "chooserole()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "staffmanagement_test_mockconvex",
-      "label": "mockConvex()",
-      "norm_label": "mockconvex()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L71"
     },
     {
       "community": 34,
@@ -63528,6 +63594,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
+      "label": "StaffManagement.test.tsx",
+      "norm_label": "staffmanagement.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "staffmanagement_test_chooserole",
+      "label": "chooseRole()",
+      "norm_label": "chooserole()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "staffmanagement_test_mockconvex",
+      "label": "mockConvex()",
+      "norm_label": "mockconvex()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
       "norm_label": "staffauthenticationdialog.tsx",
@@ -63535,7 +63628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -63544,7 +63637,7 @@
       "source_location": "L158"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -63553,7 +63646,7 @@
       "source_location": "L105"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -63562,7 +63655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -63571,7 +63664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -63580,7 +63673,7 @@
       "source_location": "L3"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -63589,7 +63682,7 @@
       "source_location": "L9"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -63598,7 +63691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -63607,7 +63700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -63616,7 +63709,7 @@
       "source_location": "L3"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -63625,7 +63718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -63634,7 +63727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -63643,7 +63736,7 @@
       "source_location": "L3"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -63652,7 +63745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -63661,7 +63754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -63670,7 +63763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -63679,7 +63772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -63688,7 +63781,7 @@
       "source_location": "L3"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -63697,7 +63790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -63706,7 +63799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -63715,7 +63808,7 @@
       "source_location": "L3"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -63724,7 +63817,7 @@
       "source_location": "L4"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -63733,7 +63826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -63742,7 +63835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -63751,7 +63844,7 @@
       "source_location": "L120"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -63760,40 +63853,13 @@
       "source_location": "L36"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
       "norm_label": "feesview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
-      "label": "WorkflowTraceRouteLink.tsx",
-      "norm_label": "workflowtraceroutelink.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
-      "label": "getWorkflowTraceRouteTarget()",
-      "norm_label": "getworkflowtraceroutetarget()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "workflowtraceroutelink_workflowtraceroutelink",
-      "label": "WorkflowTraceRouteLink()",
-      "norm_label": "workflowtraceroutelink()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L41"
     },
     {
       "community": 35,
@@ -63915,6 +63981,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
+      "label": "WorkflowTraceRouteLink.tsx",
+      "norm_label": "workflowtraceroutelink.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
+      "label": "getWorkflowTraceRouteTarget()",
+      "norm_label": "getworkflowtraceroutetarget()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "workflowtraceroutelink_workflowtraceroutelink",
+      "label": "WorkflowTraceRouteLink()",
+      "norm_label": "workflowtraceroutelink()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
       "norm_label": "appcontextmenu()",
@@ -63922,7 +64015,7 @@
       "source_location": "L20"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -63931,7 +64024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -63940,7 +64033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -63949,7 +64042,7 @@
       "source_location": "L30"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -63958,7 +64051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -63967,7 +64060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -63976,7 +64069,7 @@
       "source_location": "L9"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -63985,7 +64078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -63994,7 +64087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -64003,7 +64096,7 @@
       "source_location": "L38"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -64012,7 +64105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -64021,7 +64114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -64030,7 +64123,7 @@
       "source_location": "L20"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -64039,7 +64132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -64048,7 +64141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -64057,7 +64150,7 @@
       "source_location": "L12"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -64066,7 +64159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -64075,7 +64168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -64084,7 +64177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -64093,7 +64186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -64102,7 +64195,7 @@
       "source_location": "L3"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -64111,7 +64204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -64120,7 +64213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -64129,7 +64222,7 @@
       "source_location": "L6"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -64138,7 +64231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -64147,40 +64240,13 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
       "norm_label": "spinner()",
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "activitysummarycards_activitysummarycards",
-      "label": "ActivitySummaryCards()",
-      "norm_label": "activitysummarycards()",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "activitysummarycards_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "label": "ActivitySummaryCards.tsx",
-      "norm_label": "activitysummarycards.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L1"
     },
     {
       "community": 36,
@@ -64302,6 +64368,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "activitysummarycards_activitysummarycards",
+      "label": "ActivitySummaryCards()",
+      "norm_label": "activitysummarycards()",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "activitysummarycards_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
+      "label": "ActivitySummaryCards.tsx",
+      "norm_label": "activitysummarycards.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
       "norm_label": "timelineeventcard.tsx",
@@ -64309,7 +64402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -64318,7 +64411,7 @@
       "source_location": "L159"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -64327,7 +64420,7 @@
       "source_location": "L195"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -64336,7 +64429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -64345,7 +64438,7 @@
       "source_location": "L22"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -64354,7 +64447,7 @@
       "source_location": "L45"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -64363,7 +64456,7 @@
       "source_location": "L24"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -64372,7 +64465,7 @@
       "source_location": "L38"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -64381,7 +64474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -64390,7 +64483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -64399,7 +64492,7 @@
       "source_location": "L23"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -64408,7 +64501,7 @@
       "source_location": "L51"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -64417,7 +64510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -64426,7 +64519,7 @@
       "source_location": "L54"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -64435,7 +64528,7 @@
       "source_location": "L282"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -64444,7 +64537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -64453,7 +64546,7 @@
       "source_location": "L12"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -64462,7 +64555,7 @@
       "source_location": "L37"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -64471,7 +64564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -64480,7 +64573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -64489,7 +64582,7 @@
       "source_location": "L4"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -64498,7 +64591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -64507,7 +64600,7 @@
       "source_location": "L9"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -64516,7 +64609,7 @@
       "source_location": "L50"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -64525,7 +64618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -64534,39 +64627,12 @@
       "source_location": "L6"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
       "norm_label": "usegetorganizations()",
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "label": "useGetProducts.ts",
-      "norm_label": "usegetproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "usegetproducts_usegetproducts",
-      "label": "useGetProducts()",
-      "norm_label": "usegetproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "usegetproducts_usegetunresolvedproducts",
-      "label": "useGetUnresolvedProducts()",
-      "norm_label": "usegetunresolvedproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31"
     },
     {
@@ -64689,6 +64755,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
+      "label": "useGetProducts.ts",
+      "norm_label": "usegetproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "usegetproducts_usegetproducts",
+      "label": "useGetProducts()",
+      "norm_label": "usegetproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "usegetproducts_usegetunresolvedproducts",
+      "label": "useGetUnresolvedProducts()",
+      "norm_label": "usegetunresolvedproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
       "norm_label": "usesessionmanagementexpense.ts",
@@ -64696,7 +64789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -64705,7 +64798,7 @@
       "source_location": "L19"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -64714,7 +64807,7 @@
       "source_location": "L33"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -64723,7 +64816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "presentcommandtoast_getapprovalguidance",
       "label": "getApprovalGuidance()",
@@ -64732,7 +64825,7 @@
       "source_location": "L9"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -64741,7 +64834,7 @@
       "source_location": "L16"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -64750,7 +64843,7 @@
       "source_location": "L7"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -64759,7 +64852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -64768,7 +64861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "bootstrapregister_test_drawer",
       "label": "drawer()",
@@ -64777,7 +64870,7 @@
       "source_location": "L9"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "bootstrapregister_test_state",
       "label": "state()",
@@ -64786,7 +64879,7 @@
       "source_location": "L23"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -64795,7 +64888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -64804,7 +64897,7 @@
       "source_location": "L3"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -64813,7 +64906,7 @@
       "source_location": "L10"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -64822,7 +64915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -64831,7 +64924,7 @@
       "source_location": "L18"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -64840,7 +64933,7 @@
       "source_location": "L60"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -64849,7 +64942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -64858,7 +64951,7 @@
       "source_location": "L31"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -64867,7 +64960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -64876,7 +64969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -64885,7 +64978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -64894,7 +64987,7 @@
       "source_location": "L28"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -64903,7 +64996,7 @@
       "source_location": "L46"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -64912,7 +65005,7 @@
       "source_location": "L18"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -64921,39 +65014,12 @@
       "source_location": "L28"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
       "norm_label": "_authed.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "actioncolorreview_stories_swatch",
-      "label": "Swatch()",
-      "norm_label": "swatch()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
-      "source_location": "L179"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "actioncolorreview_stories_tokenscope",
-      "label": "TokenScope()",
-      "norm_label": "tokenscope()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
-      "label": "ActionColorReview.stories.tsx",
-      "norm_label": "actioncolorreview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -65076,6 +65142,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "actioncolorreview_stories_swatch",
+      "label": "Swatch()",
+      "norm_label": "swatch()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L179"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "actioncolorreview_stories_tokenscope",
+      "label": "TokenScope()",
+      "norm_label": "tokenscope()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
+      "label": "ActionColorReview.stories.tsx",
+      "norm_label": "actioncolorreview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
       "norm_label": "patterncard()",
@@ -65083,7 +65176,7 @@
       "source_location": "L127"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -65092,7 +65185,7 @@
       "source_location": "L106"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -65101,7 +65194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -65110,7 +65203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -65119,7 +65212,7 @@
       "source_location": "L49"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -65128,7 +65221,7 @@
       "source_location": "L62"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -65137,7 +65230,7 @@
       "source_location": "L66"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -65146,7 +65239,7 @@
       "source_location": "L20"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -65155,7 +65248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -65164,7 +65257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -65173,7 +65266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -65182,7 +65275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -65191,7 +65284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -65200,7 +65293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -65209,7 +65302,7 @@
       "source_location": "L16"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -65218,7 +65311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -65227,7 +65320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -65236,7 +65329,7 @@
       "source_location": "L23"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -65245,7 +65338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -65254,7 +65347,7 @@
       "source_location": "L23"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -65263,7 +65356,7 @@
       "source_location": "L24"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -65272,7 +65365,7 @@
       "source_location": "L32"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -65281,7 +65374,7 @@
       "source_location": "L3"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -65290,7 +65383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -65299,7 +65392,7 @@
       "source_location": "L7"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -65308,39 +65401,12 @@
       "source_location": "L5"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "organization_getallorganizations",
-      "label": "getAllOrganizations()",
-      "norm_label": "getallorganizations()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "organization_getorganization",
-      "label": "getOrganization()",
-      "norm_label": "getorganization()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
     },
     {
@@ -65463,6 +65529,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "organization_getallorganizations",
+      "label": "getAllOrganizations()",
+      "norm_label": "getallorganizations()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "organization_getorganization",
+      "label": "getOrganization()",
+      "norm_label": "getorganization()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -65470,7 +65563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -65479,7 +65572,7 @@
       "source_location": "L60"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "postransaction_getpostransaction",
       "label": "getPosTransaction()",
@@ -65488,7 +65581,7 @@
       "source_location": "L62"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -65497,7 +65590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -65506,7 +65599,7 @@
       "source_location": "L3"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -65515,7 +65608,7 @@
       "source_location": "L5"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -65524,7 +65617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -65533,7 +65626,7 @@
       "source_location": "L18"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -65542,7 +65635,7 @@
       "source_location": "L23"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -65551,7 +65644,7 @@
       "source_location": "L22"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -65560,7 +65653,7 @@
       "source_location": "L55"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -65569,7 +65662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -65578,7 +65671,7 @@
       "source_location": "L77"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -65587,7 +65680,7 @@
       "source_location": "L11"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -65596,7 +65689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -65605,7 +65698,7 @@
       "source_location": "L11"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -65614,7 +65707,7 @@
       "source_location": "L22"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -65623,7 +65716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -65632,7 +65725,7 @@
       "source_location": "L110"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -65641,7 +65734,7 @@
       "source_location": "L89"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -65650,7 +65743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -65659,7 +65752,7 @@
       "source_location": "L4"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -65668,7 +65761,7 @@
       "source_location": "L24"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -65677,7 +65770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -65686,7 +65779,7 @@
       "source_location": "L131"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -65695,39 +65788,12 @@
       "source_location": "L12"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
       "norm_label": "footer.tsx",
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredproductssection",
-      "label": "FeaturedProductsSection()",
-      "norm_label": "featuredproductssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredsection",
-      "label": "FeaturedSection()",
-      "norm_label": "featuredsection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "label": "FeaturedProductsSection.tsx",
-      "norm_label": "featuredproductssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -66102,6 +66168,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "featuredproductssection_featuredproductssection",
+      "label": "FeaturedProductsSection()",
+      "norm_label": "featuredproductssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "featuredproductssection_featuredsection",
+      "label": "FeaturedSection()",
+      "norm_label": "featuredsection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
+      "label": "FeaturedProductsSection.tsx",
+      "norm_label": "featuredproductssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
       "norm_label": "promoalert.tsx",
@@ -66109,7 +66202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -66118,7 +66211,7 @@
       "source_location": "L20"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -66127,7 +66220,7 @@
       "source_location": "L59"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -66136,7 +66229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -66145,7 +66238,7 @@
       "source_location": "L25"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -66154,7 +66247,7 @@
       "source_location": "L20"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -66163,7 +66256,7 @@
       "source_location": "L30"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -66172,7 +66265,7 @@
       "source_location": "L95"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -66181,7 +66274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -66190,7 +66283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -66199,7 +66292,7 @@
       "source_location": "L150"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -66208,7 +66301,7 @@
       "source_location": "L157"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -66217,7 +66310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -66226,7 +66319,7 @@
       "source_location": "L63"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -66235,7 +66328,7 @@
       "source_location": "L48"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -66244,7 +66337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -66253,7 +66346,7 @@
       "source_location": "L63"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -66262,7 +66355,7 @@
       "source_location": "L76"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -66271,7 +66364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -66280,7 +66373,7 @@
       "source_location": "L51"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -66289,7 +66382,7 @@
       "source_location": "L36"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -66298,7 +66391,7 @@
       "source_location": "L16"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -66307,7 +66400,7 @@
       "source_location": "L39"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -66316,7 +66409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -66325,7 +66418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -66334,40 +66427,13 @@
       "source_location": "L20"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
       "norm_label": "usestorefrontobservability()",
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
     },
     {
       "community": 41,
@@ -66489,6 +66555,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
       "norm_label": "useshoppingbag.ts",
@@ -66496,7 +66589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -66505,7 +66598,7 @@
       "source_location": "L556"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -66514,7 +66607,7 @@
       "source_location": "L52"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -66523,7 +66616,7 @@
       "source_location": "L429"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -66532,7 +66625,7 @@
       "source_location": "L102"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -66541,7 +66634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -66550,7 +66643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -66559,7 +66652,7 @@
       "source_location": "L250"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -66568,7 +66661,7 @@
       "source_location": "L46"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -66577,7 +66670,7 @@
       "source_location": "L17"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -66586,7 +66679,7 @@
       "source_location": "L63"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -66595,7 +66688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -66604,7 +66697,7 @@
       "source_location": "L47"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -66613,7 +66706,7 @@
       "source_location": "L141"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -66622,7 +66715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -66631,7 +66724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -66640,7 +66733,7 @@
       "source_location": "L21"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -66649,7 +66742,7 @@
       "source_location": "L107"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "index_money",
       "label": "money()",
@@ -66658,7 +66751,7 @@
       "source_location": "L51"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "index_paymentlabel",
       "label": "paymentLabel()",
@@ -66667,7 +66760,7 @@
       "source_location": "L14"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
       "label": "index.tsx",
@@ -66676,7 +66769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -66685,7 +66778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -66694,7 +66787,7 @@
       "source_location": "L161"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -66703,7 +66796,7 @@
       "source_location": "L66"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -66712,7 +66805,7 @@
       "source_location": "L11"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -66721,39 +66814,12 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "graphify_wiki_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "graphify_wiki_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_test_ts",
-      "label": "graphify-wiki.test.ts",
-      "norm_label": "graphify-wiki.test.ts",
-      "source_file": "scripts/graphify-wiki.test.ts",
       "source_location": "L1"
     },
     {
@@ -66867,6 +66933,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "graphify_wiki_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "graphify_wiki_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_test_ts",
+      "label": "graphify-wiki.test.ts",
+      "norm_label": "graphify-wiki.test.ts",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -66874,7 +66967,7 @@
       "source_location": "L17"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -66883,7 +66976,7 @@
       "source_location": "L11"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -66892,7 +66985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -66901,7 +66994,7 @@
       "source_location": "L21"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -66910,7 +67003,7 @@
       "source_location": "L15"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -66919,7 +67012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -66928,7 +67021,7 @@
       "source_location": "L48"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -66937,7 +67030,7 @@
       "source_location": "L42"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -66946,7 +67039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -66955,7 +67048,7 @@
       "source_location": "L16"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -66964,7 +67057,7 @@
       "source_location": "L10"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -66973,7 +67066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -66982,7 +67075,7 @@
       "source_location": "L19"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -66991,7 +67084,7 @@
       "source_location": "L13"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -67000,7 +67093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -67009,7 +67102,7 @@
       "source_location": "L16"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -67018,7 +67111,7 @@
       "source_location": "L10"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -67027,7 +67120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -67036,7 +67129,7 @@
       "source_location": "L20"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -67045,7 +67138,7 @@
       "source_location": "L14"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -67054,7 +67147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -67063,7 +67156,7 @@
       "source_location": "L30"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -67072,7 +67165,7 @@
       "source_location": "L22"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -67081,7 +67174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -67090,7 +67183,7 @@
       "source_location": "L56"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "label": "stageTrackedGeneratedArtifacts()",
@@ -67099,30 +67192,12 @@
       "source_location": "L29"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
       "norm_label": "pre-commit-generated-artifacts.ts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "deposits_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
-      "label": "deposits.test.ts",
-      "norm_label": "deposits.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
       "source_location": "L1"
     },
     {
@@ -67236,6 +67311,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "deposits_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
+      "label": "deposits.test.ts",
+      "norm_label": "deposits.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
       "norm_label": "paymentallocationattribution.test.ts",
@@ -67243,7 +67336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -67252,7 +67345,7 @@
       "source_location": "L12"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -67261,7 +67354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -67270,7 +67363,7 @@
       "source_location": "L8"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -67279,7 +67372,7 @@
       "source_location": "L10"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -67288,7 +67381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -67297,7 +67390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -67306,7 +67399,7 @@
       "source_location": "L18"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -67315,7 +67408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -67324,7 +67417,7 @@
       "source_location": "L10"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -67333,7 +67426,7 @@
       "source_location": "L10"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -67342,7 +67435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -67351,7 +67444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -67360,7 +67453,7 @@
       "source_location": "L6"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -67369,7 +67462,7 @@
       "source_location": "L110"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -67378,7 +67471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
@@ -67387,31 +67480,13 @@
       "source_location": "L14"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
       "norm_label": "expensesessionitems.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
-      "label": "posQueryCleanup.test.ts",
-      "norm_label": "posquerycleanup.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "posquerycleanup_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 44,
@@ -67515,6 +67590,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
+      "label": "posQueryCleanup.test.ts",
+      "norm_label": "posquerycleanup.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "posquerycleanup_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
       "norm_label": "possessionitems.ts",
@@ -67522,7 +67615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -67531,7 +67624,7 @@
       "source_location": "L22"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -67540,7 +67633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -67549,7 +67642,7 @@
       "source_location": "L8"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -67558,7 +67651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -67567,7 +67660,7 @@
       "source_location": "L29"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -67576,7 +67669,7 @@
       "source_location": "L73"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -67585,7 +67678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -67594,7 +67687,7 @@
       "source_location": "L4"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -67603,7 +67696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -67612,7 +67705,7 @@
       "source_location": "L3"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -67621,7 +67714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -67630,7 +67723,7 @@
       "source_location": "L3"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -67639,7 +67732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -67648,7 +67741,7 @@
       "source_location": "L6"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -67657,7 +67750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -67666,30 +67759,12 @@
       "source_location": "L11"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
       "norm_label": "approvalauditevents.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "approvalproofs_test_createapprovalproofmutationctx",
-      "label": "createApprovalProofMutationCtx()",
-      "norm_label": "createapprovalproofmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
-      "label": "approvalProofs.test.ts",
-      "norm_label": "approvalproofs.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
       "source_location": "L1"
     },
     {
@@ -67794,6 +67869,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "approvalproofs_test_createapprovalproofmutationctx",
+      "label": "createApprovalProofMutationCtx()",
+      "norm_label": "createapprovalproofmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
+      "label": "approvalProofs.test.ts",
+      "norm_label": "approvalproofs.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
       "norm_label": "buildapprovalrequest()",
@@ -67801,7 +67894,7 @@
       "source_location": "L3"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -67810,7 +67903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -67819,7 +67912,7 @@
       "source_location": "L19"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -67828,7 +67921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -67837,7 +67930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -67846,7 +67939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -67855,7 +67948,7 @@
       "source_location": "L9"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -67864,7 +67957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -67873,7 +67966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -67882,7 +67975,7 @@
       "source_location": "L17"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -67891,7 +67984,7 @@
       "source_location": "L63"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -67900,7 +67993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -67909,7 +68002,7 @@
       "source_location": "L35"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -67918,7 +68011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -67927,7 +68020,7 @@
       "source_location": "L35"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -67936,7 +68029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -67945,30 +68038,12 @@
       "source_location": "L33"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
       "norm_label": "gettransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "inventoryholdgateway_createinventoryholdgateway",
-      "label": "createInventoryHoldGateway()",
-      "norm_label": "createinventoryholdgateway()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "label": "inventoryHoldGateway.ts",
-      "norm_label": "inventoryholdgateway.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
       "source_location": "L1"
     },
     {
@@ -68073,6 +68148,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "inventoryholdgateway_createinventoryholdgateway",
+      "label": "createInventoryHoldGateway()",
+      "norm_label": "createinventoryholdgateway()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
+      "label": "inventoryHoldGateway.ts",
+      "norm_label": "inventoryholdgateway.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
       "norm_label": "getcashierforregisterstate()",
@@ -68080,7 +68173,7 @@
       "source_location": "L7"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -68089,7 +68182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -68098,7 +68191,7 @@
       "source_location": "L60"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -68107,7 +68200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -68116,7 +68209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -68125,7 +68218,7 @@
       "source_location": "L88"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -68134,7 +68227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -68143,7 +68236,7 @@
       "source_location": "L57"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -68152,7 +68245,7 @@
       "source_location": "L9"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -68161,7 +68254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -68170,7 +68263,7 @@
       "source_location": "L4"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -68179,7 +68272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -68188,7 +68281,7 @@
       "source_location": "L15"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -68197,7 +68290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -68206,7 +68299,7 @@
       "source_location": "L7"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -68215,7 +68308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -68224,31 +68317,13 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
-      "label": "vendors.test.ts",
-      "norm_label": "vendors.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "vendors_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 47,
@@ -68352,6 +68427,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
+      "label": "vendors.test.ts",
+      "norm_label": "vendors.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "vendors_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
@@ -68359,7 +68452,7 @@
       "source_location": "L15"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -68368,7 +68461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -68377,7 +68470,7 @@
       "source_location": "L8"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -68386,7 +68479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -68395,7 +68488,7 @@
       "source_location": "L17"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -68404,7 +68497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -68413,7 +68506,7 @@
       "source_location": "L6"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -68422,7 +68515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -68431,7 +68524,7 @@
       "source_location": "L5"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -68440,7 +68533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -68449,7 +68542,7 @@
       "source_location": "L25"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -68458,7 +68551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -68467,7 +68560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -68476,7 +68569,7 @@
       "source_location": "L19"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -68485,7 +68578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -68494,7 +68587,7 @@
       "source_location": "L7"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -68503,31 +68596,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
       "norm_label": "listsavedbagitems()",
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "label": "storefrontObservabilityReport.test.ts",
-      "norm_label": "storefrontobservabilityreport.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 48,
@@ -68631,6 +68706,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
+      "label": "storefrontObservabilityReport.test.ts",
+      "norm_label": "storefrontobservabilityreport.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
       "norm_label": "syntheticmonitor.ts",
@@ -68638,7 +68731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -68647,7 +68740,7 @@
       "source_location": "L3"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -68656,7 +68749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -68665,7 +68758,7 @@
       "source_location": "L5"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -68674,7 +68767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -68683,7 +68776,7 @@
       "source_location": "L16"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -68692,7 +68785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -68701,7 +68794,7 @@
       "source_location": "L30"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -68710,7 +68803,7 @@
       "source_location": "L42"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
@@ -68719,7 +68812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -68728,7 +68821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -68737,7 +68830,7 @@
       "source_location": "L42"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -68746,7 +68839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -68755,7 +68848,7 @@
       "source_location": "L31"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -68764,7 +68857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -68773,7 +68866,7 @@
       "source_location": "L5"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -68782,30 +68875,12 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
       "norm_label": "validateserviceintakeinput()",
       "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "organizationview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "label": "OrganizationView.tsx",
-      "norm_label": "organizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1"
     },
     {
@@ -68910,6 +68985,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "organizationview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationview_tsx",
+      "label": "OrganizationView.tsx",
+      "norm_label": "organizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -68917,7 +69010,7 @@
       "source_location": "L12"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -68926,7 +69019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -68935,7 +69028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -68944,7 +69037,7 @@
       "source_location": "L11"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -68953,7 +69046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -68962,7 +69055,7 @@
       "source_location": "L11"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -68971,7 +69064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -68980,7 +69073,7 @@
       "source_location": "L3"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -68989,7 +69082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -68998,7 +69091,7 @@
       "source_location": "L12"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -69007,7 +69100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -69016,7 +69109,7 @@
       "source_location": "L42"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -69025,7 +69118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -69034,7 +69127,7 @@
       "source_location": "L13"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -69043,7 +69136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -69052,7 +69145,7 @@
       "source_location": "L42"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -69061,31 +69154,13 @@
       "source_location": "L31"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
       "norm_label": "barcodeqrviewer.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "label": "ProcessingFees.tsx",
-      "norm_label": "processingfees.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "processingfees_processingfeesview",
-      "label": "ProcessingFeesView()",
-      "norm_label": "processingfeesview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L10"
     },
     {
       "community": 5,
@@ -69432,6 +69507,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
+      "label": "ProcessingFees.tsx",
+      "norm_label": "processingfees.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "processingfees_processingfeesview",
+      "label": "ProcessingFeesView()",
+      "norm_label": "processingfeesview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
       "norm_label": "productattributes.tsx",
@@ -69439,7 +69532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -69448,7 +69541,7 @@
       "source_location": "L14"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -69457,7 +69550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -69466,7 +69559,7 @@
       "source_location": "L5"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -69475,7 +69568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -69484,7 +69577,7 @@
       "source_location": "L10"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -69493,7 +69586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -69502,7 +69595,7 @@
       "source_location": "L15"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -69511,7 +69604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -69520,7 +69613,7 @@
       "source_location": "L13"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -69529,7 +69622,7 @@
       "source_location": "L118"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -69538,7 +69631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -69547,7 +69640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -69556,7 +69649,7 @@
       "source_location": "L47"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -69565,7 +69658,7 @@
       "source_location": "L151"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -69574,7 +69667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -69583,30 +69676,12 @@
       "source_location": "L6"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
       "norm_label": "analyticsitems.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "analyticsproducts_analyticsproducts",
-      "label": "AnalyticsProducts()",
-      "norm_label": "analyticsproducts()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "label": "AnalyticsProducts.tsx",
-      "norm_label": "analyticsproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -69702,6 +69777,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "analyticsproducts_analyticsproducts",
+      "label": "AnalyticsProducts()",
+      "norm_label": "analyticsproducts()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
+      "label": "AnalyticsProducts.tsx",
+      "norm_label": "analyticsproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
       "norm_label": "analyticsusers()",
@@ -69709,7 +69802,7 @@
       "source_location": "L7"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -69718,7 +69811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -69727,7 +69820,7 @@
       "source_location": "L42"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -69736,7 +69829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -69745,7 +69838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -69754,7 +69847,7 @@
       "source_location": "L66"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -69763,7 +69856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -69772,7 +69865,7 @@
       "source_location": "L18"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -69781,7 +69874,7 @@
       "source_location": "L6"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -69790,7 +69883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -69799,7 +69892,7 @@
       "source_location": "L10"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -69808,7 +69901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -69817,7 +69910,7 @@
       "source_location": "L27"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -69826,7 +69919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -69835,7 +69928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -69844,7 +69937,7 @@
       "source_location": "L12"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -69853,30 +69946,12 @@
       "source_location": "L3"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
       "norm_label": "auth.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "index_login",
-      "label": "Login()",
-      "norm_label": "login()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69972,6 +70047,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "index_login",
+      "label": "Login()",
+      "norm_label": "login()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
       "norm_label": "datatablecolumnheader()",
@@ -69979,7 +70072,7 @@
       "source_location": "L24"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -69988,7 +70081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -69997,7 +70090,7 @@
       "source_location": "L49"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -70006,7 +70099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -70015,7 +70108,7 @@
       "source_location": "L23"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -70024,7 +70117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -70033,7 +70126,7 @@
       "source_location": "L50"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -70042,7 +70135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "formatreviewreason_formatreviewreason",
       "label": "formatReviewReason()",
@@ -70051,7 +70144,7 @@
       "source_location": "L3"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
       "label": "formatReviewReason.ts",
@@ -70060,7 +70153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
@@ -70069,7 +70162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -70078,7 +70171,7 @@
       "source_location": "L25"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -70087,7 +70180,7 @@
       "source_location": "L13"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -70096,7 +70189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -70105,7 +70198,7 @@
       "source_location": "L11"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -70114,7 +70207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -70123,30 +70216,12 @@
       "source_location": "L24"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
       "norm_label": "expensecompletion.tsx",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "expenseview_expenseview",
-      "label": "ExpenseView()",
-      "norm_label": "expenseview()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
-      "label": "ExpenseView.tsx",
-      "norm_label": "expenseview.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1"
     },
     {
@@ -70242,6 +70317,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "expenseview_expenseview",
+      "label": "ExpenseView()",
+      "norm_label": "expenseview()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
+      "label": "ExpenseView.tsx",
+      "norm_label": "expenseview.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
       "norm_label": "handleaddbestseller()",
@@ -70249,7 +70342,7 @@
       "source_location": "L29"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -70258,7 +70351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -70267,7 +70360,7 @@
       "source_location": "L37"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -70276,7 +70369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -70285,7 +70378,7 @@
       "source_location": "L25"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -70294,7 +70387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -70303,7 +70396,7 @@
       "source_location": "L83"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -70312,7 +70405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -70321,7 +70414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -70330,7 +70423,7 @@
       "source_location": "L35"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -70339,7 +70432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -70348,7 +70441,7 @@
       "source_location": "L28"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -70357,7 +70450,7 @@
       "source_location": "L12"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -70366,7 +70459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -70375,7 +70468,7 @@
       "source_location": "L13"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -70384,7 +70477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -70393,30 +70486,12 @@
       "source_location": "L43"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1"
     },
     {
@@ -70512,6 +70587,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
       "norm_label": "gettimefilter()",
@@ -70519,7 +70612,7 @@
       "source_location": "L35"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -70528,7 +70621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -70537,7 +70630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -70546,7 +70639,7 @@
       "source_location": "L81"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -70555,7 +70648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -70564,7 +70657,7 @@
       "source_location": "L6"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -70573,7 +70666,7 @@
       "source_location": "L34"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -70582,7 +70675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -70591,7 +70684,7 @@
       "source_location": "L89"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -70600,7 +70693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -70609,7 +70702,7 @@
       "source_location": "L215"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -70618,7 +70711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -70627,7 +70720,7 @@
       "source_location": "L5"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -70636,7 +70729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -70645,7 +70738,7 @@
       "source_location": "L7"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -70654,7 +70747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -70663,31 +70756,13 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
       "norm_label": "pininput()",
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
     },
     {
       "community": 55,
@@ -70782,6 +70857,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
       "norm_label": "printinstructions.tsx",
@@ -70789,7 +70882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -70798,7 +70891,7 @@
       "source_location": "L3"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -70807,7 +70900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -70816,7 +70909,7 @@
       "source_location": "L14"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -70825,7 +70918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -70834,7 +70927,7 @@
       "source_location": "L12"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -70843,7 +70936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -70852,7 +70945,7 @@
       "source_location": "L15"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -70861,7 +70954,7 @@
       "source_location": "L9"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -70870,7 +70963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -70879,7 +70972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -70888,7 +70981,7 @@
       "source_location": "L28"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -70897,7 +70990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -70906,7 +70999,7 @@
       "source_location": "L9"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
       "label": "RegisterDrawerGate.test.tsx",
@@ -70915,7 +71008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "registerdrawergate_test_rendergate",
       "label": "renderGate()",
@@ -70924,7 +71017,7 @@
       "source_location": "L26"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -70933,31 +71026,13 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
       "norm_label": "registersessionpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
-      "label": "transactionColumns.test.tsx",
-      "norm_label": "transactioncolumns.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "transactioncolumns_test_rendertransactioncell",
-      "label": "renderTransactionCell()",
-      "norm_label": "rendertransactioncell()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L34"
     },
     {
       "community": 56,
@@ -71052,6 +71127,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
+      "label": "transactionColumns.test.tsx",
+      "norm_label": "transactioncolumns.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "transactioncolumns_test_rendertransactioncell",
+      "label": "renderTransactionCell()",
+      "norm_label": "rendertransactioncell()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
       "norm_label": "transactioncolumns.tsx",
@@ -71059,7 +71152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -71068,7 +71161,7 @@
       "source_location": "L26"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -71077,7 +71170,7 @@
       "source_location": "L14"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -71086,7 +71179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -71095,7 +71188,7 @@
       "source_location": "L6"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -71104,7 +71197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -71113,7 +71206,7 @@
       "source_location": "L37"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -71122,7 +71215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -71131,7 +71224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -71140,7 +71233,7 @@
       "source_location": "L11"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -71149,7 +71242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -71158,7 +71251,7 @@
       "source_location": "L10"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -71167,7 +71260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -71176,7 +71269,7 @@
       "source_location": "L6"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -71185,7 +71278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -71194,7 +71287,7 @@
       "source_location": "L5"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -71203,31 +71296,13 @@
       "source_location": "L17"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
       "norm_label": "add-product-command.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "products_products",
-      "label": "Products()",
-      "norm_label": "products()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L4"
     },
     {
       "community": 57,
@@ -71322,6 +71397,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "products_products",
+      "label": "Products()",
+      "norm_label": "products()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
       "norm_label": "promocodeform.tsx",
@@ -71329,7 +71422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -71338,7 +71431,7 @@
       "source_location": "L84"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -71347,7 +71440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -71356,7 +71449,7 @@
       "source_location": "L23"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -71365,7 +71458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -71374,7 +71467,7 @@
       "source_location": "L37"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -71383,7 +71476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -71392,7 +71485,7 @@
       "source_location": "L9"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -71401,7 +71494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -71410,7 +71503,7 @@
       "source_location": "L23"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -71419,7 +71512,7 @@
       "source_location": "L5"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -71428,7 +71521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -71437,7 +71530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -71446,7 +71539,7 @@
       "source_location": "L4"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -71455,7 +71548,7 @@
       "source_location": "L13"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -71464,7 +71557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -71473,31 +71566,13 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
       "norm_label": "promocodemodal()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "label": "ReviewActions.tsx",
-      "norm_label": "reviewactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "reviewactions_reviewactions",
-      "label": "ReviewActions()",
-      "norm_label": "reviewactions()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L20"
     },
     {
       "community": 58,
@@ -71592,6 +71667,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
+      "label": "ReviewActions.tsx",
+      "norm_label": "reviewactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "reviewactions_reviewactions",
+      "label": "ReviewActions()",
+      "norm_label": "reviewactions()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
       "norm_label": "servicecasesview.test.tsx",
@@ -71599,7 +71692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -71608,7 +71701,7 @@
       "source_location": "L63"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -71617,7 +71710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -71626,7 +71719,7 @@
       "source_location": "L30"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -71635,7 +71728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -71644,7 +71737,7 @@
       "source_location": "L59"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -71653,7 +71746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -71662,7 +71755,7 @@
       "source_location": "L45"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -71671,7 +71764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -71680,7 +71773,7 @@
       "source_location": "L47"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -71689,7 +71782,7 @@
       "source_location": "L29"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -71698,7 +71791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -71707,7 +71800,7 @@
       "source_location": "L3"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -71716,7 +71809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -71725,7 +71818,7 @@
       "source_location": "L4"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -71734,7 +71827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -71743,31 +71836,13 @@
       "source_location": "L4"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
       "norm_label": "notfoundview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
-      "label": "ProtectedAdminSignInView.tsx",
-      "norm_label": "protectedadminsigninview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "protectedadminsigninview_protectedadminsigninview",
-      "label": "ProtectedAdminSignInView()",
-      "norm_label": "protectedadminsigninview()",
-      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
-      "source_location": "L9"
     },
     {
       "community": 59,
@@ -71862,6 +71937,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
+      "label": "ProtectedAdminSignInView.tsx",
+      "norm_label": "protectedadminsigninview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "protectedadminsigninview_protectedadminsigninview",
+      "label": "ProtectedAdminSignInView()",
+      "norm_label": "protectedadminsigninview()",
+      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
       "norm_label": "contactview()",
@@ -71869,7 +71962,7 @@
       "source_location": "L9"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -71878,7 +71971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -71887,7 +71980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -71896,7 +71989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -71905,7 +71998,7 @@
       "source_location": "L11"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -71914,7 +72007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -71923,7 +72016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -71932,7 +72025,7 @@
       "source_location": "L25"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -71941,7 +72034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -71950,7 +72043,7 @@
       "source_location": "L21"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -71959,7 +72052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -71968,7 +72061,7 @@
       "source_location": "L63"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -71977,7 +72070,7 @@
       "source_location": "L7"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -71986,7 +72079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -71995,7 +72088,7 @@
       "source_location": "L25"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -72004,7 +72097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -72013,30 +72106,12 @@
       "source_location": "L15"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
       "norm_label": "copy-button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "copy_wrapper_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "label": "copy-wrapper.tsx",
-      "norm_label": "copy-wrapper.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1"
     },
     {
@@ -72366,6 +72441,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "copy_wrapper_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
+      "label": "copy-wrapper.tsx",
+      "norm_label": "copy-wrapper.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "label_label",
       "label": "Label()",
       "norm_label": "label()",
@@ -72373,7 +72466,7 @@
       "source_location": "L6"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -72382,7 +72475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -72391,7 +72484,7 @@
       "source_location": "L25"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -72400,7 +72493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -72409,7 +72502,7 @@
       "source_location": "L49"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -72418,7 +72511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -72427,7 +72520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -72436,7 +72529,7 @@
       "source_location": "L63"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -72445,7 +72538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -72454,7 +72547,7 @@
       "source_location": "L5"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -72463,7 +72556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -72472,7 +72565,7 @@
       "source_location": "L12"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -72481,7 +72574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -72490,7 +72583,7 @@
       "source_location": "L15"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -72499,7 +72592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -72508,7 +72601,7 @@
       "source_location": "L3"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -72517,30 +72610,12 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "bagitems_bagitems",
-      "label": "BagItems()",
-      "norm_label": "bagitems()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "label": "BagItems.tsx",
-      "norm_label": "bagitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1"
     },
     {
@@ -72627,6 +72702,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "bagitems_bagitems",
+      "label": "BagItems()",
+      "norm_label": "bagitems()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
+      "label": "BagItems.tsx",
+      "norm_label": "bagitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
       "norm_label": "bagitemsview()",
@@ -72634,7 +72727,7 @@
       "source_location": "L11"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -72643,7 +72736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -72652,7 +72745,7 @@
       "source_location": "L4"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -72661,7 +72754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -72670,7 +72763,7 @@
       "source_location": "L102"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -72679,7 +72772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -72688,7 +72781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -72697,7 +72790,7 @@
       "source_location": "L13"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -72706,7 +72799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -72715,7 +72808,7 @@
       "source_location": "L7"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -72724,7 +72817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -72733,7 +72826,7 @@
       "source_location": "L11"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -72742,7 +72835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -72751,7 +72844,7 @@
       "source_location": "L7"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -72760,7 +72853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -72769,7 +72862,7 @@
       "source_location": "L45"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -72778,31 +72871,13 @@
       "source_location": "L13"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
       "norm_label": "customerjourneystage.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "label": "use-image-upload.ts",
-      "norm_label": "use-image-upload.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "use_image_upload_useimageupload",
-      "label": "useImageUpload()",
-      "norm_label": "useimageupload()",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L7"
     },
     {
       "community": 62,
@@ -72888,6 +72963,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
+      "label": "use-image-upload.ts",
+      "norm_label": "use-image-upload.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "use_image_upload_useimageupload",
+      "label": "useImageUpload()",
+      "norm_label": "useimageupload()",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_test_tsx",
       "label": "use-mobile.test.tsx",
       "norm_label": "use-mobile.test.tsx",
@@ -72895,7 +72988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "use_mobile_test_notifyviewportwidth",
       "label": "notifyViewportWidth()",
@@ -72904,7 +72997,7 @@
       "source_location": "L12"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -72913,7 +73006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -72922,7 +73015,7 @@
       "source_location": "L5"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -72931,7 +73024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -72940,7 +73033,7 @@
       "source_location": "L5"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -72949,7 +73042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -72958,7 +73051,7 @@
       "source_location": "L7"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -72967,7 +73060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -72976,7 +73069,7 @@
       "source_location": "L9"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -72985,7 +73078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -72994,7 +73087,7 @@
       "source_location": "L6"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -73003,7 +73096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -73012,7 +73105,7 @@
       "source_location": "L168"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -73021,7 +73114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -73030,7 +73123,7 @@
       "source_location": "L5"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -73039,31 +73132,13 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
       "norm_label": "usecopytext()",
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "label": "useCreateComplimentaryProduct.ts",
-      "norm_label": "usecreatecomplimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "label": "useCreateComplimentaryProduct()",
-      "norm_label": "usecreatecomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 63,
@@ -73149,6 +73224,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
+      "label": "useCreateComplimentaryProduct.ts",
+      "norm_label": "usecreatecomplimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
+      "label": "useCreateComplimentaryProduct()",
+      "norm_label": "usecreatecomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
       "norm_label": "usedebounce.ts",
@@ -73156,7 +73249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -73165,7 +73258,7 @@
       "source_location": "L12"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -73174,7 +73267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -73183,7 +73276,7 @@
       "source_location": "L24"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -73192,7 +73285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -73201,7 +73294,7 @@
       "source_location": "L6"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -73210,7 +73303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -73219,7 +73312,7 @@
       "source_location": "L4"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -73228,7 +73321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -73237,7 +73330,7 @@
       "source_location": "L5"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -73246,7 +73339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -73255,7 +73348,7 @@
       "source_location": "L5"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -73264,7 +73357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -73273,7 +73366,7 @@
       "source_location": "L4"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -73282,7 +73375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -73291,7 +73384,7 @@
       "source_location": "L5"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -73300,31 +73393,13 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
       "norm_label": "usegetterminal()",
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "label": "useNewOrderNotification.ts",
-      "norm_label": "usenewordernotification.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "usenewordernotification_usenewordernotification",
-      "label": "useNewOrderNotification()",
-      "norm_label": "usenewordernotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L8"
     },
     {
       "community": 64,
@@ -73410,6 +73485,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
+      "label": "useNewOrderNotification.ts",
+      "norm_label": "usenewordernotification.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "usenewordernotification_usenewordernotification",
+      "label": "useNewOrderNotification()",
+      "norm_label": "usenewordernotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
       "norm_label": "usepermissions.ts",
@@ -73417,7 +73510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -73426,7 +73519,7 @@
       "source_location": "L13"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -73435,7 +73528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -73444,7 +73537,7 @@
       "source_location": "L3"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -73453,7 +73546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -73462,7 +73555,7 @@
       "source_location": "L27"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -73471,7 +73564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -73480,7 +73573,7 @@
       "source_location": "L7"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -73489,7 +73582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -73498,7 +73591,7 @@
       "source_location": "L5"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -73507,7 +73600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -73516,7 +73609,7 @@
       "source_location": "L12"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -73525,7 +73618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -73534,7 +73627,7 @@
       "source_location": "L12"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -73543,7 +73636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -73552,7 +73645,7 @@
       "source_location": "L5"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -73561,31 +73654,13 @@
       "source_location": "L48"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
       "norm_label": "operatormessages.ts",
       "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
-      "label": "presentUnexpectedErrorToast.ts",
-      "norm_label": "presentunexpectederrortoast.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "presentunexpectederrortoast_presentunexpectederrortoast",
-      "label": "presentUnexpectedErrorToast()",
-      "norm_label": "presentunexpectederrortoast()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
-      "source_location": "L7"
     },
     {
       "community": 65,
@@ -73671,6 +73746,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
+      "label": "presentUnexpectedErrorToast.ts",
+      "norm_label": "presentunexpectederrortoast.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "presentunexpectederrortoast_presentunexpectederrortoast",
+      "label": "presentUnexpectedErrorToast()",
+      "norm_label": "presentunexpectederrortoast()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
       "norm_label": "getorigin()",
@@ -73678,7 +73771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -73687,7 +73780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -73696,7 +73789,7 @@
       "source_location": "L5"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -73705,7 +73798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -73714,7 +73807,7 @@
       "source_location": "L6"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -73723,7 +73816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -73732,7 +73825,7 @@
       "source_location": "L5"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -73741,7 +73834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -73750,7 +73843,7 @@
       "source_location": "L5"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -73759,7 +73852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -73768,7 +73861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -73777,7 +73870,7 @@
       "source_location": "L5"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -73786,7 +73879,7 @@
       "source_location": "L10"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -73795,7 +73888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -73804,7 +73897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "useregisterviewmodel_test_deferred",
       "label": "deferred()",
@@ -73813,7 +73906,7 @@
       "source_location": "L190"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -73822,31 +73915,13 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
       "norm_label": "hashpin()",
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 66,
@@ -73932,6 +74007,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
       "norm_label": "$sessionid.tsx",
@@ -73939,7 +74032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -73948,7 +74041,7 @@
       "source_location": "L6"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -73957,7 +74050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -73966,7 +74059,7 @@
       "source_location": "L6"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -73975,7 +74068,7 @@
       "source_location": "L13"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -73984,7 +74077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -73993,7 +74086,7 @@
       "source_location": "L6"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -74002,7 +74095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -74011,7 +74104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -74020,7 +74113,7 @@
       "source_location": "L9"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -74029,7 +74122,7 @@
       "source_location": "L13"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -74038,7 +74131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -74047,7 +74140,7 @@
       "source_location": "L4"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -74056,7 +74149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -74065,7 +74158,7 @@
       "source_location": "L13"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -74074,7 +74167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -74083,30 +74176,12 @@
       "source_location": "L5"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "controls_stories_controlsshowcase",
-      "label": "ControlsShowcase()",
-      "norm_label": "controlsshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
-      "label": "Controls.stories.tsx",
-      "norm_label": "controls.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -74193,6 +74268,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "controls_stories_controlsshowcase",
+      "label": "ControlsShowcase()",
+      "norm_label": "controlsshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
+      "label": "Controls.stories.tsx",
+      "norm_label": "controls.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
       "norm_label": "dialogshowcase()",
@@ -74200,7 +74293,7 @@
       "source_location": "L15"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -74209,7 +74302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -74218,7 +74311,7 @@
       "source_location": "L12"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -74227,7 +74320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -74236,7 +74329,7 @@
       "source_location": "L5"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -74245,7 +74338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -74254,7 +74347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -74263,7 +74356,7 @@
       "source_location": "L13"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -74272,7 +74365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -74281,7 +74374,7 @@
       "source_location": "L14"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -74290,7 +74383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -74299,7 +74392,7 @@
       "source_location": "L13"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -74308,7 +74401,7 @@
       "source_location": "L5"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -74317,7 +74410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -74326,7 +74419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -74335,7 +74428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -74344,30 +74437,12 @@
       "source_location": "L4"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "checkoutsession_test_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "label": "checkoutSession.test.ts",
-      "norm_label": "checkoutsession.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1"
     },
     {
@@ -74445,6 +74520,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "checkoutsession_test_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
+      "label": "checkoutSession.test.ts",
+      "norm_label": "checkoutsession.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
       "norm_label": "updateguest()",
@@ -74452,7 +74545,7 @@
       "source_location": "L4"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -74461,7 +74554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -74470,7 +74563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -74479,7 +74572,7 @@
       "source_location": "L5"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -74488,7 +74581,7 @@
       "source_location": "L10"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -74497,7 +74590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -74506,7 +74599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -74515,7 +74608,7 @@
       "source_location": "L10"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -74524,7 +74617,7 @@
       "source_location": "L4"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -74533,7 +74626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -74542,7 +74635,7 @@
       "source_location": "L39"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -74551,7 +74644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -74560,7 +74653,7 @@
       "source_location": "L18"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -74569,7 +74662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -74578,7 +74671,7 @@
       "source_location": "L71"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -74587,7 +74680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -74596,31 +74689,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
       "norm_label": "iswithinrestrictiontime()",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "label": "EnteredBillingAddressDetails.tsx",
-      "norm_label": "enteredbillingaddressdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
     },
     {
       "community": 69,
@@ -74697,6 +74772,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
+      "label": "EnteredBillingAddressDetails.tsx",
+      "norm_label": "enteredbillingaddressdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
       "norm_label": "ordersummary()",
@@ -74704,7 +74797,7 @@
       "source_location": "L18"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -74713,7 +74806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -74722,7 +74815,7 @@
       "source_location": "L10"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -74731,7 +74824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -74740,7 +74833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -74749,7 +74842,7 @@
       "source_location": "L8"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -74758,7 +74851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -74767,7 +74860,7 @@
       "source_location": "L27"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -74776,7 +74869,7 @@
       "source_location": "L40"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -74785,7 +74878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -74794,7 +74887,7 @@
       "source_location": "L3"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -74803,7 +74896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -74812,7 +74905,7 @@
       "source_location": "L8"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -74821,7 +74914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -74830,7 +74923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -74839,7 +74932,7 @@
       "source_location": "L12"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -74848,30 +74941,12 @@
       "source_location": "L77"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
       "norm_label": "customerdetailsform.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1"
     },
     {
@@ -75183,6 +75258,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
       "norm_label": "usecountdown()",
@@ -75190,7 +75283,7 @@
       "source_location": "L3"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -75199,7 +75292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -75208,7 +75301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -75217,7 +75310,7 @@
       "source_location": "L4"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -75226,7 +75319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -75235,7 +75328,7 @@
       "source_location": "L14"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -75244,7 +75337,7 @@
       "source_location": "L27"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -75253,7 +75346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -75262,7 +75355,7 @@
       "source_location": "L17"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -75271,7 +75364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -75280,7 +75373,7 @@
       "source_location": "L13"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -75289,7 +75382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -75298,7 +75391,7 @@
       "source_location": "L47"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -75307,7 +75400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -75316,7 +75409,7 @@
       "source_location": "L7"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -75325,7 +75418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -75334,31 +75427,13 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
       "norm_label": "sitebanner()",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
     },
     {
       "community": 71,
@@ -75435,6 +75510,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
       "norm_label": "mapvaluetolabelindex()",
@@ -75442,7 +75535,7 @@
       "source_location": "L12"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -75451,7 +75544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -75460,7 +75553,7 @@
       "source_location": "L7"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -75469,7 +75562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -75478,7 +75571,7 @@
       "source_location": "L45"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -75487,7 +75580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -75496,7 +75589,7 @@
       "source_location": "L5"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -75505,7 +75598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -75514,7 +75607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -75523,7 +75616,7 @@
       "source_location": "L17"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -75532,7 +75625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -75541,7 +75634,7 @@
       "source_location": "L3"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -75550,7 +75643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -75559,7 +75652,7 @@
       "source_location": "L37"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -75568,7 +75661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -75577,7 +75670,7 @@
       "source_location": "L79"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -75586,31 +75679,13 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
       "norm_label": "handlehelpful()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
     },
     {
       "community": 72,
@@ -75687,6 +75762,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
       "norm_label": "orderitem()",
@@ -75694,7 +75787,7 @@
       "source_location": "L12"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -75703,7 +75796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -75712,7 +75805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -75721,7 +75814,7 @@
       "source_location": "L18"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -75730,7 +75823,7 @@
       "source_location": "L10"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -75739,7 +75832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -75748,7 +75841,7 @@
       "source_location": "L11"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -75757,7 +75850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -75766,7 +75859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -75775,7 +75868,7 @@
       "source_location": "L59"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -75784,7 +75877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -75793,7 +75886,7 @@
       "source_location": "L33"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -75802,7 +75895,7 @@
       "source_location": "L19"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -75811,7 +75904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -75820,7 +75913,7 @@
       "source_location": "L4"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -75829,7 +75922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -75838,31 +75931,13 @@
       "source_location": "L22"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
       "norm_label": "errorboundary.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
-      "label": "ScrollDownButton.tsx",
-      "norm_label": "scrolldownbutton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "scrolldownbutton_scrolldownbutton",
-      "label": "ScrollDownButton()",
-      "norm_label": "scrolldownbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L11"
     },
     {
       "community": 73,
@@ -75939,6 +76014,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
+      "label": "ScrollDownButton.tsx",
+      "norm_label": "scrolldownbutton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "scrolldownbutton_scrolldownbutton",
+      "label": "ScrollDownButton()",
+      "norm_label": "scrolldownbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
       "norm_label": "countryselect()",
@@ -75946,7 +76039,7 @@
       "source_location": "L3"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -75955,7 +76048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -75964,7 +76057,7 @@
       "source_location": "L3"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -75973,7 +76066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -75982,7 +76075,7 @@
       "source_location": "L9"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -75991,7 +76084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -76000,7 +76093,7 @@
       "source_location": "L66"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -76009,7 +76102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -76018,7 +76111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -76027,7 +76120,7 @@
       "source_location": "L19"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -76036,7 +76129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -76045,7 +76138,7 @@
       "source_location": "L13"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -76054,7 +76147,7 @@
       "source_location": "L46"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -76063,7 +76156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -76072,7 +76165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -76081,7 +76174,7 @@
       "source_location": "L46"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -76090,30 +76183,12 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "formsubmissionprovider_useformsubmission",
-      "label": "useFormSubmission()",
-      "norm_label": "useformsubmission()",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
-      "label": "FormSubmissionProvider.tsx",
-      "norm_label": "formsubmissionprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1"
     },
     {
@@ -76191,6 +76266,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "formsubmissionprovider_useformsubmission",
+      "label": "useFormSubmission()",
+      "norm_label": "useformsubmission()",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
+      "label": "FormSubmissionProvider.tsx",
+      "norm_label": "formsubmissionprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
       "norm_label": "usecheckout.ts",
@@ -76198,7 +76291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -76207,7 +76300,7 @@
       "source_location": "L5"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -76216,7 +76309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -76225,7 +76318,7 @@
       "source_location": "L14"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -76234,7 +76327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -76243,7 +76336,7 @@
       "source_location": "L29"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -76252,7 +76345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -76261,7 +76354,7 @@
       "source_location": "L5"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -76270,7 +76363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -76279,7 +76372,7 @@
       "source_location": "L5"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -76288,7 +76381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -76297,7 +76390,7 @@
       "source_location": "L3"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -76306,7 +76399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -76315,7 +76408,7 @@
       "source_location": "L4"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -76324,7 +76417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -76333,7 +76426,7 @@
       "source_location": "L4"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -76342,31 +76435,13 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
       "norm_label": "useinventorystatus()",
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
-      "label": "useLeaveAReviewModal.tsx",
-      "norm_label": "useleaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "label": "useLeaveAReviewModal()",
-      "norm_label": "useleaveareviewmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L17"
     },
     {
       "community": 75,
@@ -76443,6 +76518,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
+      "label": "useLeaveAReviewModal.tsx",
+      "norm_label": "useleaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "useleaveareviewmodal_useleaveareviewmodal",
+      "label": "useLeaveAReviewModal()",
+      "norm_label": "useleaveareviewmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
       "norm_label": "uselogout.ts",
@@ -76450,7 +76543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -76459,7 +76552,7 @@
       "source_location": "L5"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -76468,7 +76561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -76477,7 +76570,7 @@
       "source_location": "L15"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -76486,7 +76579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -76495,7 +76588,7 @@
       "source_location": "L18"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -76504,7 +76597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -76513,7 +76606,7 @@
       "source_location": "L9"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -76522,7 +76615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -76531,7 +76624,7 @@
       "source_location": "L16"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -76540,7 +76633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -76549,7 +76642,7 @@
       "source_location": "L4"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -76558,7 +76651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -76567,7 +76660,7 @@
       "source_location": "L11"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -76576,7 +76669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -76585,7 +76678,7 @@
       "source_location": "L3"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -76594,31 +76687,13 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
       "norm_label": "usetrackaction()",
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
-      "label": "useTrackEvent.ts",
-      "norm_label": "usetrackevent.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "usetrackevent_usetrackevent",
-      "label": "useTrackEvent()",
-      "norm_label": "usetrackevent()",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L4"
     },
     {
       "community": 76,
@@ -76695,6 +76770,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
+      "label": "useTrackEvent.ts",
+      "norm_label": "usetrackevent.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "usetrackevent_usetrackevent",
+      "label": "useTrackEvent()",
+      "norm_label": "usetrackevent()",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
       "norm_label": "useupsellmodal.tsx",
@@ -76702,7 +76795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -76711,7 +76804,7 @@
       "source_location": "L14"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -76720,7 +76813,7 @@
       "source_location": "L4"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -76729,7 +76822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -76738,7 +76831,7 @@
       "source_location": "L7"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -76747,7 +76840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -76756,7 +76849,7 @@
       "source_location": "L6"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -76765,7 +76858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -76774,7 +76867,7 @@
       "source_location": "L10"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -76783,7 +76876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -76792,7 +76885,7 @@
       "source_location": "L6"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -76801,7 +76894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -76810,7 +76903,7 @@
       "source_location": "L5"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -76819,7 +76912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -76828,7 +76921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -76837,7 +76930,7 @@
       "source_location": "L5"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -76846,31 +76939,13 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
       "norm_label": "useproductqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "promocode_usepromocodesqueries",
-      "label": "usePromoCodesQueries()",
-      "norm_label": "usepromocodesqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
-      "source_location": "L9"
     },
     {
       "community": 77,
@@ -76947,6 +77022,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
+      "file_type": "code",
+      "id": "promocode_usepromocodesqueries",
+      "label": "usePromoCodesQueries()",
+      "norm_label": "usepromocodesqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -76954,7 +77047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -76963,7 +77056,7 @@
       "source_location": "L10"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -76972,7 +77065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -76981,7 +77074,7 @@
       "source_location": "L11"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -76990,7 +77083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -76999,7 +77092,7 @@
       "source_location": "L6"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -77008,7 +77101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -77017,7 +77110,7 @@
       "source_location": "L5"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -77026,7 +77119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -77035,7 +77128,7 @@
       "source_location": "L6"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -77044,7 +77137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -77053,7 +77146,7 @@
       "source_location": "L10"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -77062,7 +77155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -77071,7 +77164,7 @@
       "source_location": "L15"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -77080,7 +77173,7 @@
       "source_location": "L14"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -77089,7 +77182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -77098,31 +77191,13 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
       "norm_label": "createrouter()",
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "homepageloader_loadhomepagedata",
-      "label": "loadHomePageData()",
-      "norm_label": "loadhomepagedata()",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
-      "label": "-homePageLoader.ts",
-      "norm_label": "-homepageloader.ts",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L1"
     },
     {
       "community": 78,
@@ -77199,6 +77274,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "homepageloader_loadhomepagedata",
+      "label": "loadHomePageData()",
+      "norm_label": "loadhomepagedata()",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 780,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
+      "label": "-homePageLoader.ts",
+      "norm_label": "-homepageloader.ts",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
       "norm_label": "layoutcomponent()",
@@ -77206,7 +77299,7 @@
       "source_location": "L8"
     },
     {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -77215,7 +77308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -77224,7 +77317,7 @@
       "source_location": "L14"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -77233,7 +77326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -77242,7 +77335,7 @@
       "source_location": "L13"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -77251,7 +77344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -77260,7 +77353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -77269,7 +77362,7 @@
       "source_location": "L9"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -77278,7 +77371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -77287,7 +77380,7 @@
       "source_location": "L15"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -77296,7 +77389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -77305,7 +77398,7 @@
       "source_location": "L16"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -77314,7 +77407,7 @@
       "source_location": "L6"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -77323,7 +77416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -77332,7 +77425,7 @@
       "source_location": "L10"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -77341,7 +77434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -77350,30 +77443,12 @@
       "source_location": "L21"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
       "norm_label": "canceled.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "complete_index_checkoutcomplete",
-      "label": "CheckoutComplete()",
-      "norm_label": "checkoutcomplete()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
-      "label": "complete.index.tsx",
-      "norm_label": "complete.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1"
     },
     {
@@ -77451,6 +77526,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "complete_index_checkoutcomplete",
+      "label": "CheckoutComplete()",
+      "norm_label": "checkoutcomplete()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 790,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
+      "label": "complete.index.tsx",
+      "norm_label": "complete.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
       "norm_label": "pod-confirmation.tsx",
@@ -77458,7 +77551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -77467,7 +77560,7 @@
       "source_location": "L193"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -77476,7 +77569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -77485,7 +77578,7 @@
       "source_location": "L7"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -77494,7 +77587,7 @@
       "source_location": "L10"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -77503,7 +77596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -77512,7 +77605,7 @@
       "source_location": "L32"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -77521,7 +77614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -77530,7 +77623,7 @@
       "source_location": "L211"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -77539,7 +77632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -77548,7 +77641,7 @@
       "source_location": "L85"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -77557,7 +77650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -77566,7 +77659,7 @@
       "source_location": "L15"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -77575,7 +77668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -77584,21 +77677,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
       "norm_label": "api.js",
       "source_file": "packages/athena-webapp/convex/_generated/api.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "label": "dataModel.d.ts",
-      "norm_label": "datamodel.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
       "source_location": "L1"
     },
     {
@@ -77901,6 +77985,15 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
+      "label": "dataModel.d.ts",
+      "norm_label": "datamodel.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
       "norm_label": "server.d.ts",
@@ -77908,7 +78001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -77917,7 +78010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -77926,7 +78019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -77935,7 +78028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -77944,7 +78037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -77953,7 +78046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -77962,7 +78055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -77971,21 +78064,12 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
       "source_file": "packages/athena-webapp/convex/constants/email.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
       "source_location": "L1"
     },
     {
@@ -78063,6 +78147,15 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -78070,7 +78163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -78079,7 +78172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -78088,7 +78181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -78097,7 +78190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -78106,7 +78199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -78115,7 +78208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -78124,7 +78217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -78133,21 +78226,12 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -78225,6 +78309,15 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
@@ -78232,7 +78325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
       "label": "index.ts",
@@ -78241,7 +78334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
       "label": "organizations.ts",
@@ -78250,7 +78343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
@@ -78259,7 +78352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -78268,7 +78361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -78277,7 +78370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
@@ -78286,7 +78379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
@@ -78295,21 +78388,12 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
-      "label": "me.ts",
-      "norm_label": "me.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/me.ts",
       "source_location": "L1"
     },
     {
@@ -78387,6 +78471,15 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
+      "label": "me.ts",
+      "norm_label": "me.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/me.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
@@ -78394,7 +78487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -78403,7 +78496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
       "label": "paystack.ts",
@@ -78412,7 +78505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -78421,7 +78514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -78430,7 +78523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
@@ -78439,7 +78532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -78448,7 +78541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
@@ -78457,21 +78550,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/upsells.ts",
       "source_location": "L1"
     },
     {
@@ -78549,6 +78633,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -78556,7 +78649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -78565,7 +78658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
       "label": "index.ts",
@@ -78574,7 +78667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -78583,7 +78676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -78592,7 +78685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -78601,7 +78694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -78610,7 +78703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -78619,21 +78712,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1"
     },
     {
@@ -78711,6 +78795,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -78718,7 +78811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
@@ -78727,7 +78820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -78736,7 +78829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -78745,7 +78838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -78754,7 +78847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -78763,7 +78856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -78772,7 +78865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -78781,21 +78874,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
       "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productsku_ts",
-      "label": "productSku.ts",
-      "norm_label": "productsku.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1"
     },
     {
@@ -78873,6 +78957,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productsku_ts",
+      "label": "productSku.ts",
+      "norm_label": "productsku.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
       "norm_label": "productutil.test.ts",
@@ -78880,7 +78973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -78889,7 +78982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -78898,7 +78991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -78907,7 +79000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -78916,7 +79009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -78925,7 +79018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -78934,7 +79027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -78943,21 +79036,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
-      "label": "migrateAmountsToPesewas.ts",
-      "norm_label": "migrateamountstopesewas.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1"
     },
     {
@@ -79035,6 +79119,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
+      "label": "migrateAmountsToPesewas.ts",
+      "norm_label": "migrateamountstopesewas.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
       "norm_label": "client.test.ts",
@@ -79042,7 +79135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -79051,7 +79144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -79060,7 +79153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -79069,7 +79162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -79078,7 +79171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -79087,7 +79180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -79096,7 +79189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -79105,21 +79198,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
       "norm_label": "correcttransactioncustomer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/correctTransactionCustomer.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
-      "label": "correctionEvents.test.ts",
-      "norm_label": "correctionevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -79197,6 +79281,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
+      "label": "correctionEvents.test.ts",
+      "norm_label": "correctionevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
       "norm_label": "correctionpolicy.test.ts",
@@ -79204,7 +79297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -79213,7 +79306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -79222,7 +79315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -79231,7 +79324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -79240,7 +79333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -79249,7 +79342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -79258,7 +79351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -79267,21 +79360,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
-      "label": "customers.ts",
-      "norm_label": "customers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
       "source_location": "L1"
     },
     {
@@ -79350,6 +79434,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
+      "label": "customers.ts",
+      "norm_label": "customers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -79357,7 +79450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -79366,7 +79459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -79375,7 +79468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -79384,7 +79477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -79393,7 +79486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -79402,7 +79495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -79411,7 +79504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -79420,21 +79513,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1"
     },
     {
@@ -79701,6 +79785,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
@@ -79708,7 +79801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -79717,7 +79810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -79726,7 +79819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -79735,7 +79828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -79744,7 +79837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -79753,7 +79846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -79762,7 +79855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -79771,21 +79864,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -79854,6 +79938,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -79861,7 +79954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -79870,7 +79963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -79879,7 +79972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -79888,7 +79981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -79897,7 +79990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -79906,7 +79999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -79915,7 +80008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -79924,21 +80017,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
       "norm_label": "operationalevent.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
-      "label": "operationalWorkItem.ts",
-      "norm_label": "operationalworkitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
       "source_location": "L1"
     },
     {
@@ -80007,6 +80091,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
+      "label": "operationalWorkItem.ts",
+      "norm_label": "operationalworkitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
       "norm_label": "paymentallocation.ts",
@@ -80014,7 +80107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -80023,7 +80116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -80032,7 +80125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -80041,7 +80134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -80050,7 +80143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -80059,7 +80152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -80068,7 +80161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -80077,21 +80170,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
       "norm_label": "expensesessionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
-      "label": "expenseTransaction.ts",
-      "norm_label": "expensetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -80160,6 +80244,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
+      "label": "expenseTransaction.ts",
+      "norm_label": "expensetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
       "norm_label": "expensetransactionitem.ts",
@@ -80167,7 +80260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -80176,7 +80269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -80185,7 +80278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -80194,7 +80287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -80203,7 +80296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -80212,7 +80305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -80221,7 +80314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -80230,21 +80323,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
       "norm_label": "serviceappointment.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
-      "label": "serviceCase.ts",
-      "norm_label": "servicecase.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
       "source_location": "L1"
     },
     {
@@ -80313,6 +80397,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
+      "label": "serviceCase.ts",
+      "norm_label": "servicecase.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
       "norm_label": "servicecaselineitem.ts",
@@ -80320,7 +80413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -80329,7 +80422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -80338,7 +80431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -80347,7 +80440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -80356,7 +80449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -80365,7 +80458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -80374,7 +80467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -80383,21 +80476,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
       "norm_label": "vendor.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -80466,6 +80550,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
@@ -80473,7 +80566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -80482,7 +80575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -80491,7 +80584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -80500,7 +80593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -80509,7 +80602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -80518,7 +80611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -80527,7 +80620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -80536,21 +80629,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "label": "review.ts",
-      "norm_label": "review.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
       "source_location": "L1"
     },
     {
@@ -80619,6 +80703,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
+      "label": "review.ts",
+      "norm_label": "review.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -80626,7 +80719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -80635,7 +80728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -80644,7 +80737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -80653,7 +80746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -80662,7 +80755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -80671,7 +80764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -80680,7 +80773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -80689,21 +80782,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -80772,6 +80856,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
@@ -80779,7 +80872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -80788,7 +80881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -80797,7 +80890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -80806,7 +80899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -80815,7 +80908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -80824,7 +80917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -80833,7 +80926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -80842,21 +80935,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
       "norm_label": "users.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_types_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/types/payment.ts",
       "source_location": "L1"
     },
     {
@@ -80925,6 +81009,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_types_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/types/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
@@ -80932,7 +81025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -80941,7 +81034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -80950,7 +81043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -80959,7 +81052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -80968,7 +81061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -80977,7 +81070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
@@ -80986,7 +81079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -80995,21 +81088,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
       "norm_label": "commandresult.test.ts",
       "source_file": "packages/athena-webapp/shared/commandResult.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
-      "label": "currencyFormatter.test.ts",
-      "norm_label": "currencyformatter.test.ts",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.test.ts",
       "source_location": "L1"
     },
     {
@@ -81078,6 +81162,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
+      "label": "currencyFormatter.test.ts",
+      "norm_label": "currencyformatter.test.ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
       "norm_label": "registersessionstatus.test.ts",
@@ -81085,7 +81178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
       "label": "staffDisplayName.test.ts",
@@ -81094,7 +81187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -81103,7 +81196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -81112,7 +81205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -81121,7 +81214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -81130,7 +81223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_test_tsx",
       "label": "View.test.tsx",
@@ -81139,7 +81232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -81148,21 +81241,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
       "norm_label": "productattributesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -41153,6 +41153,18 @@
     },
     {
       "_src": "scripts_worktree_manager_test_ts",
+      "_tgt": "worktree_manager_test_fixtureenv",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_worktree_manager_test_ts",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L59",
+      "target": "worktree_manager_test_fixtureenv",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_worktree_manager_test_ts",
       "_tgt": "worktree_manager_test_rungit",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -41171,7 +41183,7 @@
       "relation": "contains",
       "source": "scripts_worktree_manager_test_ts",
       "source_file": "scripts/worktree-manager.test.ts",
-      "source_location": "L45",
+      "source_location": "L50",
       "target": "worktree_manager_test_runworktreemanager",
       "weight": 1
     },
@@ -44354,6 +44366,30 @@
       "source_location": "L27",
       "target": "worktree_manager_test_rungit",
       "weight": 1
+    },
+    {
+      "_src": "worktree_manager_test_rungit",
+      "_tgt": "worktree_manager_test_fixtureenv",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "worktree_manager_test_rungit",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L39",
+      "target": "worktree_manager_test_fixtureenv",
+      "weight": 1
+    },
+    {
+      "_src": "worktree_manager_test_runworktreemanager",
+      "_tgt": "worktree_manager_test_fixtureenv",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "worktree_manager_test_runworktreemanager",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L53",
+      "target": "worktree_manager_test_fixtureenv",
+      "weight": 1
     }
   ],
   "multigraph": false,
@@ -46773,65 +46809,65 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1090,
@@ -47115,65 +47151,65 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1100,
@@ -47268,65 +47304,65 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1110,
@@ -54360,6 +54396,51 @@
     {
       "community": 167,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
       "norm_label": "formatrequestdelay()",
@@ -54367,7 +54448,7 @@
       "source_location": "L33"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -54376,7 +54457,7 @@
       "source_location": "L81"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -54385,7 +54466,7 @@
       "source_location": "L120"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -54394,7 +54475,7 @@
       "source_location": "L89"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -54403,7 +54484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -54412,7 +54493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -54421,7 +54502,7 @@
       "source_location": "L30"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -54430,7 +54511,7 @@
       "source_location": "L8"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -54439,58 +54520,13 @@
       "source_location": "L49"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
       "norm_label": "viewheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
     },
     {
       "community": 17,
@@ -54666,6 +54702,51 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
       "norm_label": "handledisplaytypechange()",
@@ -54673,7 +54754,7 @@
       "source_location": "L61"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -54682,7 +54763,7 @@
       "source_location": "L57"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -54691,7 +54772,7 @@
       "source_location": "L98"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -54700,7 +54781,7 @@
       "source_location": "L134"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -54709,7 +54790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -54718,7 +54799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -54727,7 +54808,7 @@
       "source_location": "L38"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -54736,7 +54817,7 @@
       "source_location": "L64"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -54745,7 +54826,7 @@
       "source_location": "L135"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -54754,7 +54835,7 @@
       "source_location": "L43"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -54763,7 +54844,7 @@
       "source_location": "L58"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -54772,7 +54853,7 @@
       "source_location": "L63"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -54781,7 +54862,7 @@
       "source_location": "L50"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -54790,7 +54871,7 @@
       "source_location": "L53"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -54799,7 +54880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -54808,7 +54889,7 @@
       "source_location": "L140"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -54817,7 +54898,7 @@
       "source_location": "L177"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -54826,7 +54907,7 @@
       "source_location": "L195"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -54835,7 +54916,7 @@
       "source_location": "L45"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -54844,7 +54925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -54853,7 +54934,7 @@
       "source_location": "L92"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -54862,7 +54943,7 @@
       "source_location": "L307"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -54871,7 +54952,7 @@
       "source_location": "L70"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -54880,57 +54961,12 @@
       "source_location": "L50"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -56808,6 +56844,51 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "scripts_worktree_manager_test_ts",
+      "label": "worktree-manager.test.ts",
+      "norm_label": "worktree-manager.test.ts",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "worktree_manager_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "worktree_manager_test_fixtureenv",
+      "label": "fixtureEnv()",
+      "norm_label": "fixtureenv()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "worktree_manager_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "worktree_manager_test_runworktreemanager",
+      "label": "runWorktreeManager()",
+      "norm_label": "runworktreemanager()",
+      "source_file": "scripts/worktree-manager.test.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
       "norm_label": "createtemproot()",
@@ -56815,7 +56896,7 @@
       "source_location": "L12"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -56824,7 +56905,7 @@
       "source_location": "L26"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -56833,7 +56914,7 @@
       "source_location": "L20"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -56842,7 +56923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -56851,7 +56932,7 @@
       "source_location": "L109"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -56860,7 +56941,7 @@
       "source_location": "L84"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -56869,7 +56950,7 @@
       "source_location": "L95"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -56878,7 +56959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -56887,7 +56968,7 @@
       "source_location": "L145"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -56896,7 +56977,7 @@
       "source_location": "L35"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -56905,7 +56986,7 @@
       "source_location": "L160"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -56914,7 +56995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -56923,7 +57004,7 @@
       "source_location": "L50"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -56932,7 +57013,7 @@
       "source_location": "L23"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -56941,7 +57022,7 @@
       "source_location": "L37"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -56950,7 +57031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -56959,7 +57040,7 @@
       "source_location": "L21"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -56968,7 +57049,7 @@
       "source_location": "L35"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -56977,7 +57058,7 @@
       "source_location": "L45"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -56986,7 +57067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -56995,7 +57076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -57004,7 +57085,7 @@
       "source_location": "L21"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -57013,7 +57094,7 @@
       "source_location": "L35"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -57022,7 +57103,7 @@
       "source_location": "L45"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -57031,7 +57112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -57040,7 +57121,7 @@
       "source_location": "L247"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -57049,7 +57130,7 @@
       "source_location": "L92"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -57058,7 +57139,7 @@
       "source_location": "L264"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -57067,7 +57148,7 @@
       "source_location": "L5"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -57076,7 +57157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -57085,7 +57166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -57094,7 +57175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -57103,7 +57184,7 @@
       "source_location": "L26"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -57112,7 +57193,7 @@
       "source_location": "L79"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -57121,48 +57202,12 @@
       "source_location": "L33"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
       "norm_label": "collections.ts",
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "normalize_maskmtnpartyid",
-      "label": "maskMtnPartyId()",
-      "norm_label": "maskmtnpartyid()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "normalize_normalizecollectionstransaction",
-      "label": "normalizeCollectionsTransaction()",
-      "norm_label": "normalizecollectionstransaction()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "normalize_parsecollectionsnotificationrequest",
-      "label": "parseCollectionsNotificationRequest()",
-      "norm_label": "parsecollectionsnotificationrequest()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "label": "normalize.ts",
-      "norm_label": "normalize.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1"
     },
     {
@@ -57330,6 +57375,42 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "normalize_maskmtnpartyid",
+      "label": "maskMtnPartyId()",
+      "norm_label": "maskmtnpartyid()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "normalize_normalizecollectionstransaction",
+      "label": "normalizeCollectionsTransaction()",
+      "norm_label": "normalizecollectionstransaction()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "normalize_parsecollectionsnotificationrequest",
+      "label": "parseCollectionsNotificationRequest()",
+      "norm_label": "parsecollectionsnotificationrequest()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
+      "label": "normalize.ts",
+      "norm_label": "normalize.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
       "norm_label": "consumeapprovalproofwithctx()",
@@ -57337,7 +57418,7 @@
       "source_location": "L98"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -57346,7 +57427,7 @@
       "source_location": "L56"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -57355,7 +57436,7 @@
       "source_location": "L49"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -57364,7 +57445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -57373,7 +57454,7 @@
       "source_location": "L28"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -57382,7 +57463,7 @@
       "source_location": "L42"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -57391,7 +57472,7 @@
       "source_location": "L73"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -57400,7 +57481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -57409,7 +57490,7 @@
       "source_location": "L8"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -57418,7 +57499,7 @@
       "source_location": "L32"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -57427,7 +57508,7 @@
       "source_location": "L64"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -57436,7 +57517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -57445,7 +57526,7 @@
       "source_location": "L18"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -57454,7 +57535,7 @@
       "source_location": "L25"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -57463,7 +57544,7 @@
       "source_location": "L11"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -57472,7 +57553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -57481,7 +57562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -57490,7 +57571,7 @@
       "source_location": "L33"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -57499,7 +57580,7 @@
       "source_location": "L19"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -57508,7 +57589,7 @@
       "source_location": "L42"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -57517,7 +57598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -57526,7 +57607,7 @@
       "source_location": "L31"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -57535,7 +57616,7 @@
       "source_location": "L48"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -57544,7 +57625,7 @@
       "source_location": "L131"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -57553,7 +57634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -57562,7 +57643,7 @@
       "source_location": "L37"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -57571,7 +57652,7 @@
       "source_location": "L24"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -57580,7 +57661,7 @@
       "source_location": "L19"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -57589,7 +57670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -57598,7 +57679,7 @@
       "source_location": "L31"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -57607,7 +57688,7 @@
       "source_location": "L26"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -57616,7 +57697,7 @@
       "source_location": "L53"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -57625,7 +57706,7 @@
       "source_location": "L36"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -57634,7 +57715,7 @@
       "source_location": "L96"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -57643,48 +57724,12 @@
       "source_location": "L71"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
       "norm_label": "opendrawer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "getregisterstate_buildregisterstate",
-      "label": "buildRegisterState()",
-      "norm_label": "buildregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "getregisterstate_getactivesessionconflictforregisterstate",
-      "label": "getActiveSessionConflictForRegisterState()",
-      "norm_label": "getactivesessionconflictforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "getregisterstate_getregisterstate",
-      "label": "getRegisterState()",
-      "norm_label": "getregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
-      "label": "getRegisterState.ts",
-      "norm_label": "getregisterstate.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
       "source_location": "L1"
     },
     {
@@ -57852,6 +57897,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "getregisterstate_buildregisterstate",
+      "label": "buildRegisterState()",
+      "norm_label": "buildregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "getregisterstate_getactivesessionconflictforregisterstate",
+      "label": "getActiveSessionConflictForRegisterState()",
+      "norm_label": "getactivesessionconflictforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "getregisterstate_getregisterstate",
+      "label": "getRegisterState()",
+      "norm_label": "getregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "label": "getRegisterState.ts",
+      "norm_label": "getregisterstate.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
       "norm_label": "searchcatalog.ts",
@@ -57859,7 +57940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -57868,7 +57949,7 @@
       "source_location": "L122"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -57877,7 +57958,7 @@
       "source_location": "L34"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -57886,7 +57967,7 @@
       "source_location": "L72"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -57895,7 +57976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -57904,7 +57985,7 @@
       "source_location": "L162"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -57913,7 +57994,7 @@
       "source_location": "L56"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -57922,7 +58003,7 @@
       "source_location": "L180"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -57931,7 +58012,7 @@
       "source_location": "L31"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -57940,7 +58021,7 @@
       "source_location": "L176"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -57949,7 +58030,7 @@
       "source_location": "L27"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -57958,7 +58039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -57967,7 +58048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -57976,7 +58057,7 @@
       "source_location": "L23"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -57985,7 +58066,7 @@
       "source_location": "L9"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -57994,7 +58075,7 @@
       "source_location": "L13"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -58003,7 +58084,7 @@
       "source_location": "L19"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -58012,7 +58093,7 @@
       "source_location": "L26"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -58021,7 +58102,7 @@
       "source_location": "L12"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -58030,7 +58111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -58039,7 +58120,7 @@
       "source_location": "L21"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -58048,7 +58129,7 @@
       "source_location": "L63"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -58057,7 +58138,7 @@
       "source_location": "L71"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -58066,7 +58147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -58075,7 +58156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -58084,7 +58165,7 @@
       "source_location": "L13"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -58093,7 +58174,7 @@
       "source_location": "L31"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -58102,7 +58183,7 @@
       "source_location": "L9"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -58111,7 +58192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -58120,7 +58201,7 @@
       "source_location": "L12"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -58129,7 +58210,7 @@
       "source_location": "L46"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -58138,7 +58219,7 @@
       "source_location": "L7"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -58147,7 +58228,7 @@
       "source_location": "L227"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -58156,7 +58237,7 @@
       "source_location": "L46"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -58165,48 +58246,12 @@
       "source_location": "L27"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
       "norm_label": "attributesmanager.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "attributestable_getproductattribute",
-      "label": "getProductAttribute()",
-      "norm_label": "getproductattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "attributestable_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "attributestable_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L211"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "label": "AttributesTable.tsx",
-      "norm_label": "attributestable.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1"
     },
     {
@@ -58365,6 +58410,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "attributestable_getproductattribute",
+      "label": "getProductAttribute()",
+      "norm_label": "getproductattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "attributestable_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "attributestable_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L211"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
+      "label": "AttributesTable.tsx",
+      "norm_label": "attributestable.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
       "norm_label": "categorymanager()",
@@ -58372,7 +58453,7 @@
       "source_location": "L52"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -58381,7 +58462,7 @@
       "source_location": "L27"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -58390,7 +58471,7 @@
       "source_location": "L288"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -58399,7 +58480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -58408,7 +58489,7 @@
       "source_location": "L48"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -58417,7 +58498,7 @@
       "source_location": "L88"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -58426,7 +58507,7 @@
       "source_location": "L14"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -58435,7 +58516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -58444,7 +58525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -58453,7 +58534,7 @@
       "source_location": "L15"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -58462,7 +58543,7 @@
       "source_location": "L28"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -58471,7 +58552,7 @@
       "source_location": "L19"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -58480,7 +58561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -58489,7 +58570,7 @@
       "source_location": "L52"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -58498,7 +58579,7 @@
       "source_location": "L3"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -58507,7 +58588,7 @@
       "source_location": "L90"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -58516,7 +58597,7 @@
       "source_location": "L86"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -58525,7 +58606,7 @@
       "source_location": "L76"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -58534,7 +58615,7 @@
       "source_location": "L52"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -58543,7 +58624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -58552,7 +58633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -58561,7 +58642,7 @@
       "source_location": "L67"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -58570,7 +58651,7 @@
       "source_location": "L90"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -58579,7 +58660,7 @@
       "source_location": "L73"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -58588,7 +58669,7 @@
       "source_location": "L76"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -58597,7 +58678,7 @@
       "source_location": "L65"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -58606,7 +58687,7 @@
       "source_location": "L83"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -58615,7 +58696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -58624,7 +58705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -58633,7 +58714,7 @@
       "source_location": "L105"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -58642,7 +58723,7 @@
       "source_location": "L97"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -58651,7 +58732,7 @@
       "source_location": "L83"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -58660,7 +58741,7 @@
       "source_location": "L91"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -58669,7 +58750,7 @@
       "source_location": "L68"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -58678,48 +58759,12 @@
       "source_location": "L22"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
       "norm_label": "newtransactionview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "ordersummary_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L377"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L259"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "ordersummary_handlestartnewtransaction",
-      "label": "handleStartNewTransaction()",
-      "norm_label": "handlestartnewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L276"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -58878,6 +58923,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L377"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L259"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "ordersummary_handlestartnewtransaction",
+      "label": "handleStartNewTransaction()",
+      "norm_label": "handlestartnewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L276"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
       "norm_label": "possettingsview.tsx",
@@ -58885,7 +58966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -58894,7 +58975,7 @@
       "source_location": "L312"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -58903,7 +58984,7 @@
       "source_location": "L364"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -58912,7 +58993,7 @@
       "source_location": "L219"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -58921,7 +59002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -58930,7 +59011,7 @@
       "source_location": "L22"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -58939,7 +59020,7 @@
       "source_location": "L27"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -58948,7 +59029,7 @@
       "source_location": "L40"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -58957,7 +59038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -58966,7 +59047,7 @@
       "source_location": "L78"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -58975,7 +59056,7 @@
       "source_location": "L118"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -58984,7 +59065,7 @@
       "source_location": "L89"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -58993,7 +59074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -59002,7 +59083,7 @@
       "source_location": "L63"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -59011,7 +59092,7 @@
       "source_location": "L54"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -59020,7 +59101,7 @@
       "source_location": "L11"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -59029,7 +59110,7 @@
       "source_location": "L16"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -59038,7 +59119,7 @@
       "source_location": "L35"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -59047,7 +59128,7 @@
       "source_location": "L6"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -59056,7 +59137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -59065,7 +59146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -59074,7 +59155,7 @@
       "source_location": "L5"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -59083,7 +59164,7 @@
       "source_location": "L30"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -59092,7 +59173,7 @@
       "source_location": "L21"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -59101,7 +59182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -59110,7 +59191,7 @@
       "source_location": "L178"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -59119,7 +59200,7 @@
       "source_location": "L205"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -59128,7 +59209,7 @@
       "source_location": "L806"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -59137,7 +59218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -59146,7 +59227,7 @@
       "source_location": "L41"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -59155,7 +59236,7 @@
       "source_location": "L45"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -59164,7 +59245,7 @@
       "source_location": "L65"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -59173,7 +59254,7 @@
       "source_location": "L75"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -59182,7 +59263,7 @@
       "source_location": "L82"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -59191,49 +59272,13 @@
       "source_location": "L93"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
       "norm_label": "engagementmetrics.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "label": "RiskIndicators.tsx",
-      "norm_label": "riskindicators.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "riskindicators_getriskicon",
-      "label": "getRiskIcon()",
-      "norm_label": "getriskicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "riskindicators_getriskstyles",
-      "label": "getRiskStyles()",
-      "norm_label": "getriskstyles()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "riskindicators_riskindicators",
-      "label": "RiskIndicators()",
-      "norm_label": "riskindicators()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L54"
     },
     {
       "community": 25,
@@ -59391,6 +59436,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
+      "label": "RiskIndicators.tsx",
+      "norm_label": "riskindicators.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "riskindicators_getriskicon",
+      "label": "getRiskIcon()",
+      "norm_label": "getriskicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "riskindicators_getriskstyles",
+      "label": "getRiskStyles()",
+      "norm_label": "getriskstyles()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "riskindicators_riskindicators",
+      "label": "RiskIndicators()",
+      "norm_label": "riskindicators()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
       "norm_label": "formatobservabilitylabel()",
@@ -59398,7 +59479,7 @@
       "source_location": "L66"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -59407,7 +59488,7 @@
       "source_location": "L121"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -59416,7 +59497,7 @@
       "source_location": "L74"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -59425,7 +59506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -59434,7 +59515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -59443,7 +59524,7 @@
       "source_location": "L34"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -59452,7 +59533,7 @@
       "source_location": "L28"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -59461,7 +59542,7 @@
       "source_location": "L48"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -59470,7 +59551,7 @@
       "source_location": "L51"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -59479,7 +59560,7 @@
       "source_location": "L92"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -59488,7 +59569,7 @@
       "source_location": "L16"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -59497,7 +59578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -59506,7 +59587,7 @@
       "source_location": "L22"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -59515,7 +59596,7 @@
       "source_location": "L10"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -59524,7 +59605,7 @@
       "source_location": "L57"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -59533,7 +59614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -59542,7 +59623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -59551,7 +59632,7 @@
       "source_location": "L83"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -59560,7 +59641,7 @@
       "source_location": "L100"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -59569,7 +59650,7 @@
       "source_location": "L79"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -59578,7 +59659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -59587,7 +59668,7 @@
       "source_location": "L38"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -59596,7 +59677,7 @@
       "source_location": "L65"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -59605,7 +59686,7 @@
       "source_location": "L91"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -59614,7 +59695,7 @@
       "source_location": "L4"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -59623,7 +59704,7 @@
       "source_location": "L20"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -59632,7 +59713,7 @@
       "source_location": "L42"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -59641,7 +59722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -59650,7 +59731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -59659,7 +59740,7 @@
       "source_location": "L36"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -59668,7 +59749,7 @@
       "source_location": "L48"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -59677,7 +59758,7 @@
       "source_location": "L64"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -59686,7 +59767,7 @@
       "source_location": "L13"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -59695,7 +59776,7 @@
       "source_location": "L46"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -59704,49 +59785,13 @@
       "source_location": "L21"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
     },
     {
       "community": 26,
@@ -59895,6 +59940,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -59902,7 +59983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -59911,7 +59992,7 @@
       "source_location": "L11"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -59920,7 +60001,7 @@
       "source_location": "L9"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -59929,7 +60010,7 @@
       "source_location": "L25"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -59938,7 +60019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -59947,7 +60028,7 @@
       "source_location": "L50"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -59956,7 +60037,7 @@
       "source_location": "L92"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -59965,7 +60046,7 @@
       "source_location": "L74"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -59974,7 +60055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -59983,7 +60064,7 @@
       "source_location": "L62"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -59992,7 +60073,7 @@
       "source_location": "L109"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -60001,7 +60082,7 @@
       "source_location": "L177"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -60010,7 +60091,7 @@
       "source_location": "L18"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -60019,7 +60100,7 @@
       "source_location": "L52"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -60028,7 +60109,7 @@
       "source_location": "L68"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -60037,7 +60118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -60046,7 +60127,7 @@
       "source_location": "L68"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -60055,7 +60136,7 @@
       "source_location": "L26"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -60064,7 +60145,7 @@
       "source_location": "L7"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -60073,7 +60154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -60082,7 +60163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -60091,7 +60172,7 @@
       "source_location": "L81"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -60100,7 +60181,7 @@
       "source_location": "L85"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -60109,7 +60190,7 @@
       "source_location": "L27"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -60118,7 +60199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -60127,7 +60208,7 @@
       "source_location": "L43"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -60136,7 +60217,7 @@
       "source_location": "L13"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -60145,7 +60226,7 @@
       "source_location": "L88"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -60154,7 +60235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -60163,7 +60244,7 @@
       "source_location": "L111"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -60172,7 +60253,7 @@
       "source_location": "L66"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -60181,7 +60262,7 @@
       "source_location": "L127"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -60190,7 +60271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -60199,7 +60280,7 @@
       "source_location": "L25"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -60208,49 +60289,13 @@
       "source_location": "L90"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
       "norm_label": "usestorecontext()",
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "label": "_shopLayout.tsx",
-      "norm_label": "_shoplayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "shoplayout_clearfilters",
-      "label": "clearFilters()",
-      "norm_label": "clearfilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "shoplayout_onclickonmobilefilters",
-      "label": "onClickOnMobileFilters()",
-      "norm_label": "onclickonmobilefilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "shoplayout_onmobilefilterscloseclick",
-      "label": "onMobileFiltersCloseClick()",
-      "norm_label": "onmobilefilterscloseclick()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L110"
     },
     {
       "community": 27,
@@ -60399,6 +60444,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
+      "label": "_shopLayout.tsx",
+      "norm_label": "_shoplayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "shoplayout_clearfilters",
+      "label": "clearFilters()",
+      "norm_label": "clearfilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "shoplayout_onclickonmobilefilters",
+      "label": "onClickOnMobileFilters()",
+      "norm_label": "onclickonmobilefilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "shoplayout_onmobilefilterscloseclick",
+      "label": "onMobileFiltersCloseClick()",
+      "norm_label": "onmobilefilterscloseclick()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
       "norm_label": "cancelorder()",
@@ -60406,7 +60487,7 @@
       "source_location": "L121"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -60415,7 +60496,7 @@
       "source_location": "L26"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -60424,7 +60505,7 @@
       "source_location": "L71"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -60433,7 +60514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -60442,7 +60523,7 @@
       "source_location": "L46"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -60451,7 +60532,7 @@
       "source_location": "L24"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -60460,7 +60541,7 @@
       "source_location": "L20"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -60469,7 +60550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -60478,7 +60559,7 @@
       "source_location": "L33"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -60487,7 +60568,7 @@
       "source_location": "L6"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -60496,7 +60577,7 @@
       "source_location": "L25"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -60505,7 +60586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60514,7 +60595,7 @@
       "source_location": "L17"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -60523,7 +60604,7 @@
       "source_location": "L11"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -60532,7 +60613,7 @@
       "source_location": "L24"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -60541,7 +60622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60550,7 +60631,7 @@
       "source_location": "L20"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -60559,7 +60640,7 @@
       "source_location": "L65"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -60568,7 +60649,7 @@
       "source_location": "L14"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -60577,7 +60658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -60586,7 +60667,7 @@
       "source_location": "L126"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -60595,7 +60676,7 @@
       "source_location": "L130"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -60604,7 +60685,7 @@
       "source_location": "L876"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -60613,7 +60694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -60622,7 +60703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -60631,7 +60712,7 @@
       "source_location": "L8"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -60640,7 +60721,7 @@
       "source_location": "L79"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -60649,7 +60730,7 @@
       "source_location": "L61"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -60658,7 +60739,7 @@
       "source_location": "L49"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -60667,7 +60748,7 @@
       "source_location": "L17"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -60676,7 +60757,7 @@
       "source_location": "L11"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -60685,7 +60766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -60694,7 +60775,7 @@
       "source_location": "L26"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -60703,7 +60784,7 @@
       "source_location": "L72"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -60712,48 +60793,12 @@
       "source_location": "L36"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
       "norm_label": "harness-test.ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "pre_push_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "pre_push_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "pre_push_review_test_warn",
-      "label": "warn()",
-      "norm_label": "warn()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_test_ts",
-      "label": "pre-push-review.test.ts",
-      "norm_label": "pre-push-review.test.ts",
-      "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -60903,38 +60948,38 @@
     {
       "community": 280,
       "file_type": "code",
-      "id": "scripts_worktree_manager_test_ts",
-      "label": "worktree-manager.test.ts",
-      "norm_label": "worktree-manager.test.ts",
-      "source_file": "scripts/worktree-manager.test.ts",
+      "id": "pre_push_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "pre_push_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "pre_push_review_test_warn",
+      "label": "warn()",
+      "norm_label": "warn()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_test_ts",
+      "label": "pre-push-review.test.ts",
+      "norm_label": "pre-push-review.test.ts",
+      "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "worktree_manager_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/worktree-manager.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "worktree_manager_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/worktree-manager.test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "worktree_manager_test_runworktreemanager",
-      "label": "runWorktreeManager()",
-      "norm_label": "runworktreemanager()",
-      "source_file": "scripts/worktree-manager.test.ts",
-      "source_location": "L45"
     },
     {
       "community": 281,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1548
-- Graph nodes: 4099
-- Graph edges: 3696
+- Graph nodes: 4100
+- Graph edges: 3699
 - Communities: 1476
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1547
-- Graph nodes: 4095
-- Graph edges: 3692
-- Communities: 1475
+- Code files discovered: 1548
+- Graph nodes: 4099
+- Graph edges: 3696
+- Communities: 1476
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 42) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 272) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 273) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 42) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 42) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 42) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -9,6 +9,7 @@
 #   3. Ensures .worktrees is gitignored (via `git check-ignore`)
 #
 # List / remove / switch operations are NOT provided here. Use git directly:
+#   scripts/worktree-manager.sh setup-env <worktree-path>
 #   git worktree list
 #   git worktree remove <path>
 #   cd <worktree-path>   # switching is just `cd`
@@ -27,10 +28,15 @@ WORKTREE_DIR="$GIT_ROOT/.worktrees"
 
 usage() {
   cat <<'EOF'
-Usage: worktree-manager.sh create <branch-name> [from-branch]
+Usage:
+  worktree-manager.sh create <branch-name> [from-branch]
+  worktree-manager.sh setup-env <worktree-path>
 
 Creates .worktrees/<branch-name> with <branch-name> branched from
 [from-branch] (default: origin's default branch, or main).
+
+setup-env copies missing local env files into an existing worktree without
+overwriting existing destination files.
 
 The main repo checkout is not modified; from-branch is fetched but
 not checked out.
@@ -55,33 +61,59 @@ ensure_gitignore() {
   echo "Added .worktrees to .gitignore"
 }
 
-# Copy .env* files (except .env.example) from main repo to worktree.
-# Backs up any pre-existing destination file.
-copy_env_files() {
-  local worktree_path="$1"
+ATHENA_WEBAPP_ENV_DIR="packages/athena-webapp"
+
+# Copy .env* files (except .env.example) from a repo-relative directory into
+# the worktree. Existing destination files are preserved so rerunning setup
+# does not clobber local overrides.
+copy_env_files_from_dir() {
+  local worktree_path="$1" relative_dir="$2" label="$3" required="$4"
   local copied=0
+  local kept=0
+  local source_dir="$GIT_ROOT"
+  if [[ -n "$relative_dir" ]]; then
+    source_dir="$GIT_ROOT/$relative_dir"
+  fi
 
   shopt -s nullglob
-  for source in "$GIT_ROOT"/.env*; do
+  for source in "$source_dir"/.env*; do
     [[ -f "$source" ]] || continue
     local name
     name=$(basename "$source")
     [[ "$name" == ".env.example" ]] && continue
 
-    local dest="$worktree_path/$name"
+    local dest_dir="$worktree_path"
+    if [[ -n "$relative_dir" ]]; then
+      dest_dir="$worktree_path/$relative_dir"
+    fi
+    mkdir -p "$dest_dir"
+    local dest="$dest_dir/$name"
     if [[ -f "$dest" ]]; then
-      cp "$dest" "${dest}.backup"
-      echo "  Backed up existing $name to ${name}.backup"
+      echo "  Kept existing ${relative_dir:+$relative_dir/}$name"
+      kept=$((kept + 1))
+      continue
     fi
     cp "$source" "$dest"
-    echo "  Copied $name"
+    echo "  Copied ${relative_dir:+$relative_dir/}$name"
     copied=$((copied + 1))
   done
   shopt -u nullglob
 
-  if [[ $copied -eq 0 ]]; then
-    echo "  No .env files in main repo"
+  if [[ $copied -eq 0 && $kept -eq 0 ]]; then
+    if [[ "$required" == "true" ]]; then
+      echo "Error: Missing $label env files." >&2
+      echo "Expected at least one local file matching $source_dir/.env* (excluding .env.example)." >&2
+      echo "Create or copy $relative_dir/.env with CONVEX_DEPLOYMENT and VITE_CONVEX_URL before creating agent worktrees." >&2
+      exit 1
+    fi
+    echo "  No $label .env files"
   fi
+}
+
+copy_env_files() {
+  local worktree_path="$1"
+  copy_env_files_from_dir "$worktree_path" "" "repo root" "false"
+  copy_env_files_from_dir "$worktree_path" "$ATHENA_WEBAPP_ENV_DIR" "Athena webapp" "true"
 }
 
 get_default_branch() {
@@ -208,8 +240,7 @@ create_worktree() {
 
   git worktree add -b "$branch_name" "$worktree_path" "$base_ref"
 
-  echo "Environment files:"
-  copy_env_files "$worktree_path"
+  setup_env "$worktree_path"
 
   echo "Dev tool trust:"
   local trust_branch="$default_branch"
@@ -238,11 +269,28 @@ create_worktree() {
   echo "Switch with: cd $worktree_path"
 }
 
+setup_env() {
+  local worktree_path="${1:-}"
+  if [[ -z "$worktree_path" ]]; then
+    echo "Error: worktree path required" >&2
+    usage >&2
+    exit 1
+  fi
+  if [[ ! -d "$worktree_path" ]]; then
+    echo "Error: worktree path does not exist: $worktree_path" >&2
+    exit 1
+  fi
+
+  echo "Environment files:"
+  copy_env_files "$worktree_path"
+}
+
 main() {
   local command="${1:-}"
   shift || true
   case "$command" in
     create) create_worktree "$@" ;;
+    setup-env) setup_env "$@" ;;
     ""|help|-h|--help) usage ;;
     *)
       echo "Error: unknown command '$command'" >&2

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -63,6 +63,37 @@ ensure_gitignore() {
 
 ATHENA_WEBAPP_ENV_DIR="packages/athena-webapp"
 
+has_env_files_in_dir() {
+  local relative_dir="$1"
+  local source_dir="$GIT_ROOT"
+  if [[ -n "$relative_dir" ]]; then
+    source_dir="$GIT_ROOT/$relative_dir"
+  fi
+
+  shopt -s nullglob
+  for source in "$source_dir"/.env*; do
+    [[ -f "$source" ]] || continue
+    [[ "$(basename "$source")" == ".env.example" ]] && continue
+    shopt -u nullglob
+    return 0
+  done
+  shopt -u nullglob
+  return 1
+}
+
+require_env_files_available() {
+  local relative_dir="$1" label="$2"
+  local source_dir="$GIT_ROOT/$relative_dir"
+  if has_env_files_in_dir "$relative_dir"; then
+    return
+  fi
+
+  echo "Error: Missing $label env files." >&2
+  echo "Expected at least one local file matching $source_dir/.env* (excluding .env.example)." >&2
+  echo "Create or copy $relative_dir/.env with CONVEX_DEPLOYMENT and VITE_CONVEX_URL before creating agent worktrees." >&2
+  exit 1
+}
+
 # Copy .env* files (except .env.example) from a repo-relative directory into
 # the worktree. Existing destination files are preserved so rerunning setup
 # does not clobber local overrides.
@@ -101,10 +132,7 @@ copy_env_files_from_dir() {
 
   if [[ $copied -eq 0 && $kept -eq 0 ]]; then
     if [[ "$required" == "true" ]]; then
-      echo "Error: Missing $label env files." >&2
-      echo "Expected at least one local file matching $source_dir/.env* (excluding .env.example)." >&2
-      echo "Create or copy $relative_dir/.env with CONVEX_DEPLOYMENT and VITE_CONVEX_URL before creating agent worktrees." >&2
-      exit 1
+      require_env_files_available "$relative_dir" "$label"
     fi
     echo "  No $label .env files"
   fi
@@ -221,6 +249,7 @@ create_worktree() {
     echo "Use 'cd $worktree_path' to switch, or 'git worktree remove' first." >&2
     exit 1
   fi
+  require_env_files_available "$ATHENA_WEBAPP_ENV_DIR" "Athena webapp"
 
   echo "Creating worktree $branch_name from $from_branch"
 

--- a/scripts/worktree-manager.test.ts
+++ b/scripts/worktree-manager.test.ts
@@ -34,7 +34,12 @@ async function createFixtureRepo() {
 }
 
 async function runGit(cwd: string, ...args: string[]) {
-  const result = Bun.spawnSync(["git", ...args], { cwd, stderr: "pipe", stdout: "pipe" });
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd,
+    env: fixtureEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
   if (result.exitCode !== 0) {
     throw new Error(
       `git ${args.join(" ")} failed\n${result.stderr.toString()}\n${result.stdout.toString()}`
@@ -45,9 +50,16 @@ async function runGit(cwd: string, ...args: string[]) {
 function runWorktreeManager(cwd: string, ...args: string[]) {
   return Bun.spawnSync(["bash", "scripts/worktree-manager.sh", ...args], {
     cwd,
+    env: fixtureEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });
+}
+
+function fixtureEnv() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  ) as Record<string, string>;
 }
 
 afterEach(async () => {

--- a/scripts/worktree-manager.test.ts
+++ b/scripts/worktree-manager.test.ts
@@ -1,0 +1,139 @@
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempRoots: string[] = [];
+
+async function createFixtureRepo() {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "athena-worktree-manager-"));
+  tempRoots.push(rootDir);
+
+  await mkdir(path.join(rootDir, "scripts"), { recursive: true });
+  await cp(
+    path.join(import.meta.dirname, "worktree-manager.sh"),
+    path.join(rootDir, "scripts/worktree-manager.sh")
+  );
+  await chmod(path.join(rootDir, "scripts/worktree-manager.sh"), 0o755);
+
+  await mkdir(path.join(rootDir, "packages/athena-webapp"), { recursive: true });
+  await writeFile(path.join(rootDir, ".gitignore"), ".env\n.env.local\n.worktrees/\n");
+  await writeFile(path.join(rootDir, ".env"), "ROOT_ENV=present\n");
+  await writeFile(
+    path.join(rootDir, "packages/athena-webapp/.gitkeep"),
+    ""
+  );
+
+  await runGit(rootDir, "init", "-b", "main");
+  await runGit(rootDir, "config", "user.email", "test@example.com");
+  await runGit(rootDir, "config", "user.name", "Test User");
+  await runGit(rootDir, "add", ".gitignore", "scripts/worktree-manager.sh", "packages/athena-webapp/.gitkeep");
+  await runGit(rootDir, "commit", "-m", "seed fixture");
+
+  return rootDir;
+}
+
+async function runGit(cwd: string, ...args: string[]) {
+  const result = Bun.spawnSync(["git", ...args], { cwd, stderr: "pipe", stdout: "pipe" });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed\n${result.stderr.toString()}\n${result.stdout.toString()}`
+    );
+  }
+}
+
+function runWorktreeManager(cwd: string, ...args: string[]) {
+  return Bun.spawnSync(["bash", "scripts/worktree-manager.sh", ...args], {
+    cwd,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
+
+describe("worktree-manager", () => {
+  it("copies Athena webapp Convex env files into new worktrees", async () => {
+    const rootDir = await createFixtureRepo();
+    await writeFile(
+      path.join(rootDir, "packages/athena-webapp/.env"),
+      "CONVEX_DEPLOYMENT=dev:fixture\nVITE_CONVEX_URL=https://fixture.convex.cloud\n"
+    );
+    await writeFile(
+      path.join(rootDir, "packages/athena-webapp/.env.local"),
+      "VITE_CONVEX_SITE_URL=https://fixture.convex.site\n"
+    );
+
+    const result = runWorktreeManager(rootDir, "create", "codex/test-env", "main");
+
+    expect(result.exitCode).toBe(0);
+    await expect(
+      readFile(
+        path.join(rootDir, ".worktrees/codex/test-env/packages/athena-webapp/.env"),
+        "utf8"
+      )
+    ).resolves.toContain("VITE_CONVEX_URL=https://fixture.convex.cloud");
+    await expect(
+      readFile(
+        path.join(
+          rootDir,
+          ".worktrees/codex/test-env/packages/athena-webapp/.env.local"
+        ),
+        "utf8"
+      )
+    ).resolves.toContain("VITE_CONVEX_SITE_URL=https://fixture.convex.site");
+  });
+
+  it("fails clearly when Athena webapp Convex env source files are missing", async () => {
+    const rootDir = await createFixtureRepo();
+
+    const result = runWorktreeManager(rootDir, "create", "codex/missing-env", "main");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "Missing Athena webapp env files"
+    );
+    expect(result.stderr.toString()).toContain(
+      "packages/athena-webapp/.env"
+    );
+  });
+
+  it("keeps existing env files when setup is rerun for a worktree", async () => {
+    const rootDir = await createFixtureRepo();
+    await writeFile(
+      path.join(rootDir, "packages/athena-webapp/.env"),
+      "VITE_CONVEX_URL=https://fixture.convex.cloud\n"
+    );
+
+    const createResult = runWorktreeManager(
+      rootDir,
+      "create",
+      "codex/idempotent-env",
+      "main"
+    );
+    expect(createResult.exitCode).toBe(0);
+
+    const worktreeEnv = path.join(
+      rootDir,
+      ".worktrees/codex/idempotent-env/packages/athena-webapp/.env"
+    );
+    await writeFile(worktreeEnv, "VITE_CONVEX_URL=https://local.override\n");
+
+    const setupResult = runWorktreeManager(
+      rootDir,
+      "setup-env",
+      ".worktrees/codex/idempotent-env"
+    );
+
+    expect(setupResult.exitCode).toBe(0);
+    await expect(readFile(worktreeEnv, "utf8")).resolves.toBe(
+      "VITE_CONVEX_URL=https://local.override\n"
+    );
+  });
+});

--- a/scripts/worktree-manager.test.ts
+++ b/scripts/worktree-manager.test.ts
@@ -1,4 +1,4 @@
-import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -114,6 +114,9 @@ describe("worktree-manager", () => {
     expect(result.stderr.toString()).toContain(
       "packages/athena-webapp/.env"
     );
+    await expect(
+      access(path.join(rootDir, ".worktrees/codex/missing-env"))
+    ).rejects.toThrow();
   });
 
   it("keeps existing env files when setup is rerun for a worktree", async () => {


### PR DESCRIPTION
## Summary
- Copy package-local `packages/athena-webapp/.env*` files into new worktrees through the existing worktree manager.
- Add `setup-env` so existing worktrees can receive missing env files without clobbering local overrides.
- Add fixture coverage for package env copying, missing-source diagnostics, idempotent reruns, and Git hook env isolation.
- Regenerate tracked graphify artifacts after adding the repo-level test.

## Why
Fresh Athena worktrees were missing the webapp Convex runtime env, which let Vite start while `/login` failed in the browser with `No address provided to ConvexReactClient`, and `bunx convex dev` could fall into interactive setup.

## Validation
- `bun test scripts/worktree-manager.test.ts`
- `GIT_DIR=/tmp/not-a-worktree/.git GIT_WORK_TREE=/tmp/not-a-worktree bun test scripts/worktree-manager.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' build`
- Fresh worktree smoke: `bun run --filter '@athena/webapp' dev -- --host 127.0.0.1 --port 5199`, browser `/login` check with no `No address provided to ConvexReactClient`
- Fresh worktree smoke: `bunx convex dev --once --typecheck disable --tail-logs disable`
- `bun run harness:review --base origin/main`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `git diff --check`
- `bun run pr:athena`
- `git push` pre-push hook: passed

Linear: https://linear.app/v26-labs/issue/V26-340/bootstrap-worktrees-with-athena-convex-env-so-bunx-convex-dev-works
