### PR TITLE
Route payment corrections through async approvals

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4108 nodes · 3720 edges · 1474 communities detected
+- 4115 nodes · 3737 edges · 1474 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1636,96 +1636,96 @@ Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
 ### Community 31 - "Community 31"
+Cohesion: 0.19
+Nodes (9): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), requiresInlineManagerProof(), runCustomerCorrection() (+1 more)
+
+### Community 32 - "Community 32"
 Cohesion: 0.28
 Nodes (12): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix() (+4 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.18
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
+Cohesion: 0.35
+Nodes (13): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+5 more)
+
+### Community 36 - "Community 36"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 35 - "Community 35"
+### Community 37 - "Community 37"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 36 - "Community 36"
+### Community 38 - "Community 38"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 37 - "Community 37"
+### Community 39 - "Community 39"
 Cohesion: 0.28
 Nodes (10): buildCompleteTransactionResult(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid(), registerSessionMatchesIdentity() (+2 more)
 
-### Community 38 - "Community 38"
+### Community 40 - "Community 40"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 39 - "Community 39"
+### Community 41 - "Community 41"
 Cohesion: 0.31
 Nodes (11): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), mapSubmitStockAdjustmentBatchError(), resolveStockAdjustmentApprovalDecisionWithCtx() (+3 more)
 
-### Community 40 - "Community 40"
+### Community 42 - "Community 42"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 41 - "Community 41"
-Cohesion: 0.23
-Nodes (9): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), requestCorrectionSubmit(), runCustomerCorrection() (+1 more)
-
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.24
 Nodes (6): createApp(), createHandlers(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern()
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 47 - "Community 47"
 Cohesion: 0.25
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 46 - "Community 46"
+### Community 48 - "Community 48"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 47 - "Community 47"
+### Community 49 - "Community 49"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
-
-### Community 48 - "Community 48"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 49 - "Community 49"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 50 - "Community 50"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 51 - "Community 51"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 52 - "Community 52"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
-
-### Community 53 - "Community 53"
-Cohesion: 0.42
-Nodes (9): adjustRegisterSessionExpectedCashForPaymentCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), getPaymentMethodCashContribution(), requireCompletedTransaction(), requireRegisterSessionAllowsPaymentCorrection() (+1 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.22
@@ -1952,16 +1952,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 110 - "Community 110"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 111 - "Community 111"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 112 - "Community 112"
+### Community 111 - "Community 111"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 112 - "Community 112"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 113 - "Community 113"
 Cohesion: 0.52
@@ -2032,16 +2032,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 131 - "Community 131"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 132 - "Community 132"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 133 - "Community 133"
 Cohesion: 0.33
@@ -2056,16 +2056,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 136 - "Community 136"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 137 - "Community 137"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 138 - "Community 138"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 139 - "Community 139"
 Cohesion: 0.33
@@ -2076,36 +2076,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 141 - "Community 141"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 143 - "Community 143"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 144 - "Community 144"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 148 - "Community 148"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 149 - "Community 149"
 Cohesion: 0.53
@@ -2469,11 +2469,11 @@ Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Nodes (2): getApprovalRequestCopy(), handleDecideApprovalRequest()
 
 ### Community 240 - "Community 240"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.5
@@ -2496,68 +2496,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 247 - "Community 247"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 247 - "Community 247"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 249 - "Community 249"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 250 - "Community 250"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 251 - "Community 251"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 254 - "Community 254"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 261 - "Community 261"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 262 - "Community 262"
 Cohesion: 0.5
@@ -2584,55 +2584,55 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 270 - "Community 270"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 272 - "Community 272"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 273 - "Community 273"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 275 - "Community 275"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 277 - "Community 277"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 278 - "Community 278"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 279 - "Community 279"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 280 - "Community 280"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 281 - "Community 281"
@@ -2685,35 +2685,35 @@ Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 297 - "Community 297"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 297 - "Community 297"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 299 - "Community 299"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 300 - "Community 300"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 300 - "Community 300"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
@@ -2724,36 +2724,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 308 - "Community 308"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 309 - "Community 309"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
@@ -2768,24 +2768,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.67
@@ -2793,11 +2793,11 @@ Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -323,7 +323,7 @@
       "relation": "calls",
       "source": "approvalrequests_decideapprovalrequestwithctx",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L100",
+      "source_location": "L108",
       "target": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "weight": 1
     },
@@ -335,7 +335,7 @@
       "relation": "calls",
       "source": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L163",
+      "source_location": "L178",
       "target": "approvalrequests_decideapprovalrequestascommandwithctx",
       "weight": 1
     },
@@ -347,7 +347,7 @@
       "relation": "calls",
       "source": "approvalrequests_mapdecideapprovalrequesterror",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L165",
+      "source_location": "L180",
       "target": "approvalrequests_decideapprovalrequestascommandwithctx",
       "weight": 1
     },
@@ -1559,8 +1559,32 @@
       "relation": "calls",
       "source": "correcttransaction_getpaymentmethodcashcontribution",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L134",
+      "source_location": "L212",
       "target": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_applypaymentmethodcorrection",
+      "_tgt": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L313",
+      "target": "correcttransaction_applypaymentmethodcorrection",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_applypaymentmethodcorrection",
+      "_tgt": "correcttransaction_transactionlabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_transactionlabel",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L328",
+      "target": "correcttransaction_applypaymentmethodcorrection",
       "weight": 1
     },
     {
@@ -1571,7 +1595,7 @@
       "relation": "calls",
       "source": "correcttransaction_transactionlabel",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L49",
+      "source_location": "L52",
       "target": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
       "weight": 1
     },
@@ -1583,7 +1607,7 @@
       "relation": "calls",
       "source": "correcttransaction_requirecompletedtransaction",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L205",
+      "source_location": "L375",
       "target": "correcttransaction_correcttransactioncustomer",
       "weight": 1
     },
@@ -1595,19 +1619,19 @@
       "relation": "calls",
       "source": "correcttransaction_transactionlabel",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L235",
+      "source_location": "L405",
       "target": "correcttransaction_correcttransactioncustomer",
       "weight": 1
     },
     {
       "_src": "correcttransaction_correcttransactionpaymentmethod",
-      "_tgt": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "_tgt": "correcttransaction_applypaymentmethodcorrection",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "source": "correcttransaction_applypaymentmethodcorrection",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L337",
+      "source_location": "L520",
       "target": "correcttransaction_correcttransactionpaymentmethod",
       "weight": 1
     },
@@ -1619,7 +1643,7 @@
       "relation": "calls",
       "source": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L295",
+      "source_location": "L476",
       "target": "correcttransaction_correcttransactionpaymentmethod",
       "weight": 1
     },
@@ -1631,7 +1655,19 @@
       "relation": "calls",
       "source": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L307",
+      "source_location": "L489",
+      "target": "correcttransaction_correcttransactionpaymentmethod",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_correcttransactionpaymentmethod",
+      "_tgt": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L464",
       "target": "correcttransaction_correcttransactionpaymentmethod",
       "weight": 1
     },
@@ -1643,7 +1679,7 @@
       "relation": "calls",
       "source": "correcttransaction_requirecompletedtransaction",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L268",
+      "source_location": "L438",
       "target": "correcttransaction_correcttransactionpaymentmethod",
       "weight": 1
     },
@@ -1655,7 +1691,7 @@
       "relation": "calls",
       "source": "correcttransaction_requireregistersessionallowspaymentcorrection",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L287",
+      "source_location": "L457",
       "target": "correcttransaction_correcttransactionpaymentmethod",
       "weight": 1
     },
@@ -1667,8 +1703,80 @@
       "relation": "calls",
       "source": "correcttransaction_transactionlabel",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L352",
+      "source_location": "L501",
       "target": "correcttransaction_correcttransactionpaymentmethod",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "_tgt": "correcttransaction_transactionlabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_transactionlabel",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L124",
+      "target": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "_tgt": "correcttransaction_applypaymentmethodcorrection",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_applypaymentmethodcorrection",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L641",
+      "target": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "_tgt": "correcttransaction_getstringmetadata",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_getstringmetadata",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L586",
+      "target": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "_tgt": "correcttransaction_requirecompletedtransaction",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_requirecompletedtransaction",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L595",
+      "target": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "_tgt": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L615",
+      "target": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "_tgt": "correcttransaction_transactionlabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "correcttransaction_transactionlabel",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L625",
+      "target": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
       "weight": 1
     },
     {
@@ -7120,6 +7228,18 @@
       "weight": 1
     },
     {
+      "_src": "operationsqueueview_handledecideapprovalrequest",
+      "_tgt": "operationsqueueview_getapprovalrequestcopy",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "operationsqueueview_getapprovalrequestcopy",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L355",
+      "target": "operationsqueueview_handledecideapprovalrequest",
+      "weight": 1
+    },
+    {
       "_src": "orderemailservice_sendpaymentverificationemails",
       "_tgt": "orderemailservice_buildorderstatusmessage",
       "confidence": "EXTRACTED",
@@ -10355,7 +10475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L77",
+      "source_location": "L85",
       "target": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "weight": 1
     },
@@ -10367,7 +10487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L158",
+      "source_location": "L173",
       "target": "approvalrequests_decideapprovalrequestascommandwithctx",
       "weight": 1
     },
@@ -10379,7 +10499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L27",
+      "source_location": "L28",
       "target": "approvalrequests_decideapprovalrequestwithctx",
       "weight": 1
     },
@@ -10391,7 +10511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L106",
+      "source_location": "L114",
       "target": "approvalrequests_mapdecideapprovalrequesterror",
       "weight": 1
     },
@@ -12035,8 +12155,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L120",
+      "source_location": "L198",
       "target": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "_tgt": "correcttransaction_applypaymentmethodcorrection",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L275",
+      "target": "correcttransaction_applypaymentmethodcorrection",
       "weight": 1
     },
     {
@@ -12047,7 +12179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L29",
+      "source_location": "L31",
       "target": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
       "weight": 1
     },
@@ -12059,7 +12191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L166",
+      "source_location": "L244",
       "target": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
       "weight": 1
     },
@@ -12071,7 +12203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L197",
+      "source_location": "L367",
       "target": "correcttransaction_correcttransactioncustomer",
       "weight": 1
     },
@@ -12083,8 +12215,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L259",
+      "source_location": "L429",
       "target": "correcttransaction_correcttransactionpaymentmethod",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "_tgt": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L77",
+      "target": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
       "weight": 1
     },
     {
@@ -12095,8 +12239,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L85",
+      "source_location": "L163",
       "target": "correcttransaction_getpaymentmethodcashcontribution",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "_tgt": "correcttransaction_getstringmetadata",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L532",
+      "target": "correcttransaction_getstringmetadata",
       "weight": 1
     },
     {
@@ -12107,7 +12263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L68",
+      "source_location": "L146",
       "target": "correcttransaction_requirecompletedtransaction",
       "weight": 1
     },
@@ -12119,8 +12275,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L95",
+      "source_location": "L173",
       "target": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "_tgt": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L540",
+      "target": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
       "weight": 1
     },
     {
@@ -12131,7 +12299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L25",
+      "source_location": "L27",
       "target": "correcttransaction_transactionlabel",
       "weight": 1
     },
@@ -13043,7 +13211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts",
-      "source_location": "L35",
+      "source_location": "L38",
       "target": "correcttransactionpaymentmethod_test_createmutationctx",
       "weight": 1
     },
@@ -19235,7 +19403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L504",
+      "source_location": "L505",
       "target": "registersessionview_applycloseoutcommandresult",
       "weight": 1
     },
@@ -19247,7 +19415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L494",
+      "source_location": "L495",
       "target": "registersessionview_applycommandresult",
       "weight": 1
     },
@@ -19259,7 +19427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L272",
+      "source_location": "L273",
       "target": "registersessionview_builddepositsubmissionkey",
       "weight": 1
     },
@@ -19271,7 +19439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2040",
+      "source_location": "L2054",
       "target": "registersessionview_errormessage",
       "weight": 1
     },
@@ -19283,7 +19451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L276",
+      "source_location": "L277",
       "target": "registersessionview_formatcurrency",
       "weight": 1
     },
@@ -19295,7 +19463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L325",
+      "source_location": "L326",
       "target": "registersessionview_formatpaymentmethod",
       "weight": 1
     },
@@ -19307,7 +19475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L338",
+      "source_location": "L339",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -19319,7 +19487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L333",
+      "source_location": "L334",
       "target": "registersessionview_formatregistername",
       "weight": 1
     },
@@ -19331,7 +19499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L352",
+      "source_location": "L353",
       "target": "registersessionview_formatsessioncode",
       "weight": 1
     },
@@ -19343,7 +19511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L295",
+      "source_location": "L296",
       "target": "registersessionview_formatstatuslabel",
       "weight": 1
     },
@@ -19355,7 +19523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L284",
+      "source_location": "L285",
       "target": "registersessionview_formatstoredamountforinput",
       "weight": 1
     },
@@ -19367,7 +19535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L288",
+      "source_location": "L289",
       "target": "registersessionview_formattimestamp",
       "weight": 1
     },
@@ -19379,7 +19547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L310",
+      "source_location": "L311",
       "target": "registersessionview_getnumericeventmetadata",
       "weight": 1
     },
@@ -19391,7 +19559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L364",
+      "source_location": "L365",
       "target": "registersessionview_getpaymentmethodicon",
       "weight": 1
     },
@@ -19403,7 +19571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L356",
+      "source_location": "L357",
       "target": "registersessionview_getvariancetone",
       "weight": 1
     },
@@ -19415,7 +19583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L658",
+      "source_location": "L659",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
       "weight": 1
     },
@@ -19427,7 +19595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L754",
+      "source_location": "L755",
       "target": "registersessionview_handleopeningfloatapprovalapproved",
       "weight": 1
     },
@@ -19439,7 +19607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L516",
+      "source_location": "L517",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -19451,7 +19619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L585",
+      "source_location": "L586",
       "target": "registersessionview_handlereviewcloseout",
       "weight": 1
     },
@@ -19463,7 +19631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L559",
+      "source_location": "L560",
       "target": "registersessionview_handlesubmitcloseout",
       "weight": 1
     },
@@ -19475,7 +19643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L602",
+      "source_location": "L603",
       "target": "registersessionview_handlesubmitopeningfloatcorrection",
       "weight": 1
     },
@@ -19487,7 +19655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L299",
+      "source_location": "L300",
       "target": "registersessionview_iscloseoutrejectionevent",
       "weight": 1
     },
@@ -19499,7 +19667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L303",
+      "source_location": "L304",
       "target": "registersessionview_isopeningfloatcorrectionevent",
       "weight": 1
     },
@@ -19511,7 +19679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L319",
+      "source_location": "L320",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -19523,7 +19691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L708",
+      "source_location": "L709",
       "target": "registersessionview_runopeningfloatcorrection",
       "weight": 1
     },
@@ -19535,7 +19703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L267",
+      "source_location": "L268",
       "target": "registersessionview_trimoptional",
       "weight": 1
     },
@@ -20261,13 +20429,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "_tgt": "operationsqueueview_getapprovalrequestcopy",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L46",
+      "target": "operationsqueueview_getapprovalrequestcopy",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "_tgt": "operationsqueueview_handledecideapprovalrequest",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L295",
+      "source_location": "L332",
       "target": "operationsqueueview_handledecideapprovalrequest",
       "weight": 1
     },
@@ -20279,7 +20459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L285",
+      "source_location": "L322",
       "target": "operationsqueueview_handlesubmitstockbatch",
       "weight": 1
     },
@@ -22199,7 +22379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L209",
+      "source_location": "L151",
       "target": "transactionview_test_async",
       "weight": 1
     },
@@ -22211,7 +22391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L314",
+      "source_location": "L338",
       "target": "transactionview_test_mocktransactionmutations",
       "weight": 1
     },
@@ -22223,7 +22403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L338",
+      "source_location": "L353",
       "target": "transactionview_authenticatecorrectionstaff",
       "weight": 1
     },
@@ -22235,7 +22415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L366",
+      "source_location": "L378",
       "target": "transactionview_exitcorrectionworkflow",
       "weight": 1
     },
@@ -22247,7 +22427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L89",
+      "source_location": "L94",
       "target": "transactionview_formatcorrectioneventtype",
       "weight": 1
     },
@@ -22259,7 +22439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L126",
+      "source_location": "L141",
       "target": "transactionview_formatcorrectionhistorychange",
       "weight": 1
     },
@@ -22271,7 +22451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L107",
+      "source_location": "L112",
       "target": "transactionview_formatcorrectionhistorymeta",
       "weight": 1
     },
@@ -22283,7 +22463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L95",
+      "source_location": "L100",
       "target": "transactionview_formatcorrectionhistorytitle",
       "weight": 1
     },
@@ -22295,7 +22475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L116",
+      "source_location": "L121",
       "target": "transactionview_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -22307,7 +22487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L147",
+      "source_location": "L162",
       "target": "transactionview_getcorrectionhistorychangeparts",
       "weight": 1
     },
@@ -22319,8 +22499,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L167",
+      "source_location": "L182",
       "target": "transactionview_gettransactioncorrectionhistory",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "_tgt": "transactionview_ismanagerstaff",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L137",
+      "target": "transactionview_ismanagerstaff",
       "weight": 1
     },
     {
@@ -22331,8 +22523,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L466",
+      "source_location": "L486",
       "target": "transactionview_requestcorrectionsubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "_tgt": "transactionview_requiresinlinemanagerproof",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L131",
+      "target": "transactionview_requiresinlinemanagerproof",
       "weight": 1
     },
     {
@@ -22343,7 +22547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L374",
+      "source_location": "L386",
       "target": "transactionview_runcustomercorrection",
       "weight": 1
     },
@@ -22355,7 +22559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L412",
+      "source_location": "L424",
       "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
@@ -23603,7 +23807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L158",
+      "source_location": "L162",
       "target": "staffauthenticationdialog_handlekeydown",
       "weight": 1
     },
@@ -23615,7 +23819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L105",
+      "source_location": "L109",
       "target": "staffauthenticationdialog_handlesubmit",
       "weight": 1
     },
@@ -23627,7 +23831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L127",
+      "source_location": "L163",
       "target": "staffmanagement_test_chooserole",
       "weight": 1
     },
@@ -23639,7 +23843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L71",
+      "source_location": "L107",
       "target": "staffmanagement_test_mockconvex",
       "weight": 1
     },
@@ -36431,7 +36635,7 @@
       "relation": "calls",
       "source": "registersessionview_formatregistername",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L339",
+      "source_location": "L340",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -36443,7 +36647,7 @@
       "relation": "calls",
       "source": "registersessionview_applycloseoutcommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L694",
+      "source_location": "L695",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
       "weight": 1
     },
@@ -36455,7 +36659,7 @@
       "relation": "calls",
       "source": "registersessionview_runopeningfloatcorrection",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L767",
+      "source_location": "L768",
       "target": "registersessionview_handleopeningfloatapprovalapproved",
       "weight": 1
     },
@@ -36467,7 +36671,7 @@
       "relation": "calls",
       "source": "registersessionview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L546",
+      "source_location": "L547",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -36479,7 +36683,7 @@
       "relation": "calls",
       "source": "registersessionview_builddepositsubmissionkey",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L553",
+      "source_location": "L554",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -36491,7 +36695,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L539",
+      "source_location": "L540",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -36503,7 +36707,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L597",
+      "source_location": "L598",
       "target": "registersessionview_handlereviewcloseout",
       "weight": 1
     },
@@ -36515,7 +36719,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L580",
+      "source_location": "L581",
       "target": "registersessionview_handlesubmitcloseout",
       "weight": 1
     },
@@ -36527,7 +36731,7 @@
       "relation": "calls",
       "source": "registersessionview_handlesubmitopeningfloatcorrection",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L655",
+      "source_location": "L656",
       "target": "registersessionview_runopeningfloatcorrection",
       "weight": 1
     },
@@ -36539,7 +36743,7 @@
       "relation": "calls",
       "source": "registersessionview_iscloseoutrejectionevent",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L321",
+      "source_location": "L322",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -36551,7 +36755,7 @@
       "relation": "calls",
       "source": "registersessionview_isopeningfloatcorrectionevent",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L321",
+      "source_location": "L322",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -42011,7 +42215,7 @@
       "relation": "calls",
       "source": "staffauthenticationdialog_handlesubmit",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L160",
+      "source_location": "L164",
       "target": "staffauthenticationdialog_handlekeydown",
       "weight": 1
     },
@@ -44327,7 +44531,7 @@
       "relation": "calls",
       "source": "transactionview_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L131",
+      "source_location": "L146",
       "target": "transactionview_formatcorrectionhistorychange",
       "weight": 1
     },
@@ -44339,7 +44543,7 @@
       "relation": "calls",
       "source": "transactionview_formatcorrectioneventtype",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L103",
+      "source_location": "L108",
       "target": "transactionview_formatcorrectionhistorytitle",
       "weight": 1
     },
@@ -44351,20 +44555,8 @@
       "relation": "calls",
       "source": "transactionview_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L152",
+      "source_location": "L167",
       "target": "transactionview_getcorrectionhistorychangeparts",
-      "weight": 1
-    },
-    {
-      "_src": "transactionview_requestcorrectionsubmit",
-      "_tgt": "transactionview_runpaymentmethodcorrection",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "transactionview_runpaymentmethodcorrection",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L491",
-      "target": "transactionview_requestcorrectionsubmit",
       "weight": 1
     },
     {
@@ -44375,7 +44567,7 @@
       "relation": "calls",
       "source": "transactionview_exitcorrectionworkflow",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L404",
+      "source_location": "L416",
       "target": "transactionview_runcustomercorrection",
       "weight": 1
     },
@@ -44387,7 +44579,19 @@
       "relation": "calls",
       "source": "transactionview_exitcorrectionworkflow",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L458",
+      "source_location": "L478",
+      "target": "transactionview_runpaymentmethodcorrection",
+      "weight": 1
+    },
+    {
+      "_src": "transactionview_runpaymentmethodcorrection",
+      "_tgt": "transactionview_requiresinlinemanagerproof",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "transactionview_requiresinlinemanagerproof",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L464",
       "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
@@ -47403,65 +47607,65 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1100,
@@ -47556,65 +47760,65 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1110,
@@ -47709,65 +47913,65 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1120,
@@ -50697,56 +50901,56 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1300,
@@ -50841,56 +51045,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1310,
@@ -50985,56 +51189,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1320,
@@ -51129,56 +51333,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1330,
@@ -51273,56 +51477,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
     },
     {
       "community": 1340,
@@ -51417,56 +51621,56 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L102"
     },
     {
       "community": 1350,
@@ -51561,56 +51765,56 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L122"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L68"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L85"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L51"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L102"
     },
     {
       "community": 1360,
@@ -51705,56 +51909,56 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
     },
     {
       "community": 1370,
@@ -51849,56 +52053,56 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L49"
     },
     {
       "community": 1380,
@@ -51993,56 +52197,56 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L28"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L37"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L12"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L6"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L49"
     },
     {
       "community": 1390,
@@ -52317,56 +52521,56 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1400,
@@ -52461,56 +52665,56 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1410,
@@ -52605,56 +52809,56 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
+      "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1420,
@@ -52749,56 +52953,56 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L83"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 1430,
@@ -52893,56 +53097,56 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1440,
@@ -53037,56 +53241,56 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1450,
@@ -53181,55 +53385,55 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -53325,55 +53529,55 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -53415,55 +53619,55 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -54040,7 +54244,7 @@
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
       "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L77"
+      "source_location": "L85"
     },
     {
       "community": 157,
@@ -54049,7 +54253,7 @@
       "label": "decideApprovalRequestAsCommandWithCtx()",
       "norm_label": "decideapprovalrequestascommandwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L158"
+      "source_location": "L173"
     },
     {
       "community": 157,
@@ -54058,7 +54262,7 @@
       "label": "decideApprovalRequestWithCtx()",
       "norm_label": "decideapprovalrequestwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L27"
+      "source_location": "L28"
     },
     {
       "community": 157,
@@ -54067,7 +54271,7 @@
       "label": "mapDecideApprovalRequestError()",
       "norm_label": "mapdecideapprovalrequesterror()",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L106"
+      "source_location": "L114"
     },
     {
       "community": 157,
@@ -59004,38 +59208,38 @@
     {
       "community": 239,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
-      "label": "ReturnExchangeView.tsx",
-      "norm_label": "returnexchangeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "id": "operationsqueueview_getapprovalrequestcopy",
+      "label": "getApprovalRequestCopy()",
+      "norm_label": "getapprovalrequestcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "operationsqueueview_handledecideapprovalrequest",
+      "label": "handleDecideApprovalRequest()",
+      "norm_label": "handledecideapprovalrequest()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L332"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "operationsqueueview_handlesubmitstockbatch",
+      "label": "handleSubmitStockBatch()",
+      "norm_label": "handlesubmitstockbatch()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "returnexchangeview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "returnexchangeview_resetreplacementfields",
-      "label": "resetReplacementFields()",
-      "norm_label": "resetreplacementfields()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "returnexchangeview_toggleitem",
-      "label": "toggleItem()",
-      "norm_label": "toggleitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L83"
     },
     {
       "community": 24,
@@ -59193,6 +59397,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "label": "ReturnExchangeView.tsx",
+      "norm_label": "returnexchangeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "returnexchangeview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "returnexchangeview_resetreplacementfields",
+      "label": "resetReplacementFields()",
+      "norm_label": "resetreplacementfields()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "returnexchangeview_toggleitem",
+      "label": "toggleItem()",
+      "norm_label": "toggleitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
       "norm_label": "handlequickstart()",
@@ -59200,7 +59440,7 @@
       "source_location": "L91"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -59209,7 +59449,7 @@
       "source_location": "L68"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -59218,7 +59458,7 @@
       "source_location": "L22"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -59227,7 +59467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -59236,7 +59476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -59245,7 +59485,7 @@
       "source_location": "L22"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -59254,7 +59494,7 @@
       "source_location": "L27"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -59263,7 +59503,7 @@
       "source_location": "L40"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -59272,7 +59512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -59281,7 +59521,7 @@
       "source_location": "L78"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -59290,7 +59530,7 @@
       "source_location": "L118"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -59299,7 +59539,7 @@
       "source_location": "L89"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -59308,7 +59548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -59317,7 +59557,7 @@
       "source_location": "L63"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -59326,7 +59566,7 @@
       "source_location": "L54"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -59335,7 +59575,7 @@
       "source_location": "L11"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -59344,7 +59584,7 @@
       "source_location": "L16"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -59353,7 +59593,7 @@
       "source_location": "L35"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -59362,7 +59602,7 @@
       "source_location": "L6"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -59371,7 +59611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -59380,7 +59620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -59389,7 +59629,7 @@
       "source_location": "L5"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -59398,7 +59638,7 @@
       "source_location": "L30"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -59407,7 +59647,7 @@
       "source_location": "L21"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -59416,7 +59656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -59425,7 +59665,7 @@
       "source_location": "L178"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -59434,7 +59674,7 @@
       "source_location": "L205"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -59443,7 +59683,7 @@
       "source_location": "L806"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -59452,7 +59692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -59461,7 +59701,7 @@
       "source_location": "L41"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -59470,7 +59710,7 @@
       "source_location": "L45"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -59479,7 +59719,7 @@
       "source_location": "L65"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -59488,7 +59728,7 @@
       "source_location": "L75"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -59497,7 +59737,7 @@
       "source_location": "L82"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -59506,49 +59746,13 @@
       "source_location": "L93"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
       "norm_label": "engagementmetrics.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "label": "RiskIndicators.tsx",
-      "norm_label": "riskindicators.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "riskindicators_getriskicon",
-      "label": "getRiskIcon()",
-      "norm_label": "getriskicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "riskindicators_getriskstyles",
-      "label": "getRiskStyles()",
-      "norm_label": "getriskstyles()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "riskindicators_riskindicators",
-      "label": "RiskIndicators()",
-      "norm_label": "riskindicators()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L54"
     },
     {
       "community": 25,
@@ -59706,6 +59910,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
+      "label": "RiskIndicators.tsx",
+      "norm_label": "riskindicators.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "riskindicators_getriskicon",
+      "label": "getRiskIcon()",
+      "norm_label": "getriskicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "riskindicators_getriskstyles",
+      "label": "getRiskStyles()",
+      "norm_label": "getriskstyles()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "riskindicators_riskindicators",
+      "label": "RiskIndicators()",
+      "norm_label": "riskindicators()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
       "norm_label": "formatobservabilitylabel()",
@@ -59713,7 +59953,7 @@
       "source_location": "L66"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -59722,7 +59962,7 @@
       "source_location": "L121"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -59731,7 +59971,7 @@
       "source_location": "L74"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -59740,7 +59980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -59749,7 +59989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -59758,7 +59998,7 @@
       "source_location": "L34"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -59767,7 +60007,7 @@
       "source_location": "L28"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -59776,7 +60016,7 @@
       "source_location": "L48"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -59785,7 +60025,7 @@
       "source_location": "L51"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -59794,7 +60034,7 @@
       "source_location": "L92"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -59803,7 +60043,7 @@
       "source_location": "L16"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -59812,7 +60052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -59821,7 +60061,7 @@
       "source_location": "L22"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -59830,7 +60070,7 @@
       "source_location": "L10"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -59839,7 +60079,7 @@
       "source_location": "L57"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -59848,7 +60088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -59857,7 +60097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -59866,7 +60106,7 @@
       "source_location": "L83"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -59875,7 +60115,7 @@
       "source_location": "L100"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -59884,7 +60124,7 @@
       "source_location": "L79"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -59893,7 +60133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -59902,7 +60142,7 @@
       "source_location": "L38"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -59911,7 +60151,7 @@
       "source_location": "L65"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -59920,7 +60160,7 @@
       "source_location": "L91"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -59929,7 +60169,7 @@
       "source_location": "L4"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -59938,7 +60178,7 @@
       "source_location": "L20"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -59947,7 +60187,7 @@
       "source_location": "L42"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -59956,7 +60196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -59965,7 +60205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -59974,7 +60214,7 @@
       "source_location": "L36"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -59983,7 +60223,7 @@
       "source_location": "L48"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -59992,7 +60232,7 @@
       "source_location": "L64"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -60001,7 +60241,7 @@
       "source_location": "L13"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -60010,7 +60250,7 @@
       "source_location": "L46"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -60019,49 +60259,13 @@
       "source_location": "L21"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
     },
     {
       "community": 26,
@@ -60210,6 +60414,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -60217,7 +60457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -60226,7 +60466,7 @@
       "source_location": "L11"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -60235,7 +60475,7 @@
       "source_location": "L9"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -60244,7 +60484,7 @@
       "source_location": "L25"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -60253,7 +60493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -60262,7 +60502,7 @@
       "source_location": "L50"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -60271,7 +60511,7 @@
       "source_location": "L92"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -60280,7 +60520,7 @@
       "source_location": "L74"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -60289,7 +60529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -60298,7 +60538,7 @@
       "source_location": "L62"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -60307,7 +60547,7 @@
       "source_location": "L109"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -60316,7 +60556,7 @@
       "source_location": "L177"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -60325,7 +60565,7 @@
       "source_location": "L18"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -60334,7 +60574,7 @@
       "source_location": "L52"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -60343,7 +60583,7 @@
       "source_location": "L68"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -60352,7 +60592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -60361,7 +60601,7 @@
       "source_location": "L68"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -60370,7 +60610,7 @@
       "source_location": "L26"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -60379,7 +60619,7 @@
       "source_location": "L7"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -60388,7 +60628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -60397,7 +60637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -60406,7 +60646,7 @@
       "source_location": "L81"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -60415,7 +60655,7 @@
       "source_location": "L85"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -60424,7 +60664,7 @@
       "source_location": "L27"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -60433,7 +60673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -60442,7 +60682,7 @@
       "source_location": "L43"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -60451,7 +60691,7 @@
       "source_location": "L13"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -60460,7 +60700,7 @@
       "source_location": "L88"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -60469,7 +60709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -60478,7 +60718,7 @@
       "source_location": "L111"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -60487,7 +60727,7 @@
       "source_location": "L66"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -60496,7 +60736,7 @@
       "source_location": "L127"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -60505,7 +60745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -60514,7 +60754,7 @@
       "source_location": "L25"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -60523,49 +60763,13 @@
       "source_location": "L90"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
       "norm_label": "usestorecontext()",
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "label": "_shopLayout.tsx",
-      "norm_label": "_shoplayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "shoplayout_clearfilters",
-      "label": "clearFilters()",
-      "norm_label": "clearfilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "shoplayout_onclickonmobilefilters",
-      "label": "onClickOnMobileFilters()",
-      "norm_label": "onclickonmobilefilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "shoplayout_onmobilefilterscloseclick",
-      "label": "onMobileFiltersCloseClick()",
-      "norm_label": "onmobilefilterscloseclick()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L110"
     },
     {
       "community": 27,
@@ -60714,6 +60918,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
+      "label": "_shopLayout.tsx",
+      "norm_label": "_shoplayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "shoplayout_clearfilters",
+      "label": "clearFilters()",
+      "norm_label": "clearfilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "shoplayout_onclickonmobilefilters",
+      "label": "onClickOnMobileFilters()",
+      "norm_label": "onclickonmobilefilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "shoplayout_onmobilefilterscloseclick",
+      "label": "onMobileFiltersCloseClick()",
+      "norm_label": "onmobilefilterscloseclick()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
       "norm_label": "cancelorder()",
@@ -60721,7 +60961,7 @@
       "source_location": "L121"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -60730,7 +60970,7 @@
       "source_location": "L26"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -60739,7 +60979,7 @@
       "source_location": "L71"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -60748,7 +60988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -60757,7 +60997,7 @@
       "source_location": "L46"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -60766,7 +61006,7 @@
       "source_location": "L24"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -60775,7 +61015,7 @@
       "source_location": "L20"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -60784,7 +61024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -60793,7 +61033,7 @@
       "source_location": "L33"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -60802,7 +61042,7 @@
       "source_location": "L6"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -60811,7 +61051,7 @@
       "source_location": "L25"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -60820,7 +61060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60829,7 +61069,7 @@
       "source_location": "L17"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -60838,7 +61078,7 @@
       "source_location": "L11"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -60847,7 +61087,7 @@
       "source_location": "L24"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -60856,7 +61096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60865,7 +61105,7 @@
       "source_location": "L20"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -60874,7 +61114,7 @@
       "source_location": "L65"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -60883,7 +61123,7 @@
       "source_location": "L14"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -60892,7 +61132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -60901,7 +61141,7 @@
       "source_location": "L126"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -60910,7 +61150,7 @@
       "source_location": "L130"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -60919,7 +61159,7 @@
       "source_location": "L876"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -60928,7 +61168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -60937,7 +61177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -60946,7 +61186,7 @@
       "source_location": "L8"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -60955,7 +61195,7 @@
       "source_location": "L79"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -60964,7 +61204,7 @@
       "source_location": "L61"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -60973,7 +61213,7 @@
       "source_location": "L49"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -60982,7 +61222,7 @@
       "source_location": "L17"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -60991,7 +61231,7 @@
       "source_location": "L11"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -61000,7 +61240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -61009,7 +61249,7 @@
       "source_location": "L26"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -61018,7 +61258,7 @@
       "source_location": "L72"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -61027,48 +61267,12 @@
       "source_location": "L36"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
       "norm_label": "harness-test.ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "pre_push_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "pre_push_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "pre_push_review_test_warn",
-      "label": "warn()",
-      "norm_label": "warn()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_test_ts",
-      "label": "pre-push-review.test.ts",
-      "norm_label": "pre-push-review.test.ts",
-      "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -61218,6 +61422,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "pre_push_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "pre_push_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "pre_push_review_test_warn",
+      "label": "warn()",
+      "norm_label": "warn()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_test_ts",
+      "label": "pre-push-review.test.ts",
+      "norm_label": "pre-push-review.test.ts",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
@@ -61225,7 +61465,7 @@
       "source_location": "L14"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -61234,7 +61474,7 @@
       "source_location": "L10"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -61243,7 +61483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -61252,7 +61492,7 @@
       "source_location": "L98"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -61261,7 +61501,7 @@
       "source_location": "L33"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -61270,7 +61510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -61279,7 +61519,7 @@
       "source_location": "L85"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -61288,7 +61528,7 @@
       "source_location": "L31"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -61297,7 +61537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -61306,7 +61546,7 @@
       "source_location": "L12"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -61315,7 +61555,7 @@
       "source_location": "L21"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -61324,7 +61564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -61333,7 +61573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -61342,7 +61582,7 @@
       "source_location": "L5"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -61351,7 +61591,7 @@
       "source_location": "L12"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -61360,7 +61600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -61369,7 +61609,7 @@
       "source_location": "L14"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -61378,7 +61618,7 @@
       "source_location": "L10"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -61387,7 +61627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61396,7 +61636,7 @@
       "source_location": "L6"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -61405,7 +61645,7 @@
       "source_location": "L9"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -61414,7 +61654,7 @@
       "source_location": "L43"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -61423,7 +61663,7 @@
       "source_location": "L11"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -61432,7 +61672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -61441,7 +61681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -61450,40 +61690,13 @@
       "source_location": "L26"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
       "source_location": "L118"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "staffprofiles_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L92"
     },
     {
       "community": 29,
@@ -61632,6 +61845,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "staffprofiles_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
       "norm_label": "staffroles.ts",
@@ -61639,7 +61879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -61648,7 +61888,7 @@
       "source_location": "L21"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -61657,7 +61897,7 @@
       "source_location": "L31"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -61666,7 +61906,7 @@
       "source_location": "L7"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -61675,7 +61915,7 @@
       "source_location": "L109"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -61684,7 +61924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -61693,7 +61933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -61702,7 +61942,7 @@
       "source_location": "L18"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -61711,7 +61951,7 @@
       "source_location": "L9"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -61720,7 +61960,7 @@
       "source_location": "L8"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -61729,7 +61969,7 @@
       "source_location": "L9"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -61738,7 +61978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -61747,7 +61987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -61756,7 +61996,7 @@
       "source_location": "L7"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -61765,7 +62005,7 @@
       "source_location": "L29"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -61774,7 +62014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -61783,7 +62023,7 @@
       "source_location": "L13"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -61792,7 +62032,7 @@
       "source_location": "L45"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -61801,7 +62041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -61810,7 +62050,7 @@
       "source_location": "L36"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -61819,7 +62059,7 @@
       "source_location": "L13"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -61828,7 +62068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -61837,7 +62077,7 @@
       "source_location": "L14"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -61846,7 +62086,7 @@
       "source_location": "L18"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -61855,7 +62095,7 @@
       "source_location": "L17"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -61864,40 +62104,13 @@
       "source_location": "L61"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
       "norm_label": "appointments.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
     },
     {
       "community": 3,
@@ -62316,6 +62529,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
       "norm_label": "receiving.test.ts",
@@ -62323,7 +62563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -62332,7 +62572,7 @@
       "source_location": "L20"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -62341,7 +62581,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -62350,7 +62590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -62359,7 +62599,7 @@
       "source_location": "L12"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -62368,7 +62608,7 @@
       "source_location": "L7"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -62377,7 +62617,7 @@
       "source_location": "L25"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -62386,7 +62626,7 @@
       "source_location": "L21"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -62395,7 +62635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -62404,7 +62644,7 @@
       "source_location": "L7"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -62413,7 +62653,7 @@
       "source_location": "L14"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -62422,7 +62662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -62431,7 +62671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -62440,7 +62680,7 @@
       "source_location": "L45"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -62449,7 +62689,7 @@
       "source_location": "L37"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -62458,7 +62698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -62467,7 +62707,7 @@
       "source_location": "L10"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -62476,7 +62716,7 @@
       "source_location": "L44"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -62485,7 +62725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -62494,7 +62734,7 @@
       "source_location": "L84"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -62503,7 +62743,7 @@
       "source_location": "L100"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -62512,7 +62752,7 @@
       "source_location": "L5"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -62521,7 +62761,7 @@
       "source_location": "L25"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -62530,7 +62770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -62539,7 +62779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -62548,7 +62788,7 @@
       "source_location": "L35"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -62557,7 +62797,142 @@
       "source_location": "L25"
     },
     {
-      "community": 309,
+      "community": 31,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_authenticatecorrectionstaff",
+      "label": "authenticateCorrectionStaff()",
+      "norm_label": "authenticatecorrectionstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L353"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_exitcorrectionworkflow",
+      "label": "exitCorrectionWorkflow()",
+      "norm_label": "exitcorrectionworkflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L378"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectioneventtype",
+      "label": "formatCorrectionEventType()",
+      "norm_label": "formatcorrectioneventtype()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L94"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectionhistorychange",
+      "label": "formatCorrectionHistoryChange()",
+      "norm_label": "formatcorrectionhistorychange()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectionhistorymeta",
+      "label": "formatCorrectionHistoryMeta()",
+      "norm_label": "formatcorrectionhistorymeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L112"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_formatcorrectionhistorytitle",
+      "label": "formatCorrectionHistoryTitle()",
+      "norm_label": "formatcorrectionhistorytitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_getcorrectionhistorychangeparts",
+      "label": "getCorrectionHistoryChangeParts()",
+      "norm_label": "getcorrectionhistorychangeparts()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L162"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_gettransactioncorrectionhistory",
+      "label": "getTransactionCorrectionHistory()",
+      "norm_label": "gettransactioncorrectionhistory()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L182"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L137"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_requestcorrectionsubmit",
+      "label": "requestCorrectionSubmit()",
+      "norm_label": "requestcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L486"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_requiresinlinemanagerproof",
+      "label": "requiresInlineManagerProof()",
+      "norm_label": "requiresinlinemanagerproof()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_runcustomercorrection",
+      "label": "runCustomerCorrection()",
+      "norm_label": "runcustomercorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L386"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_runpaymentmethodcorrection",
+      "label": "runPaymentMethodCorrection()",
+      "norm_label": "runpaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L424"
+    },
+    {
+      "community": 310,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -62566,7 +62941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 310,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -62575,7 +62950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 310,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -62584,142 +62959,7 @@
       "source_location": "L4"
     },
     {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_addgroupederror",
-      "label": "addGroupedError()",
-      "norm_label": "addgroupederror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_collectlivesurfaceentries",
-      "label": "collectLiveSurfaceEntries()",
-      "norm_label": "collectlivesurfaceentries()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_formatgroupederrors",
-      "label": "formatGroupedErrors()",
-      "norm_label": "formatgroupederrors()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L341"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_infergroupfromerror",
-      "label": "inferGroupFromError()",
-      "norm_label": "infergroupfromerror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_loadaudittarget",
-      "label": "loadAuditTarget()",
-      "norm_label": "loadaudittarget()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_runharnessaudit",
-      "label": "runHarnessAudit()",
-      "norm_label": "runharnessaudit()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L356"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "harness_audit_shouldskipsurfaceentry",
-      "label": "shouldSkipSurfaceEntry()",
-      "norm_label": "shouldskipsurfaceentry()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "scripts_harness_audit_ts",
-      "label": "harness-audit.ts",
-      "norm_label": "harness-audit.ts",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -62728,7 +62968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -62737,7 +62977,7 @@
       "source_location": "L19"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -62746,7 +62986,7 @@
       "source_location": "L5"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -62755,7 +62995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -62764,7 +63004,7 @@
       "source_location": "L19"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -62773,7 +63013,7 @@
       "source_location": "L11"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -62782,7 +63022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -62791,7 +63031,7 @@
       "source_location": "L22"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -62800,7 +63040,7 @@
       "source_location": "L8"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -62809,7 +63049,7 @@
       "source_location": "L21"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -62818,7 +63058,7 @@
       "source_location": "L13"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -62827,7 +63067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -62836,7 +63076,7 @@
       "source_location": "L100"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -62845,7 +63085,7 @@
       "source_location": "L10"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -62854,7 +63094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -62863,7 +63103,7 @@
       "source_location": "L100"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -62872,7 +63112,7 @@
       "source_location": "L10"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -62881,7 +63121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -62890,7 +63130,7 @@
       "source_location": "L15"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -62899,7 +63139,7 @@
       "source_location": "L39"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -62908,7 +63148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -62917,7 +63157,7 @@
       "source_location": "L3"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -62926,7 +63166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -62935,7 +63175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -62944,7 +63184,7 @@
       "source_location": "L53"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -62953,7 +63193,7 @@
       "source_location": "L65"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -62962,7 +63202,142 @@
       "source_location": "L1"
     },
     {
-      "community": 319,
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_addgroupederror",
+      "label": "addGroupedError()",
+      "norm_label": "addgroupederror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_collectlivesurfaceentries",
+      "label": "collectLiveSurfaceEntries()",
+      "norm_label": "collectlivesurfaceentries()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_formatgroupederrors",
+      "label": "formatGroupedErrors()",
+      "norm_label": "formatgroupederrors()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L341"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_infergroupfromerror",
+      "label": "inferGroupFromError()",
+      "norm_label": "infergroupfromerror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_loadaudittarget",
+      "label": "loadAuditTarget()",
+      "norm_label": "loadaudittarget()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_runharnessaudit",
+      "label": "runHarnessAudit()",
+      "norm_label": "runharnessaudit()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L356"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "label": "shouldSkipSurfaceEntry()",
+      "norm_label": "shouldskipsurfaceentry()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "scripts_harness_audit_ts",
+      "label": "harness-audit.ts",
+      "norm_label": "harness-audit.ts",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -62971,7 +63346,7 @@
       "source_location": "L47"
     },
     {
-      "community": 319,
+      "community": 320,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -62980,7 +63355,7 @@
       "source_location": "L53"
     },
     {
-      "community": 319,
+      "community": 320,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -62989,133 +63364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L303"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L307"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
-      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
-      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_buildregistersessioncloseoutreview",
-      "label": "buildRegisterSessionCloseoutReview()",
-      "norm_label": "buildregistersessioncloseoutreview()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L357"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
-      "label": "buildRegisterSessionVarianceApprovalRequirement()",
-      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L411"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_cancelpendingapprovalifneeded",
-      "label": "cancelPendingApprovalIfNeeded()",
-      "norm_label": "cancelpendingapprovalifneeded()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L521"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_getcashcontrolsconfig",
-      "label": "getCashControlsConfig()",
-      "norm_label": "getcashcontrolsconfig()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_listregistersessionsforcloseout",
-      "label": "listRegisterSessionsForCloseout()",
-      "norm_label": "listregistersessionsforcloseout()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L439"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L469"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L316"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
-      "label": "staffProfileCanReviewCloseoutVariance()",
-      "norm_label": "staffprofilecanreviewcloseoutvariance()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L486"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "closeouts_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
-      "label": "closeouts.ts",
-      "norm_label": "closeouts.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -63124,7 +63373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -63133,40 +63382,13 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
       "norm_label": "videoplayer()",
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "operationsqueueview_handledecideapprovalrequest",
-      "label": "handleDecideApprovalRequest()",
-      "norm_label": "handledecideapprovalrequest()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L295"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "operationsqueueview_handlesubmitstockbatch",
-      "label": "handleSubmitStockBatch()",
-      "norm_label": "handlesubmitstockbatch()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L285"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 322,
@@ -63387,128 +63609,128 @@
     {
       "community": 33,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "closeouts_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L303"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
+      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
+      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_buildregistersessioncloseoutreview",
+      "label": "buildRegisterSessionCloseoutReview()",
+      "norm_label": "buildregistersessioncloseoutreview()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L357"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
+      "label": "buildRegisterSessionVarianceApprovalRequirement()",
+      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L411"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_cancelpendingapprovalifneeded",
+      "label": "cancelPendingApprovalIfNeeded()",
+      "norm_label": "cancelpendingapprovalifneeded()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L521"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_getcashcontrolsconfig",
+      "label": "getCashControlsConfig()",
+      "norm_label": "getcashcontrolsconfig()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L338"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_listregistersessionsforcloseout",
+      "label": "listRegisterSessionsForCloseout()",
+      "norm_label": "listregistersessionsforcloseout()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L439"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L469"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L316"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
+      "label": "staffProfileCanReviewCloseoutVariance()",
+      "norm_label": "staffprofilecanreviewcloseoutvariance()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L486"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "closeouts_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
+      "label": "closeouts.ts",
+      "norm_label": "closeouts.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L292"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L367"
     },
     {
       "community": 330,
@@ -63526,7 +63748,7 @@
       "label": "async()",
       "norm_label": "async()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L148"
+      "source_location": "L151"
     },
     {
       "community": 330,
@@ -63535,7 +63757,7 @@
       "label": "mockTransactionMutations()",
       "norm_label": "mocktransactionmutations()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L314"
+      "source_location": "L338"
     },
     {
       "community": 331,
@@ -63783,128 +64005,128 @@
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_cleanundefinedfields",
-      "label": "cleanUndefinedFields()",
-      "norm_label": "cleanundefinedfields()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L52"
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L1"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_clonereceivingaccount",
-      "label": "cloneReceivingAccount()",
-      "norm_label": "clonereceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L27"
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L105"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_createemptyreceivingaccount",
-      "label": "createEmptyReceivingAccount()",
-      "norm_label": "createemptyreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L35"
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L83"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_getstatusbadgevariant",
-      "label": "getStatusBadgeVariant()",
-      "norm_label": "getstatusbadgevariant()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L114"
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L55"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_handleaddaccount",
-      "label": "handleAddAccount()",
-      "norm_label": "handleaddaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L152"
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L186"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_handlemakeprimary",
-      "label": "handleMakePrimary()",
-      "norm_label": "handlemakeprimary()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L159"
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L292"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_handleremoveaccount",
-      "label": "handleRemoveAccount()",
-      "norm_label": "handleremoveaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
       "source_location": "L168"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L188"
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L45"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_hasreceivingaccountdetails",
-      "label": "hasReceivingAccountDetails()",
-      "norm_label": "hasreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L64"
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L119"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "mtnmomoview_normalizeprimaryaccounts",
-      "label": "normalizePrimaryAccounts()",
-      "norm_label": "normalizeprimaryaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "mtnmomoview_topatchreceivingaccounts",
-      "label": "toPatchReceivingAccounts()",
-      "norm_label": "topatchreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "mtnmomoview_trimtoundefined",
-      "label": "trimToUndefined()",
-      "norm_label": "trimtoundefined()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "mtnmomoview_updateaccount",
-      "label": "updateAccount()",
-      "norm_label": "updateaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
-      "label": "MtnMomoView.tsx",
-      "norm_label": "mtnmomoview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L1"
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L367"
     },
     {
       "community": 340,
@@ -63922,7 +64144,7 @@
       "label": "chooseRole()",
       "norm_label": "chooserole()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L127"
+      "source_location": "L163"
     },
     {
       "community": 340,
@@ -63931,7 +64153,7 @@
       "label": "mockConvex()",
       "norm_label": "mockconvex()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L71"
+      "source_location": "L107"
     },
     {
       "community": 341,
@@ -63949,7 +64171,7 @@
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L158"
+      "source_location": "L162"
     },
     {
       "community": 341,
@@ -63958,7 +64180,7 @@
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L105"
+      "source_location": "L109"
     },
     {
       "community": 342,
@@ -64179,128 +64401,128 @@
     {
       "community": 35,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_validation_ts",
-      "label": "validation.ts",
-      "norm_label": "validation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
+      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_applypaymentmethodcorrection",
+      "label": "applyPaymentMethodCorrection()",
+      "norm_label": "applypaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
+      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
+      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
+      "label": "consumePaymentMethodCorrectionApprovalProof()",
+      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactioncustomer",
+      "label": "correctTransactionCustomer()",
+      "norm_label": "correcttransactioncustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L367"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactionpaymentmethod",
+      "label": "correctTransactionPaymentMethod()",
+      "norm_label": "correcttransactionpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L429"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "label": "createPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_getpaymentmethodcashcontribution",
+      "label": "getPaymentMethodCashContribution()",
+      "norm_label": "getpaymentmethodcashcontribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L532"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "label": "requireRegisterSessionAllowsPaymentCorrection()",
+      "norm_label": "requireregistersessionallowspaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
+      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L540"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "correcttransaction_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "label": "correctTransaction.ts",
+      "norm_label": "correcttransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_cancompletetransaction",
-      "label": "canCompleteTransaction()",
-      "norm_label": "cancompletetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L406"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_isoverpaypaymentmethod",
-      "label": "isOverpayPaymentMethod()",
-      "norm_label": "isoverpaypaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L416"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_isvalidphone",
-      "label": "isValidPhone()",
-      "norm_label": "isvalidphone()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L306"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatebarcode",
-      "label": "validateBarcode()",
-      "norm_label": "validatebarcode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatecart",
-      "label": "validateCart()",
-      "norm_label": "validatecart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatecustomer",
-      "label": "validateCustomer()",
-      "norm_label": "validatecustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatepayment",
-      "label": "validatePayment()",
-      "norm_label": "validatepayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatepayments",
-      "label": "validatePayments()",
-      "norm_label": "validatepayments()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L361"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validateproduct",
-      "label": "validateProduct()",
-      "norm_label": "validateproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatequantity",
-      "label": "validateQuantity()",
-      "norm_label": "validatequantity()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "validation_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L254"
     },
     {
       "community": 350,
@@ -64575,118 +64797,127 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "mtnmomoview_cleanundefinedfields",
+      "label": "cleanUndefinedFields()",
+      "norm_label": "cleanundefinedfields()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L52"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "mtnmomoview_clonereceivingaccount",
+      "label": "cloneReceivingAccount()",
+      "norm_label": "clonereceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L27"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "mtnmomoview_createemptyreceivingaccount",
+      "label": "createEmptyReceivingAccount()",
+      "norm_label": "createemptyreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L35"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L341"
+      "id": "mtnmomoview_getstatusbadgevariant",
+      "label": "getStatusBadgeVariant()",
+      "norm_label": "getstatusbadgevariant()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "mtnmomoview_handleaddaccount",
+      "label": "handleAddAccount()",
+      "norm_label": "handleaddaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "mtnmomoview_handlemakeprimary",
+      "label": "handleMakePrimary()",
+      "norm_label": "handlemakeprimary()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L159"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L469"
+      "id": "mtnmomoview_handleremoveaccount",
+      "label": "handleRemoveAccount()",
+      "norm_label": "handleremoveaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "mtnmomoview_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L188"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L375"
+      "id": "mtnmomoview_hasreceivingaccountdetails",
+      "label": "hasReceivingAccountDetails()",
+      "norm_label": "hasreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L64"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "mtnmomoview_normalizeprimaryaccounts",
+      "label": "normalizePrimaryAccounts()",
+      "norm_label": "normalizeprimaryaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L77"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "mtnmomoview_topatchreceivingaccounts",
+      "label": "toPatchReceivingAccounts()",
+      "norm_label": "topatchreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "mtnmomoview_trimtoundefined",
+      "label": "trimToUndefined()",
+      "norm_label": "trimtoundefined()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L47"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "mtnmomoview_updateaccount",
+      "label": "updateAccount()",
+      "norm_label": "updateaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
+      "label": "MtnMomoView.tsx",
+      "norm_label": "mtnmomoview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1"
     },
     {
@@ -64962,119 +65193,128 @@
     {
       "community": 37,
       "file_type": "code",
-      "id": "completetransaction_buildcompletetransactionresult",
-      "label": "buildCompleteTransactionResult()",
-      "norm_label": "buildcompletetransactionresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_calculatetotalpaid",
-      "label": "calculateTotalPaid()",
-      "norm_label": "calculatetotalpaid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_completetransaction",
-      "label": "completeTransaction()",
-      "norm_label": "completetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_createtransactionfromsessionhandler",
-      "label": "createTransactionFromSessionHandler()",
-      "norm_label": "createtransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L480"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionsale",
-      "label": "recordRegisterSessionSale()",
-      "norm_label": "recordregistersessionsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionvoid",
-      "label": "recordRegisterSessionVoid()",
-      "norm_label": "recordregistersessionvoid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_resolvesessionregistersessionid",
-      "label": "resolveSessionRegisterSessionId()",
-      "norm_label": "resolvesessionregistersessionid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "completetransaction_voidtransaction",
-      "label": "voidTransaction()",
-      "norm_label": "voidtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "id": "packages_athena_webapp_src_lib_pos_validation_ts",
+      "label": "validation.ts",
+      "norm_label": "validation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L1"
+      "id": "validation_cancompletetransaction",
+      "label": "canCompleteTransaction()",
+      "norm_label": "cancompletetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L406"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_isoverpaypaymentmethod",
+      "label": "isOverpayPaymentMethod()",
+      "norm_label": "isoverpaypaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L416"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_isvalidphone",
+      "label": "isValidPhone()",
+      "norm_label": "isvalidphone()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L306"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatebarcode",
+      "label": "validateBarcode()",
+      "norm_label": "validatebarcode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatecart",
+      "label": "validateCart()",
+      "norm_label": "validatecart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatecustomer",
+      "label": "validateCustomer()",
+      "norm_label": "validatecustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatepayment",
+      "label": "validatePayment()",
+      "norm_label": "validatepayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatepayments",
+      "label": "validatePayments()",
+      "norm_label": "validatepayments()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L361"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validateproduct",
+      "label": "validateProduct()",
+      "norm_label": "validateproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatequantity",
+      "label": "validateQuantity()",
+      "norm_label": "validatequantity()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "validation_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L254"
     },
     {
       "community": 370,
@@ -65349,119 +65589,119 @@
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_ts",
-      "label": "serviceCases.ts",
-      "norm_label": "servicecases.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L1"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "servicecases_assertvalidservicecasestatustransition",
-      "label": "assertValidServiceCaseStatusTransition()",
-      "norm_label": "assertvalidservicecasestatustransition()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L226"
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "servicecases_buildservicecase",
-      "label": "buildServiceCase()",
-      "norm_label": "buildservicecase()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_buildservicecaselineitem",
-      "label": "buildServiceCaseLineItem()",
-      "norm_label": "buildservicecaselineitem()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_createservicecasewithctx",
-      "label": "createServiceCaseWithCtx()",
-      "norm_label": "createservicecasewithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L304"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_deriveservicecasepaymentstatus",
-      "label": "deriveServiceCasePaymentStatus()",
-      "norm_label": "deriveservicecasepaymentstatus()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_getservicecasecontext",
-      "label": "getServiceCaseContext()",
-      "norm_label": "getservicecasecontext()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_listpendingapprovalrequestswithctx",
-      "label": "listPendingApprovalRequestsWithCtx()",
-      "norm_label": "listpendingapprovalrequestswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_listservicecaseallocationswithctx",
-      "label": "listServiceCaseAllocationsWithCtx()",
-      "norm_label": "listservicecaseallocationswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "servicecases_listservicecaselineitemswithctx",
-      "label": "listServiceCaseLineItemsWithCtx()",
-      "norm_label": "listservicecaselineitemswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L111"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "servicecases_listserviceinventoryusagewithctx",
-      "label": "listServiceInventoryUsageWithCtx()",
-      "norm_label": "listserviceinventoryusagewithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L121"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L341"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "servicecases_mapservicecasestatustoworkitemstatus",
-      "label": "mapServiceCaseStatusToWorkItemStatus()",
-      "norm_label": "mapservicecasestatustoworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L71"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "servicecases_syncservicecasefinancialswithctx",
-      "label": "syncServiceCaseFinancialsWithCtx()",
-      "norm_label": "syncservicecasefinancialswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L156"
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L469"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L375"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L1"
     },
     {
       "community": 380,
@@ -65736,118 +65976,118 @@
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L141"
+      "id": "completetransaction_buildcompletetransactionresult",
+      "label": "buildCompleteTransactionResult()",
+      "norm_label": "buildcompletetransactionresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L46"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L65"
+      "id": "completetransaction_calculatetotalpaid",
+      "label": "calculateTotalPaid()",
+      "norm_label": "calculatetotalpaid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L67"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L95"
+      "id": "completetransaction_completetransaction",
+      "label": "completeTransaction()",
+      "norm_label": "completetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L5"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L199"
+      "id": "completetransaction_createtransactionfromsessionhandler",
+      "label": "createTransactionFromSessionHandler()",
+      "norm_label": "createtransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L480"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L189"
+      "id": "completetransaction_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L86"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L81"
+      "id": "completetransaction_recordregistersessionsale",
+      "label": "recordRegisterSessionSale()",
+      "norm_label": "recordregistersessionsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L140"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L85"
+      "id": "completetransaction_recordregistersessionvoid",
+      "label": "recordRegisterSessionVoid()",
+      "norm_label": "recordregistersessionvoid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L165"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L529"
+      "id": "completetransaction_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L71"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L205"
+      "id": "completetransaction_resolvesessionregistersessionid",
+      "label": "resolveSessionRegisterSessionId()",
+      "norm_label": "resolvesessionregistersessionid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L90"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L582"
+      "id": "completetransaction_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L190"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L339"
+      "id": "completetransaction_voidtransaction",
+      "label": "voidTransaction()",
+      "norm_label": "voidtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L404"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L60"
+      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L1"
     },
     {
       "community": 39,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -66375,119 +66615,119 @@
     {
       "community": 40,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
-      "label": "receiving.ts",
-      "norm_label": "receiving.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_ts",
+      "label": "serviceCases.ts",
+      "norm_label": "servicecases.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
       "source_location": "L1"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_assertdistinctreceivinglineitems",
-      "label": "assertDistinctReceivingLineItems()",
-      "norm_label": "assertdistinctreceivinglineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "servicecases_assertvalidservicecasestatustransition",
+      "label": "assertValidServiceCaseStatusTransition()",
+      "norm_label": "assertvalidservicecasestatustransition()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "servicecases_buildservicecase",
+      "label": "buildServiceCase()",
+      "norm_label": "buildservicecase()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "servicecases_buildservicecaselineitem",
+      "label": "buildServiceCaseLineItem()",
+      "norm_label": "buildservicecaselineitem()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "servicecases_createservicecasewithctx",
+      "label": "createServiceCaseWithCtx()",
+      "norm_label": "createservicecasewithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L304"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "servicecases_deriveservicecasepaymentstatus",
+      "label": "deriveServiceCasePaymentStatus()",
+      "norm_label": "deriveservicecasepaymentstatus()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
       "source_location": "L87"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_assertreceivablepurchaseorderstatus",
-      "label": "assertReceivablePurchaseOrderStatus()",
-      "norm_label": "assertreceivablepurchaseorderstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L63"
+      "id": "servicecases_getservicecasecontext",
+      "label": "getServiceCaseContext()",
+      "norm_label": "getservicecasecontext()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L191"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_assertreceivinglinequantities",
-      "label": "assertReceivingLineQuantities()",
-      "norm_label": "assertreceivinglinequantities()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L73"
+      "id": "servicecases_listpendingapprovalrequestswithctx",
+      "label": "listPendingApprovalRequestsWithCtx()",
+      "norm_label": "listpendingapprovalrequestswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L144"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_buildreceivingbatchsourceid",
-      "label": "buildReceivingBatchSourceId()",
-      "norm_label": "buildreceivingbatchsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L135"
+      "id": "servicecases_listservicecaseallocationswithctx",
+      "label": "listServiceCaseAllocationsWithCtx()",
+      "norm_label": "listservicecaseallocationswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L131"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_calculatepurchaseorderreceivingstatus",
-      "label": "calculatePurchaseOrderReceivingStatus()",
-      "norm_label": "calculatepurchaseorderreceivingstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L53"
+      "id": "servicecases_listservicecaselineitemswithctx",
+      "label": "listServiceCaseLineItemsWithCtx()",
+      "norm_label": "listservicecaselineitemswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L111"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_calculatereceivingbatchtotals",
-      "label": "calculateReceivingBatchTotals()",
-      "norm_label": "calculatereceivingbatchtotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L32"
+      "id": "servicecases_listserviceinventoryusagewithctx",
+      "label": "listServiceInventoryUsageWithCtx()",
+      "norm_label": "listserviceinventoryusagewithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L121"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L142"
+      "id": "servicecases_mapservicecasestatustoworkitemstatus",
+      "label": "mapServiceCaseStatusToWorkItemStatus()",
+      "norm_label": "mapservicecasestatustoworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L71"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "receiving_mapreceivepurchaseorderbatcherror",
-      "label": "mapReceivePurchaseOrderBatchError()",
-      "norm_label": "mapreceivepurchaseorderbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
-      "label": "receivePurchaseOrderBatchCommandWithCtx()",
-      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L390"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchwithctx",
-      "label": "receivePurchaseOrderBatchWithCtx()",
-      "norm_label": "receivepurchaseorderbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "receiving_summarizereceivingskudeltas",
-      "label": "summarizeReceivingSkuDeltas()",
-      "norm_label": "summarizereceivingskudeltas()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "receiving_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L27"
+      "id": "servicecases_syncservicecasefinancialswithctx",
+      "label": "syncServiceCaseFinancialsWithCtx()",
+      "norm_label": "syncservicecasefinancialswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L156"
     },
     {
       "community": 400,
@@ -66762,119 +67002,119 @@
     {
       "community": 41,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L141"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_authenticatecorrectionstaff",
-      "label": "authenticateCorrectionStaff()",
-      "norm_label": "authenticatecorrectionstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L338"
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L65"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_exitcorrectionworkflow",
-      "label": "exitCorrectionWorkflow()",
-      "norm_label": "exitcorrectionworkflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L366"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectioneventtype",
-      "label": "formatCorrectionEventType()",
-      "norm_label": "formatcorrectioneventtype()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorychange",
-      "label": "formatCorrectionHistoryChange()",
-      "norm_label": "formatcorrectionhistorychange()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L126"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorymeta",
-      "label": "formatCorrectionHistoryMeta()",
-      "norm_label": "formatcorrectionhistorymeta()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorytitle",
-      "label": "formatCorrectionHistoryTitle()",
-      "norm_label": "formatcorrectionhistorytitle()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L95"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L116"
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L199"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_getcorrectionhistorychangeparts",
-      "label": "getCorrectionHistoryChangeParts()",
-      "norm_label": "getcorrectionhistorychangeparts()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L147"
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L189"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_gettransactioncorrectionhistory",
-      "label": "getTransactionCorrectionHistory()",
-      "norm_label": "gettransactioncorrectionhistory()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L167"
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L81"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_requestcorrectionsubmit",
-      "label": "requestCorrectionSubmit()",
-      "norm_label": "requestcorrectionsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L466"
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L85"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_runcustomercorrection",
-      "label": "runCustomerCorrection()",
-      "norm_label": "runcustomercorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L374"
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L529"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "transactionview_runpaymentmethodcorrection",
-      "label": "runPaymentMethodCorrection()",
-      "norm_label": "runpaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L412"
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L582"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L339"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1"
     },
     {
       "community": 410,
@@ -67149,119 +67389,119 @@
     {
       "community": 42,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
+      "label": "receiving.ts",
+      "norm_label": "receiving.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
       "source_location": "L1"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "receiving_assertdistinctreceivinglineitems",
+      "label": "assertDistinctReceivingLineItems()",
+      "norm_label": "assertdistinctreceivinglineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L87"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "receiving_assertreceivablepurchaseorderstatus",
+      "label": "assertReceivablePurchaseOrderStatus()",
+      "norm_label": "assertreceivablepurchaseorderstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L63"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "receiving_assertreceivinglinequantities",
+      "label": "assertReceivingLineQuantities()",
+      "norm_label": "assertreceivinglinequantities()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L73"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "receiving_buildreceivingbatchsourceid",
+      "label": "buildReceivingBatchSourceId()",
+      "norm_label": "buildreceivingbatchsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "receiving_calculatepurchaseorderreceivingstatus",
+      "label": "calculatePurchaseOrderReceivingStatus()",
+      "norm_label": "calculatepurchaseorderreceivingstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "receiving_calculatereceivingbatchtotals",
+      "label": "calculateReceivingBatchTotals()",
+      "norm_label": "calculatereceivingbatchtotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
       "source_location": "L32"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "receiving_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L142"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "receiving_mapreceivepurchaseorderbatcherror",
+      "label": "mapReceivePurchaseOrderBatchError()",
+      "norm_label": "mapreceivepurchaseorderbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L347"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
+      "label": "receivePurchaseOrderBatchCommandWithCtx()",
+      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L390"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "receiving_receivepurchaseorderbatchwithctx",
+      "label": "receivePurchaseOrderBatchWithCtx()",
+      "norm_label": "receivepurchaseorderbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L171"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "receiving_summarizereceivingskudeltas",
+      "label": "summarizeReceivingSkuDeltas()",
+      "norm_label": "summarizereceivingskudeltas()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L103"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "receiving_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L27"
     },
     {
       "community": 420,
@@ -67536,110 +67776,119 @@
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_attachredislogging",
-      "label": "attachRedisLogging()",
-      "norm_label": "attachredislogging()",
-      "source_file": "packages/valkey-proxy-server/app.js",
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_createapp",
-      "label": "createApp()",
-      "norm_label": "createapp()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L300"
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_createhandlers",
-      "label": "createHandlers()",
-      "norm_label": "createhandlers()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L192"
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_createrediscluster",
-      "label": "createRedisCluster()",
-      "norm_label": "createrediscluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L28"
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_deletekeysindividually",
-      "label": "deleteKeysIndividually()",
-      "norm_label": "deletekeysindividually()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L75"
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_invalidateacrosscluster",
-      "label": "invalidateAcrossCluster()",
-      "norm_label": "invalidateacrosscluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L91"
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_invalidateacrossclusterwithpipeline",
-      "label": "invalidateAcrossClusterWithPipeline()",
-      "norm_label": "invalidateacrossclusterwithpipeline()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L114"
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L183"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_runconnectionprobe",
-      "label": "runConnectionProbe()",
-      "norm_label": "runconnectionprobe()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L155"
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "app_scannodeforpattern",
-      "label": "scanNodeForPattern()",
-      "norm_label": "scannodeforpattern()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L51"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "app_serializeredisvalue",
-      "label": "serializeRedisValue()",
-      "norm_label": "serializeredisvalue()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L47"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "app_startserver",
-      "label": "startServer()",
-      "norm_label": "startserver()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L319"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_js",
-      "label": "app.js",
-      "norm_label": "app.js",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L1"
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 430,
@@ -67824,109 +68073,109 @@
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_collectrepairableharnessdocerrors",
-      "label": "collectRepairableHarnessDocErrors()",
-      "norm_label": "collectrepairableharnessdocerrors()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L154"
+      "id": "app_attachredislogging",
+      "label": "attachRedisLogging()",
+      "norm_label": "attachredislogging()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L32"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_formatblockerlist",
-      "label": "formatBlockerList()",
-      "norm_label": "formatblockerlist()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L186"
+      "id": "app_createapp",
+      "label": "createApp()",
+      "norm_label": "createapp()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L300"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "label": "getChangedFilesVsOriginMain()",
-      "norm_label": "getchangedfilesvsoriginmain()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L67"
+      "id": "app_createhandlers",
+      "label": "createHandlers()",
+      "norm_label": "createhandlers()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L192"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_isrepairablegraphifydrift",
-      "label": "isRepairableGraphifyDrift()",
-      "norm_label": "isrepairablegraphifydrift()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L190"
+      "id": "app_createrediscluster",
+      "label": "createRedisCluster()",
+      "norm_label": "createrediscluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L28"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L63"
+      "id": "app_deletekeysindividually",
+      "label": "deleteKeysIndividually()",
+      "norm_label": "deletekeysindividually()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L75"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_runarchitecturecheck",
-      "label": "runArchitectureCheck()",
-      "norm_label": "runarchitecturecheck()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L108"
+      "id": "app_invalidateacrosscluster",
+      "label": "invalidateAcrossCluster()",
+      "norm_label": "invalidateacrosscluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L91"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_runharnessgenerate",
-      "label": "runHarnessGenerate()",
-      "norm_label": "runharnessgenerate()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L126"
+      "id": "app_invalidateacrossclusterwithpipeline",
+      "label": "invalidateAcrossClusterWithPipeline()",
+      "norm_label": "invalidateacrossclusterwithpipeline()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L114"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_runharnessimplementationtests",
-      "label": "runHarnessImplementationTests()",
-      "norm_label": "runharnessimplementationtests()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L130"
+      "id": "app_runconnectionprobe",
+      "label": "runConnectionProbe()",
+      "norm_label": "runconnectionprobe()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L155"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_runharnessinferentialreview",
-      "label": "runHarnessInferentialReview()",
-      "norm_label": "runharnessinferentialreview()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L142"
+      "id": "app_scannodeforpattern",
+      "label": "scanNodeForPattern()",
+      "norm_label": "scannodeforpattern()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L51"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_runharnessselfreview",
-      "label": "runHarnessSelfReview()",
-      "norm_label": "runharnessselfreview()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L120"
+      "id": "app_serializeredisvalue",
+      "label": "serializeRedisValue()",
+      "norm_label": "serializeredisvalue()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L47"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "pre_push_review_runprepushreview",
-      "label": "runPrePushReview()",
-      "norm_label": "runprepushreview()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L198"
+      "id": "app_startserver",
+      "label": "startServer()",
+      "norm_label": "startserver()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L319"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "scripts_pre_push_review_ts",
-      "label": "pre-push-review.ts",
-      "norm_label": "pre-push-review.ts",
-      "source_file": "scripts/pre-push-review.ts",
+      "id": "packages_valkey_proxy_server_app_js",
+      "label": "app.js",
+      "norm_label": "app.js",
+      "source_file": "packages/valkey-proxy-server/app.js",
       "source_location": "L1"
     },
     {
@@ -68112,100 +68361,109 @@
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L116"
+      "id": "pre_push_review_collectrepairableharnessdocerrors",
+      "label": "collectRepairableHarnessDocErrors()",
+      "norm_label": "collectrepairableharnessdocerrors()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L154"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L283"
+      "id": "pre_push_review_formatblockerlist",
+      "label": "formatBlockerList()",
+      "norm_label": "formatblockerlist()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L186"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L318"
+      "id": "pre_push_review_getchangedfilesvsoriginmain",
+      "label": "getChangedFilesVsOriginMain()",
+      "norm_label": "getchangedfilesvsoriginmain()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L67"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L91"
+      "id": "pre_push_review_isrepairablegraphifydrift",
+      "label": "isRepairableGraphifyDrift()",
+      "norm_label": "isrepairablegraphifydrift()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L190"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L164"
+      "id": "pre_push_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L63"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L106"
+      "id": "pre_push_review_runarchitecturecheck",
+      "label": "runArchitectureCheck()",
+      "norm_label": "runarchitecturecheck()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L108"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L74"
+      "id": "pre_push_review_runharnessgenerate",
+      "label": "runHarnessGenerate()",
+      "norm_label": "runharnessgenerate()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L126"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L55"
+      "id": "pre_push_review_runharnessimplementationtests",
+      "label": "runHarnessImplementationTests()",
+      "norm_label": "runharnessimplementationtests()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L130"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L46"
+      "id": "pre_push_review_runharnessinferentialreview",
+      "label": "runHarnessInferentialReview()",
+      "norm_label": "runharnessinferentialreview()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L142"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L16"
+      "id": "pre_push_review_runharnessselfreview",
+      "label": "runHarnessSelfReview()",
+      "norm_label": "runharnessselfreview()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L120"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "pre_push_review_runprepushreview",
+      "label": "runPrePushReview()",
+      "norm_label": "runprepushreview()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_ts",
+      "label": "pre-push-review.ts",
+      "norm_label": "pre-push-review.ts",
+      "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1"
     },
     {
@@ -68341,7 +68599,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts",
-      "source_location": "L35"
+      "source_location": "L38"
     },
     {
       "community": 457,
@@ -68391,101 +68649,101 @@
     {
       "community": 46,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 460,
@@ -68670,101 +68928,101 @@
     {
       "community": 47,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
     },
     {
       "community": 470,
@@ -68949,100 +69207,100 @@
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -69228,101 +69486,101 @@
     {
       "community": 49,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L75"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 490,
@@ -69759,100 +70017,100 @@
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getbanneranimationdelay",
-      "label": "getBannerAnimationDelay()",
-      "norm_label": "getbanneranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L152"
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getbannerbgclass",
-      "label": "getBannerBGClass()",
-      "norm_label": "getbannerbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L136"
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getbannertextclass",
-      "label": "getBannerTextClass()",
-      "norm_label": "getbannertextclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L119"
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_gethoverclass",
-      "label": "getHoverClass()",
-      "norm_label": "gethoverclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L76"
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getmainwrapperclass",
-      "label": "getMainWrapperClass()",
-      "norm_label": "getmainwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L28"
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getnavbaranimationdelay",
-      "label": "getNavBarAnimationDelay()",
-      "norm_label": "getnavbaranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L174"
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getnavbarwrapperclass",
-      "label": "getNavBarWrapperClass()",
-      "norm_label": "getnavbarwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L163"
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getnavbgclass",
-      "label": "getNavBGClass()",
-      "norm_label": "getnavbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L43"
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getoverlayclass",
-      "label": "getOverlayClass()",
-      "norm_label": "getoverlayclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L184"
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "navbarstyles_getsubmenubgclass",
-      "label": "getSubmenuBGClass()",
-      "norm_label": "getsubmenubgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L93"
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
-      "label": "navBarStyles.ts",
-      "norm_label": "navbarstyles.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
     },
     {
@@ -70038,92 +70296,101 @@
     {
       "community": 51,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
-      "label": "resultTypes.ts",
-      "norm_label": "resulttypes.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L1"
+      "id": "navbarstyles_getbanneranimationdelay",
+      "label": "getBannerAnimationDelay()",
+      "norm_label": "getbanneranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L152"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "id": "navbarstyles_getbannerbgclass",
+      "label": "getBannerBGClass()",
+      "norm_label": "getbannerbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "navbarstyles_getbannertextclass",
+      "label": "getBannerTextClass()",
+      "norm_label": "getbannertextclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "navbarstyles_gethoverclass",
+      "label": "getHoverClass()",
+      "norm_label": "gethoverclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "navbarstyles_getmainwrapperclass",
+      "label": "getMainWrapperClass()",
+      "norm_label": "getmainwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L28"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_expenseitemsuccess",
-      "label": "expenseItemSuccess()",
-      "norm_label": "expenseitemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L276"
+      "id": "navbarstyles_getnavbaranimationdelay",
+      "label": "getNavBarAnimationDelay()",
+      "norm_label": "getnavbaranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L174"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_expensesessionsuccess",
-      "label": "expenseSessionSuccess()",
-      "norm_label": "expensesessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L286"
+      "id": "navbarstyles_getnavbarwrapperclass",
+      "label": "getNavBarWrapperClass()",
+      "norm_label": "getnavbarwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L163"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_iserror",
-      "label": "isError()",
-      "norm_label": "iserror()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L176"
+      "id": "navbarstyles_getnavbgclass",
+      "label": "getNavBGClass()",
+      "norm_label": "getnavbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L43"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_issuccess",
-      "label": "isSuccess()",
-      "norm_label": "issuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L167"
+      "id": "navbarstyles_getoverlayclass",
+      "label": "getOverlayClass()",
+      "norm_label": "getoverlayclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L184"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_itemsuccess",
-      "label": "itemSuccess()",
-      "norm_label": "itemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L140"
+      "id": "navbarstyles_getsubmenubgclass",
+      "label": "getSubmenuBGClass()",
+      "norm_label": "getsubmenubgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L93"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "resulttypes_operationsuccess",
-      "label": "operationSuccess()",
-      "norm_label": "operationsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "resulttypes_sessionsuccess",
-      "label": "sessionSuccess()",
-      "norm_label": "sessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "resulttypes_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L21"
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
+      "label": "navBarStyles.ts",
+      "norm_label": "navbarstyles.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L1"
     },
     {
       "community": 510,
@@ -70308,92 +70575,92 @@
     {
       "community": 52,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
-      "label": "sessionValidation.ts",
-      "norm_label": "sessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
+      "label": "resultTypes.ts",
+      "norm_label": "resulttypes.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L1"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "sessionvalidation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L303"
+      "id": "resulttypes_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L28"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "sessionvalidation_validatecartitems",
-      "label": "validateCartItems()",
-      "norm_label": "validatecartitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L191"
+      "id": "resulttypes_expenseitemsuccess",
+      "label": "expenseItemSuccess()",
+      "norm_label": "expenseitemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L276"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "sessionvalidation_validatecustomerinfo",
-      "label": "validateCustomerInfo()",
-      "norm_label": "validatecustomerinfo()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L275"
+      "id": "resulttypes_expensesessionsuccess",
+      "label": "expenseSessionSuccess()",
+      "norm_label": "expensesessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L286"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "sessionvalidation_validateitembelongstosession",
-      "label": "validateItemBelongsToSession()",
-      "norm_label": "validateitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L248"
+      "id": "resulttypes_iserror",
+      "label": "isError()",
+      "norm_label": "iserror()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L176"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "sessionvalidation_validatepaymentdetails",
-      "label": "validatePaymentDetails()",
-      "norm_label": "validatepaymentdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L311"
+      "id": "resulttypes_issuccess",
+      "label": "isSuccess()",
+      "norm_label": "issuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L167"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "sessionvalidation_validatesessionactive",
-      "label": "validateSessionActive()",
-      "norm_label": "validatesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionexists",
-      "label": "validateSessionExists()",
-      "norm_label": "validatesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionmodifiable",
-      "label": "validateSessionModifiable()",
-      "norm_label": "validatesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionownership",
-      "label": "validateSessionOwnership()",
-      "norm_label": "validatesessionownership()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "id": "resulttypes_itemsuccess",
+      "label": "itemSuccess()",
+      "norm_label": "itemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L140"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "resulttypes_operationsuccess",
+      "label": "operationSuccess()",
+      "norm_label": "operationsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "resulttypes_sessionsuccess",
+      "label": "sessionSuccess()",
+      "norm_label": "sessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "resulttypes_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L21"
     },
     {
       "community": 520,
@@ -70578,92 +70845,92 @@
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
-      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
-      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L120"
+      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
+      "label": "sessionValidation.ts",
+      "norm_label": "sessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L1"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
-      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
-      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L29"
+      "id": "sessionvalidation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L303"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
-      "label": "consumePaymentMethodCorrectionApprovalProof()",
-      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L166"
+      "id": "sessionvalidation_validatecartitems",
+      "label": "validateCartItems()",
+      "norm_label": "validatecartitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L191"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_correcttransactioncustomer",
-      "label": "correctTransactionCustomer()",
-      "norm_label": "correcttransactioncustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L197"
+      "id": "sessionvalidation_validatecustomerinfo",
+      "label": "validateCustomerInfo()",
+      "norm_label": "validatecustomerinfo()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L275"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_correcttransactionpaymentmethod",
-      "label": "correctTransactionPaymentMethod()",
-      "norm_label": "correcttransactionpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L259"
+      "id": "sessionvalidation_validateitembelongstosession",
+      "label": "validateItemBelongsToSession()",
+      "norm_label": "validateitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L248"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_getpaymentmethodcashcontribution",
-      "label": "getPaymentMethodCashContribution()",
-      "norm_label": "getpaymentmethodcashcontribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L85"
+      "id": "sessionvalidation_validatepaymentdetails",
+      "label": "validatePaymentDetails()",
+      "norm_label": "validatepaymentdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L311"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L68"
+      "id": "sessionvalidation_validatesessionactive",
+      "label": "validateSessionActive()",
+      "norm_label": "validatesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L39"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
-      "label": "requireRegisterSessionAllowsPaymentCorrection()",
-      "norm_label": "requireregistersessionallowspaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "sessionvalidation_validatesessionexists",
+      "label": "validateSessionExists()",
+      "norm_label": "validatesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 53,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionmodifiable",
+      "label": "validateSessionModifiable()",
+      "norm_label": "validatesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L95"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "correcttransaction_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 53,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
-      "label": "correctTransaction.ts",
-      "norm_label": "correcttransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L1"
+      "id": "sessionvalidation_validatesessionownership",
+      "label": "validateSessionOwnership()",
+      "norm_label": "validatesessionownership()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L140"
     },
     {
       "community": 530,
@@ -72481,7 +72748,7 @@
       "label": "applyCloseoutCommandResult()",
       "norm_label": "applycloseoutcommandresult()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L504"
+      "source_location": "L505"
     },
     {
       "community": 6,
@@ -72490,7 +72757,7 @@
       "label": "applyCommandResult()",
       "norm_label": "applycommandresult()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L494"
+      "source_location": "L495"
     },
     {
       "community": 6,
@@ -72499,7 +72766,7 @@
       "label": "buildDepositSubmissionKey()",
       "norm_label": "builddepositsubmissionkey()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L272"
+      "source_location": "L273"
     },
     {
       "community": 6,
@@ -72508,7 +72775,7 @@
       "label": "errorMessage()",
       "norm_label": "errormessage()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2040"
+      "source_location": "L2054"
     },
     {
       "community": 6,
@@ -72517,7 +72784,7 @@
       "label": "formatCurrency()",
       "norm_label": "formatcurrency()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L276"
+      "source_location": "L277"
     },
     {
       "community": 6,
@@ -72526,7 +72793,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L325"
+      "source_location": "L326"
     },
     {
       "community": 6,
@@ -72535,7 +72802,7 @@
       "label": "formatRegisterHeaderName()",
       "norm_label": "formatregisterheadername()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L338"
+      "source_location": "L339"
     },
     {
       "community": 6,
@@ -72544,7 +72811,7 @@
       "label": "formatRegisterName()",
       "norm_label": "formatregistername()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L333"
+      "source_location": "L334"
     },
     {
       "community": 6,
@@ -72553,7 +72820,7 @@
       "label": "formatSessionCode()",
       "norm_label": "formatsessioncode()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L352"
+      "source_location": "L353"
     },
     {
       "community": 6,
@@ -72562,7 +72829,7 @@
       "label": "formatStatusLabel()",
       "norm_label": "formatstatuslabel()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L295"
+      "source_location": "L296"
     },
     {
       "community": 6,
@@ -72571,7 +72838,7 @@
       "label": "formatStoredAmountForInput()",
       "norm_label": "formatstoredamountforinput()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L284"
+      "source_location": "L285"
     },
     {
       "community": 6,
@@ -72580,7 +72847,7 @@
       "label": "formatTimestamp()",
       "norm_label": "formattimestamp()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L288"
+      "source_location": "L289"
     },
     {
       "community": 6,
@@ -72589,7 +72856,7 @@
       "label": "getNumericEventMetadata()",
       "norm_label": "getnumericeventmetadata()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L310"
+      "source_location": "L311"
     },
     {
       "community": 6,
@@ -72598,7 +72865,7 @@
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L364"
+      "source_location": "L365"
     },
     {
       "community": 6,
@@ -72607,7 +72874,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L356"
+      "source_location": "L357"
     },
     {
       "community": 6,
@@ -72616,7 +72883,7 @@
       "label": "handleAuthenticatedCloseoutStaff()",
       "norm_label": "handleauthenticatedcloseoutstaff()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L658"
+      "source_location": "L659"
     },
     {
       "community": 6,
@@ -72625,7 +72892,7 @@
       "label": "handleOpeningFloatApprovalApproved()",
       "norm_label": "handleopeningfloatapprovalapproved()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L754"
+      "source_location": "L755"
     },
     {
       "community": 6,
@@ -72634,7 +72901,7 @@
       "label": "handleRecordDeposit()",
       "norm_label": "handlerecorddeposit()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L516"
+      "source_location": "L517"
     },
     {
       "community": 6,
@@ -72643,7 +72910,7 @@
       "label": "handleReviewCloseout()",
       "norm_label": "handlereviewcloseout()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L585"
+      "source_location": "L586"
     },
     {
       "community": 6,
@@ -72652,7 +72919,7 @@
       "label": "handleSubmitCloseout()",
       "norm_label": "handlesubmitcloseout()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L559"
+      "source_location": "L560"
     },
     {
       "community": 6,
@@ -72661,7 +72928,7 @@
       "label": "handleSubmitOpeningFloatCorrection()",
       "norm_label": "handlesubmitopeningfloatcorrection()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L602"
+      "source_location": "L603"
     },
     {
       "community": 6,
@@ -72670,7 +72937,7 @@
       "label": "isCloseoutRejectionEvent()",
       "norm_label": "iscloseoutrejectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L299"
+      "source_location": "L300"
     },
     {
       "community": 6,
@@ -72679,7 +72946,7 @@
       "label": "isOpeningFloatCorrectionEvent()",
       "norm_label": "isopeningfloatcorrectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L303"
+      "source_location": "L304"
     },
     {
       "community": 6,
@@ -72688,7 +72955,7 @@
       "label": "isRegisterSessionCorrectionEvent()",
       "norm_label": "isregistersessioncorrectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L319"
+      "source_location": "L320"
     },
     {
       "community": 6,
@@ -72697,7 +72964,7 @@
       "label": "runOpeningFloatCorrection()",
       "norm_label": "runopeningfloatcorrection()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L708"
+      "source_location": "L709"
     },
     {
       "community": 6,
@@ -72706,7 +72973,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L267"
+      "source_location": "L268"
     },
     {
       "community": 60,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1546
-- Graph nodes: 4108
-- Graph edges: 3720
+- Graph nodes: 4115
+- Graph edges: 3737
 - Communities: 1474
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (11 edges, Community 43) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 272) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `deleteKeysIndividually()` (3 edges, Community 43) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (3 edges, Community 43) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (3 edges, Community 43) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (11 edges, Community 44) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (3 edges, Community 273) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `deleteKeysIndividually()` (3 edges, Community 44) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (3 edges, Community 44) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (3 edges, Community 44) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/operations/approvalRequests.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.ts
@@ -2,6 +2,7 @@ import { internalMutation, mutation, type MutationCtx } from "../_generated/serv
 import type { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
 import { resolveStockAdjustmentApprovalDecisionWithCtx } from "../stockOps/adjustments";
+import { resolvePaymentMethodCorrectionApprovalDecisionWithCtx } from "../pos/application/commands/correctTransaction";
 import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
@@ -61,6 +62,13 @@ export async function decideApprovalRequestWithCtx(
     approvalRequest.subjectType === "stock_adjustment_batch"
   ) {
     await resolveStockAdjustmentApprovalDecisionWithCtx(ctx, args);
+  }
+
+  if (
+    approvalRequest.requestType === "payment_method_correction" &&
+    approvalRequest.subjectType === "pos_transaction"
+  ) {
+    await resolvePaymentMethodCorrectionApprovalDecisionWithCtx(ctx, args);
   }
 
   await ctx.db.patch("approvalRequest", args.approvalRequestId, {
@@ -134,7 +142,9 @@ function mapDecideApprovalRequestError(
 
   if (
     message === "Inventory adjustment approval request not found." ||
-    message === "Stock adjustment batch not found for this approval request."
+    message === "Stock adjustment batch not found for this approval request." ||
+    message === "Payment method approval request not found." ||
+    message === "Transaction not found."
   ) {
     return userError({
       code: "not_found",
@@ -144,7 +154,12 @@ function mapDecideApprovalRequestError(
 
   if (
     message === "Approval request has already been decided." ||
-    message === "Stock adjustment batch has already been resolved."
+    message === "Stock adjustment batch has already been resolved." ||
+    message === "Payment method approval request is missing correction details." ||
+    message === "Payment method approval request does not match this store." ||
+    message === "Only single-payment transactions can be corrected." ||
+    message === "Only same-amount payment method corrections are supported." ||
+    message === "Payment allocation must be a same-amount single payment."
   ) {
     return userError({
       code: "precondition_failed",

--- a/packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts
@@ -1,6 +1,7 @@
 import type { Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import type { ApprovalRequirement } from "../../../../shared/approvalPolicy";
+import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
 import { consumeApprovalProofWithCtx } from "../../../operations/approvalProofs";
 import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
 import { correctSameAmountSinglePaymentAllocationWithCtx } from "../../../operations/paymentAllocations";
@@ -16,6 +17,7 @@ type CorrectionActor = {
 
 const PAYMENT_METHOD_CORRECTION_ACTION_KEY =
   "pos.transaction.correct_payment_method";
+const PAYMENT_METHOD_CORRECTION_REQUEST_TYPE = "payment_method_correction";
 
 type PaymentMethodCorrectionApprovalProof = {
   approvalProofId: Id<"approvalProof">;
@@ -27,6 +29,7 @@ function transactionLabel(transaction: { transactionNumber: string }) {
 }
 
 function buildPaymentMethodCorrectionApprovalRequirement(args: {
+  approvalRequestId?: Id<"approvalRequest">;
   amount: number;
   paymentMethod: string;
   previousPaymentMethod: string;
@@ -52,17 +55,92 @@ function buildPaymentMethodCorrectionApprovalRequirement(args: {
     copy: {
       title: "Manager approval required",
       message:
-        "Authorization is needed from a manager to update this completed transaction payment method.",
-      primaryActionLabel: "Approve update",
-      secondaryActionLabel: "Cancel",
+        "A manager needs to review this completed transaction payment method update before it is applied.",
+      primaryActionLabel: "Request approval",
+      secondaryActionLabel: "Got it",
     },
-    resolutionModes: [{ kind: "inline_manager_proof" }],
+    resolutionModes: [
+      {
+        kind: "async_request",
+        requestType: PAYMENT_METHOD_CORRECTION_REQUEST_TYPE,
+        approvalRequestId: args.approvalRequestId,
+      },
+    ],
     metadata: {
       amount: args.amount,
       paymentMethod: args.paymentMethod,
       previousPaymentMethod: args.previousPaymentMethod,
     },
   };
+}
+
+async function createPaymentMethodCorrectionApprovalRequest(
+  ctx: MutationCtx,
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    amount: number;
+    paymentMethod: string;
+    previousPaymentMethod: string;
+    reason?: string;
+    transaction: {
+      _id: Id<"posTransaction">;
+      registerSessionId?: Id<"registerSession">;
+      storeId: Id<"store">;
+      transactionNumber: string;
+    };
+  },
+) {
+  const store = await ctx.db.get("store", args.transaction.storeId);
+  const approvalRequestId = await ctx.db.insert(
+    "approvalRequest",
+    buildApprovalRequest({
+      metadata: {
+        actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+        amount: args.amount,
+        paymentMethod: args.paymentMethod,
+        previousPaymentMethod: args.previousPaymentMethod,
+        transactionId: args.transaction._id,
+      },
+      notes: args.reason,
+      organizationId: store?.organizationId,
+      reason:
+        "Manager approval is required to correct a completed transaction payment method.",
+      registerSessionId: args.transaction.registerSessionId,
+      requestType: PAYMENT_METHOD_CORRECTION_REQUEST_TYPE,
+      requestedByStaffProfileId: args.actorStaffProfileId,
+      requestedByUserId: args.actorUserId,
+      storeId: args.transaction.storeId,
+      subjectId: args.transaction._id,
+      subjectType: "pos_transaction",
+    }),
+  );
+
+  await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    approvalRequestId,
+    eventType: "pos_transaction_payment_method_approval_requested",
+    message: `Payment method correction requested for ${transactionLabel(args.transaction)}.`,
+    metadata: {
+      actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+      approvalMode: "async_approval",
+      approvalRequestId,
+      amount: args.amount,
+      paymentMethod: args.paymentMethod,
+      previousPaymentMethod: args.previousPaymentMethod,
+      requiredRole: "manager",
+    },
+    reason: args.reason,
+    registerSessionId: args.transaction.registerSessionId,
+    storeId: args.transaction.storeId,
+    subjectId: args.transaction._id,
+    subjectLabel: transactionLabel(args.transaction),
+    subjectType: "pos_transaction",
+    posTransactionId: args.transaction._id,
+  });
+
+  return approvalRequestId;
 }
 
 async function requireCompletedTransaction(
@@ -194,6 +272,98 @@ async function consumePaymentMethodCorrectionApprovalProof(
   };
 }
 
+async function applyPaymentMethodCorrection(
+  ctx: MutationCtx,
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    approvalOperationalEventId?: Id<"operationalEvent">;
+    approvalProofId?: Id<"approvalProof">;
+    approvalRequestId?: Id<"approvalRequest">;
+    approverStaffProfileId?: Id<"staffProfile">;
+    paymentMethod: string;
+    reason?: string;
+    transaction: Awaited<ReturnType<typeof requireCompletedTransaction>>;
+  },
+) {
+  const [payment] = args.transaction.payments;
+  const correctedAllocation =
+    await correctSameAmountSinglePaymentAllocationWithCtx(ctx, {
+      storeId: args.transaction.storeId,
+      targetType: "pos_transaction",
+      targetId: args.transaction._id,
+      amount: payment.amount,
+      method: args.paymentMethod,
+    });
+
+  if (!correctedAllocation) {
+    throw new Error("Payment allocation must be a same-amount single payment.");
+  }
+
+  await patchPosTransaction(ctx, args.transaction._id, {
+    paymentMethod: args.paymentMethod,
+    payments: [
+      {
+        ...payment,
+        method: args.paymentMethod,
+      },
+    ],
+  });
+  const registerSessionExpectedCashDelta =
+    await adjustRegisterSessionExpectedCashForPaymentCorrection(ctx, {
+      nextPayment: {
+        amount: payment.amount,
+        method: args.paymentMethod,
+      },
+      previousPayment: payment,
+      registerSessionId: args.transaction.registerSessionId,
+      storeId: args.transaction.storeId,
+    });
+
+  const event = await recordOperationalEventWithCtx(ctx, {
+    storeId: args.transaction.storeId,
+    eventType: "pos_transaction_payment_method_corrected",
+    subjectType: "pos_transaction",
+    subjectId: args.transaction._id,
+    subjectLabel: transactionLabel(args.transaction),
+    message: `Corrected payment method for ${transactionLabel(args.transaction)}.`,
+    approvalRequestId: args.approvalRequestId,
+    reason: args.reason,
+    metadata: {
+      correctionType: "payment_method",
+      actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+      approvalProofId: args.approvalProofId,
+      approvalRequestId: args.approvalRequestId,
+      approvalOperationalEventId: args.approvalOperationalEventId,
+      approverStaffProfileId: args.approverStaffProfileId,
+      previousPaymentMethod: payment.method,
+      paymentMethod: args.paymentMethod,
+      requesterStaffProfileId: args.actorStaffProfileId,
+      amount: payment.amount,
+      registerSessionExpectedCashDelta,
+      representation: "patch_single_same_amount_payment_and_allocation",
+    },
+    actorUserId: args.actorUserId,
+    actorStaffProfileId: args.actorStaffProfileId,
+    customerProfileId: args.transaction.customerProfileId,
+    paymentAllocationId: correctedAllocation._id,
+    registerSessionId: args.transaction.registerSessionId,
+    posTransactionId: args.transaction._id,
+  });
+
+  return {
+    transactionId: args.transaction._id,
+    previousPaymentMethod: payment.method,
+    paymentMethod: args.paymentMethod,
+    approvalProofId: args.approvalProofId,
+    approvalRequestId: args.approvalRequestId,
+    approvalOperationalEventId: args.approvalOperationalEventId,
+    approverStaffProfileId: args.approverStaffProfileId,
+    paymentAllocationId: correctedAllocation._id,
+    operationalEventId: event?._id,
+  };
+}
+
 export async function correctTransactionCustomer(
   ctx: MutationCtx,
   args: {
@@ -290,9 +460,21 @@ export async function correctTransactionPaymentMethod(
   });
 
   if (!args.approvalProofId) {
+    const approvalRequestId =
+      await createPaymentMethodCorrectionApprovalRequest(ctx, {
+        actorStaffProfileId: args.actorStaffProfileId,
+        actorUserId: args.actorUserId,
+        amount: payment.amount,
+        paymentMethod: args.paymentMethod,
+        previousPaymentMethod: payment.method,
+        reason: args.reason,
+        transaction,
+      });
+
     return {
       action: "approval_required" as const,
       approval: buildPaymentMethodCorrectionApprovalRequirement({
+        approvalRequestId,
         amount: payment.amount,
         paymentMethod: args.paymentMethod,
         previousPaymentMethod: payment.method,
@@ -310,39 +492,6 @@ export async function correctTransactionPaymentMethod(
     storeId: transaction.storeId,
     transactionId: args.transactionId,
   });
-
-  const correctedAllocation =
-    await correctSameAmountSinglePaymentAllocationWithCtx(ctx, {
-      storeId: transaction.storeId,
-      targetType: "pos_transaction",
-      targetId: args.transactionId,
-      amount: payment.amount,
-      method: args.paymentMethod,
-    });
-
-  if (!correctedAllocation) {
-    throw new Error("Payment allocation must be a same-amount single payment.");
-  }
-
-  await patchPosTransaction(ctx, args.transactionId, {
-    paymentMethod: args.paymentMethod,
-    payments: [
-      {
-        ...payment,
-        method: args.paymentMethod,
-      },
-    ],
-  });
-  const registerSessionExpectedCashDelta =
-    await adjustRegisterSessionExpectedCashForPaymentCorrection(ctx, {
-      nextPayment: {
-        amount: payment.amount,
-        method: args.paymentMethod,
-      },
-      previousPayment: payment,
-      registerSessionId: transaction.registerSessionId,
-      storeId: transaction.storeId,
-    });
 
   const approvalEvent = await recordOperationalEventWithCtx(ctx, {
     storeId: transaction.storeId,
@@ -368,43 +517,135 @@ export async function correctTransactionPaymentMethod(
     posTransactionId: args.transactionId,
   });
 
-  const event = await recordOperationalEventWithCtx(ctx, {
-    storeId: transaction.storeId,
-    eventType: "pos_transaction_payment_method_corrected",
-    subjectType: "pos_transaction",
-    subjectId: args.transactionId,
-    subjectLabel: transactionLabel(transaction),
-    message: `Corrected payment method for ${transactionLabel(transaction)}.`,
-    reason: args.reason,
-    metadata: {
-      correctionType: "payment_method",
-      actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
-      approvalProofId: approvalProof.approvalProofId,
-      approvalOperationalEventId: approvalEvent?._id,
-      approverStaffProfileId: approvalProof.approvedByStaffProfileId,
-      previousPaymentMethod: payment.method,
-      paymentMethod: args.paymentMethod,
-      requesterStaffProfileId: args.actorStaffProfileId,
-      amount: payment.amount,
-      registerSessionExpectedCashDelta,
-      representation: "patch_single_same_amount_payment_and_allocation",
-    },
-    actorUserId: args.actorUserId,
+  return applyPaymentMethodCorrection(ctx, {
     actorStaffProfileId: args.actorStaffProfileId,
-    customerProfileId: transaction.customerProfileId,
-    paymentAllocationId: correctedAllocation._id,
+    actorUserId: args.actorUserId,
+    approvalOperationalEventId: approvalEvent?._id,
+    approvalProofId: approvalProof.approvalProofId,
+    approverStaffProfileId: approvalProof.approvedByStaffProfileId,
+    paymentMethod: args.paymentMethod,
+    reason: args.reason,
+    transaction,
+  });
+}
+
+function getStringMetadata(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+export async function resolvePaymentMethodCorrectionApprovalDecisionWithCtx(
+  ctx: MutationCtx,
+  args: {
+    approvalRequestId: Id<"approvalRequest">;
+    decision: "approved" | "rejected" | "cancelled";
+    reviewedByStaffProfileId?: Id<"staffProfile">;
+    reviewedByUserId?: Id<"athenaUser">;
+    decisionNotes?: string;
+  },
+) {
+  const approvalRequest = await ctx.db.get(
+    "approvalRequest",
+    args.approvalRequestId,
+  );
+
+  if (
+    !approvalRequest ||
+    approvalRequest.requestType !== PAYMENT_METHOD_CORRECTION_REQUEST_TYPE ||
+    approvalRequest.subjectType !== "pos_transaction"
+  ) {
+    throw new Error("Payment method approval request not found.");
+  }
+
+  const transactionId = approvalRequest.subjectId as Id<"posTransaction">;
+
+  if (args.decision !== "approved") {
+    await recordOperationalEventWithCtx(ctx, {
+      actorStaffProfileId: args.reviewedByStaffProfileId,
+      actorUserId: args.reviewedByUserId,
+      approvalRequestId: args.approvalRequestId,
+      eventType: "pos_transaction_payment_method_approval_rejected",
+      message: `Payment method correction ${args.decision} for Transaction ${transactionId}.`,
+      metadata: {
+        actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+        approvalRequestId: args.approvalRequestId,
+        decision: args.decision,
+      },
+      reason: args.decisionNotes,
+      storeId: approvalRequest.storeId,
+      subjectId: transactionId,
+      subjectType: "pos_transaction",
+      posTransactionId: transactionId,
+    });
+    return null;
+  }
+
+  const paymentMethod = getStringMetadata(
+    approvalRequest.metadata,
+    "paymentMethod",
+  );
+
+  if (!paymentMethod) {
+    throw new Error("Payment method approval request is missing correction details.");
+  }
+
+  const transaction = await requireCompletedTransaction(ctx, transactionId);
+
+  if (transaction.storeId !== approvalRequest.storeId) {
+    throw new Error("Payment method approval request does not match this store.");
+  }
+
+  if (transaction.payments.length !== 1) {
+    throw new Error("Only single-payment transactions can be corrected.");
+  }
+
+  const [payment] = transaction.payments;
+  if (
+    payment.amount !== transaction.totalPaid ||
+    payment.amount !== transaction.total
+  ) {
+    throw new Error(
+      "Only same-amount payment method corrections are supported.",
+    );
+  }
+
+  await requireRegisterSessionAllowsPaymentCorrection(ctx, {
     registerSessionId: transaction.registerSessionId,
-    posTransactionId: args.transactionId,
+    storeId: transaction.storeId,
   });
 
-  return {
-    transactionId: args.transactionId,
-    previousPaymentMethod: payment.method,
-    paymentMethod: args.paymentMethod,
-    approvalProofId: approvalProof.approvalProofId,
+  const approvalEvent = await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.reviewedByStaffProfileId,
+    actorUserId: args.reviewedByUserId,
+    approvalRequestId: args.approvalRequestId,
+    eventType: "pos_transaction_payment_method_approval_request_approved",
+    message: `Manager approved payment method correction for ${transactionLabel(transaction)}.`,
+    metadata: {
+      actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+      approvalRequestId: args.approvalRequestId,
+      paymentMethod,
+      previousPaymentMethod: payment.method,
+    },
+    reason: args.decisionNotes,
+    registerSessionId: transaction.registerSessionId,
+    storeId: transaction.storeId,
+    subjectId: transaction._id,
+    subjectLabel: transactionLabel(transaction),
+    subjectType: "pos_transaction",
+    posTransactionId: transaction._id,
+  });
+
+  return applyPaymentMethodCorrection(ctx, {
+    actorStaffProfileId: approvalRequest.requestedByStaffProfileId,
+    actorUserId: approvalRequest.requestedByUserId,
     approvalOperationalEventId: approvalEvent?._id,
-    approverStaffProfileId: approvalProof.approvedByStaffProfileId,
-    paymentAllocationId: correctedAllocation._id,
-    operationalEventId: event?._id,
-  };
+    approvalRequestId: args.approvalRequestId,
+    approverStaffProfileId: args.reviewedByStaffProfileId,
+    paymentMethod,
+    reason: approvalRequest.notes ?? approvalRequest.reason,
+    transaction,
+  });
 }

--- a/packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts
+++ b/packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Id } from "../../_generated/dataModel";
-import { correctTransactionPaymentMethod } from "./commands/correctTransaction";
+import {
+  correctTransactionPaymentMethod,
+  resolvePaymentMethodCorrectionApprovalDecisionWithCtx,
+} from "./commands/correctTransaction";
 import { consumeApprovalProofWithCtx } from "../../operations/approvalProofs";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 import { correctSameAmountSinglePaymentAllocationWithCtx } from "../../operations/paymentAllocations";
@@ -36,13 +39,22 @@ describe("correctTransactionPaymentMethod", () => {
     return {
       db: {
         get: vi.fn(),
+        insert: vi.fn(),
         patch: vi.fn(),
       },
       runMutation: vi.fn(),
     };
   }
 
-  it("returns an inline manager approval requirement before mutating", async () => {
+  it("creates an async manager approval request before mutating", async () => {
+    const ctx = createMutationCtx();
+    vi.mocked(ctx.db.get).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(ctx.db.insert).mockResolvedValue(
+      "approval-1" as Id<"approvalRequest">,
+    );
     vi.mocked(getPosTransactionById).mockResolvedValue({
       _id: "txn-1" as Id<"posTransaction">,
       storeId: "store-1" as Id<"store">,
@@ -54,7 +66,11 @@ describe("correctTransactionPaymentMethod", () => {
       payments: [{ method: "cash", amount: 1000, timestamp: 1 }],
     } as never);
 
-    const result = await correctTransactionPaymentMethod({} as never, {
+    vi.mocked(recordOperationalEventWithCtx).mockResolvedValue({
+      _id: "request-event-1" as Id<"operationalEvent">,
+    } as never);
+
+    const result = await correctTransactionPaymentMethod(ctx as never, {
       actorStaffProfileId: "cashier-1" as Id<"staffProfile">,
       transactionId: "txn-1" as Id<"posTransaction">,
       paymentMethod: "card",
@@ -72,14 +88,43 @@ describe("correctTransactionPaymentMethod", () => {
           id: "txn-1",
           type: "pos_transaction",
         },
+        resolutionModes: [
+          {
+            kind: "async_request",
+            requestType: "payment_method_correction",
+            approvalRequestId: "approval-1",
+          },
+        ],
       },
       previousPaymentMethod: "cash",
       paymentMethod: "card",
       transactionId: "txn-1",
     });
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "approvalRequest",
+      expect.objectContaining({
+        organizationId: "org-1",
+        requestType: "payment_method_correction",
+        requestedByStaffProfileId: "cashier-1",
+        status: "pending",
+        subjectId: "txn-1",
+        subjectType: "pos_transaction",
+        metadata: expect.objectContaining({
+          actionKey: "pos.transaction.correct_payment_method",
+          paymentMethod: "card",
+          previousPaymentMethod: "cash",
+        }),
+      }),
+    );
     expect(correctSameAmountSinglePaymentAllocationWithCtx).not.toHaveBeenCalled();
     expect(patchPosTransaction).not.toHaveBeenCalled();
-    expect(recordOperationalEventWithCtx).not.toHaveBeenCalled();
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        approvalRequestId: "approval-1",
+        eventType: "pos_transaction_payment_method_approval_requested",
+      }),
+    );
   });
 
   it("patches the single same-amount payment and matching allocation after consuming a matching proof", async () => {
@@ -174,6 +219,88 @@ describe("correctTransactionPaymentMethod", () => {
         approverStaffProfileId: "manager-1",
         paymentAllocationId: "allocation-1",
         operationalEventId: "event-1",
+      }),
+    );
+  });
+
+  it("applies the queued payment correction when the async request is approved", async () => {
+    const ctx = createMutationCtx();
+    vi.mocked(ctx.db.get).mockResolvedValue({
+      _id: "approval-1",
+      requestType: "payment_method_correction",
+      subjectType: "pos_transaction",
+      subjectId: "txn-1",
+      storeId: "store-1",
+      requestedByStaffProfileId: "cashier-1",
+      notes: "Till entry correction",
+      metadata: {
+        paymentMethod: "card",
+      },
+    } as never);
+    vi.mocked(getPosTransactionById).mockResolvedValue({
+      _id: "txn-1" as Id<"posTransaction">,
+      storeId: "store-1" as Id<"store">,
+      transactionNumber: "POS-111111",
+      status: "completed",
+      total: 1000,
+      totalPaid: 1000,
+      paymentMethod: "cash",
+      payments: [{ method: "cash", amount: 1000, timestamp: 1 }],
+    } as never);
+    vi.mocked(correctSameAmountSinglePaymentAllocationWithCtx).mockResolvedValue({
+      _id: "allocation-1" as Id<"paymentAllocation">,
+    } as never);
+    vi.mocked(recordOperationalEventWithCtx)
+      .mockResolvedValueOnce({
+        _id: "approval-event-1" as Id<"operationalEvent">,
+      } as never)
+      .mockResolvedValueOnce({
+        _id: "event-1" as Id<"operationalEvent">,
+      } as never);
+
+    const result = await resolvePaymentMethodCorrectionApprovalDecisionWithCtx(
+      ctx as never,
+      {
+        approvalRequestId: "approval-1" as Id<"approvalRequest">,
+        decision: "approved",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+      },
+    );
+
+    expect(correctSameAmountSinglePaymentAllocationWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      {
+        storeId: "store-1",
+        targetType: "pos_transaction",
+        targetId: "txn-1",
+        amount: 1000,
+        method: "card",
+      },
+    );
+    expect(patchPosTransaction).toHaveBeenCalledWith(ctx as never, "txn-1", {
+      paymentMethod: "card",
+      payments: [{ method: "card", amount: 1000, timestamp: 1 }],
+    });
+    expect(recordOperationalEventWithCtx).toHaveBeenNthCalledWith(
+      2,
+      ctx as never,
+      expect.objectContaining({
+        approvalRequestId: "approval-1",
+        eventType: "pos_transaction_payment_method_corrected",
+        metadata: expect.objectContaining({
+          approvalRequestId: "approval-1",
+          approvalOperationalEventId: "approval-event-1",
+          approverStaffProfileId: "manager-1",
+          paymentMethod: "card",
+          previousPaymentMethod: "cash",
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        approvalRequestId: "approval-1",
+        paymentMethod: "card",
+        previousPaymentMethod: "cash",
       }),
     );
   });

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
@@ -351,14 +351,6 @@ describe("CashControlsDashboardContent", () => {
     expect(screen.getAllByText("$5").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Recent deposits").length).toBeGreaterThan(0);
     expect(screen.queryByText("Review closeouts")).not.toBeInTheDocument();
-    expect(screen.getByText("Cashroom workflow")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Move drawers from live cash to reviewed closeout, with exceptions surfaced only when action is needed.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Ready for action")).toBeInTheDocument();
-    expect(screen.getAllByText("1 drawer").length).toBeGreaterThan(0);
     expect(screen.getByText("Needs action")).toBeInTheDocument();
     expect(screen.getByText("Live drawers")).toBeInTheDocument();
     expect(screen.getByText("Closed sessions")).toBeInTheDocument();
@@ -574,15 +566,13 @@ describe("CashControlsDashboardContent", () => {
     expect(
       screen.queryByText("Register 2 is ready for review or deposit entry."),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getAllByText("No live drawers are open right now.").length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByText("No drawers in cashroom flow")).toBeInTheDocument();
     expect(screen.queryByText("Needs action")).not.toBeInTheDocument();
     expect(screen.queryByText("Live drawers")).not.toBeInTheDocument();
     expect(
       screen.queryByText("No drawer needs closeout or variance review."),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("No open sessions")).toBeInTheDocument();
+    expect(screen.getByText("Closed sessions")).toBeInTheDocument();
   });
 
   it("links register session cards to the session route", () => {

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -201,7 +201,7 @@ function CashPositionSummary({
     },
     {
       label: "Deposited today",
-      supporting: `${snapshot.recentDeposits.length} recent drop${snapshot.recentDeposits.length === 1 ? "" : "s"}`,
+      supporting: `${snapshot.recentDeposits.length == 0 ? "No" : snapshot.recentDeposits.length} recent drop${snapshot.recentDeposits.length === 1 ? "" : "s"}`,
       value: formatCurrency(currency, depositedTotal),
     },
     {
@@ -519,7 +519,7 @@ function DrawerSessionCard({
       >
         <div>
           <dt className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-            Expected
+            Expected cash
           </dt>
           <dd className="mt-1 font-mono text-sm text-foreground">
             {formatCurrency(currency, session.expectedCash)}
@@ -610,7 +610,7 @@ function DrawerSessionLane({
           {emptyDescription}
         </div>
       ) : (
-        <div className="space-y-layout-sm">
+        <div className="space-y-layout-2xl">
           {sessions.map((session) => (
             <DrawerSessionCard
               currency={currency}
@@ -828,34 +828,7 @@ function CashroomWorkflow({
       : undefined;
 
   return (
-    <section className="space-y-layout-md rounded-lg border border-border bg-surface p-layout-lg shadow-surface">
-      <div className="flex flex-col gap-layout-md xl:flex-row xl:items-end xl:justify-between">
-        <div className="space-y-layout-2xs">
-          <h2 className="font-display text-2xl font-semibold tracking-tight text-foreground">
-            Cashroom workflow
-          </h2>
-          <p className="max-w-3xl text-sm text-muted-foreground">
-            Move drawers from live cash to reviewed closeout, with exceptions
-            surfaced only when action is needed.
-          </p>
-        </div>
-        <div className="grid gap-layout-xs sm:grid-cols-3 xl:min-w-[520px]">
-          <WorkflowSummaryItem
-            label="Ready for action"
-            value={`${needsAttention.length} drawer${needsAttention.length === 1 ? "" : "s"}`}
-          />
-          <WorkflowSummaryItem
-            label="Still in drawers"
-            value={formatCurrency(currency, onHandTotal)}
-          />
-          <WorkflowSummaryItem
-            label="Variance exposure"
-            tone={unresolvedVarianceTotal > 0 ? "text-danger" : undefined}
-            value={formatCurrency(currency, unresolvedVarianceTotal)}
-          />
-        </div>
-      </div>
-
+    <section className="space-y-layout-2xl">
       {sessions.length === 0 ? (
         <div className="rounded-lg border border-dashed border-border bg-surface-raised px-layout-lg py-layout-xl">
           <EmptyState
@@ -883,7 +856,7 @@ function CashroomWorkflow({
               variant="primary"
             />
           ) : null}
-          <div className="space-y-layout-lg">
+          <div className="space-y-layout-3xl">
             {hasNeedsAttention ? (
               <DrawerSessionLane
                 currency={currency}
@@ -1036,7 +1009,7 @@ export function CashControlsDashboardContent({
       }
     >
       <FadeIn className="container mx-auto py-layout-xl">
-        <div className="space-y-layout-xl">
+        <div className="space-y-layout-3xl">
           <section className="space-y-layout-md">
             <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-end lg:justify-between">
               <div className="space-y-layout-2xs">
@@ -1058,11 +1031,11 @@ export function CashControlsDashboardContent({
             />
           </section>
 
-          <WorkflowJumpPoints
+          {/* <WorkflowJumpPoints
             dashboardSnapshot={dashboardSnapshot}
             orgUrlSlug={orgUrlSlug}
             storeUrlSlug={storeUrlSlug}
-          />
+          /> */}
 
           {isLoading ? (
             <section className="rounded-lg border border-border bg-surface-raised p-layout-lg text-sm text-muted-foreground shadow-surface">
@@ -1134,14 +1107,12 @@ export function CashControlsDashboard() {
 
   if (!activeStore || !params?.orgUrlSlug || !params.storeUrlSlug) {
     return (
-      <View>
-        <div className="container mx-auto py-8">
-          <EmptyState
-            description="Select a store before opening the cash-controls workspace."
-            title="No active store"
-          />
-        </div>
-      </View>
+      <div className="container mx-auto py-8">
+        <EmptyState
+          description="Select a store before opening the cash-controls workspace."
+          title="No active store"
+        />
+      </div>
     );
   }
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery } from "convex/react";
 import {
   ArrowUpRight,
   Banknote,
+  ChevronDown,
   CreditCard,
   Receipt,
   Smartphone,
@@ -888,10 +889,6 @@ export function RegisterSessionViewContent({
     !hasOpeningFloatCorrectionHistory
       ? "Review the rejected closeout, then recount or correct the drawer."
       : "Correct the starting cash amount without changing linked sales.";
-  const shouldShowOpeningFloatBadge =
-    isOpeningFloatCorrectionOpen ||
-    Boolean(openingFloatCorrectionSuccess) ||
-    hasOpeningFloatCorrectionHistory;
   const correctionHistoryLabel = hasCloseoutRejectionHistory
     ? "Closeout history"
     : "Correction history";
@@ -1282,31 +1279,41 @@ export function RegisterSessionViewContent({
                   ) : null}
                 </aside>
 
-                <div className="space-y-layout-lg px-layout-lg py-layout-lg">
+                <div className="flex flex-col gap-layout-lg px-layout-lg py-layout-lg">
                   {pendingCloseoutApprovalPanel}
 
                   {shouldShowProminentCorrectionPanel ? (
-                    <section className="space-y-4 rounded-lg border border-border bg-surface-raised p-layout-md">
+                    <section
+                      className={
+                        isOpeningFloatCorrectionOpen ||
+                        openingFloatCorrectionSuccess
+                          ? "order-3 space-y-4 rounded-lg border border-border bg-surface-raised p-layout-md"
+                          : "order-3 space-y-3 rounded-lg border border-border bg-muted/20 px-layout-md py-3"
+                      }
+                    >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="space-y-1">
-                          <h2 className="font-display text-xl font-semibold text-foreground">
+                          <h2
+                            className={
+                              isOpeningFloatCorrectionOpen ||
+                              openingFloatCorrectionSuccess
+                                ? "font-display text-xl font-semibold text-foreground"
+                                : "font-display text-base font-semibold text-foreground"
+                            }
+                          >
                             {openingFloatCorrectionCardTitle}
                           </h2>
-                          <p className="text-sm text-muted-foreground">
+                          <p
+                            className={
+                              isOpeningFloatCorrectionOpen ||
+                              openingFloatCorrectionSuccess
+                                ? "text-sm text-muted-foreground"
+                                : "text-xs text-muted-foreground"
+                            }
+                          >
                             {openingFloatCorrectionCardDescription}
                           </p>
                         </div>
-                        {shouldShowOpeningFloatBadge ? (
-                          <Badge
-                            className="border-border bg-muted text-muted-foreground"
-                            variant="outline"
-                          >
-                            {formatCurrency(
-                              currency,
-                              registerSession.openingFloat,
-                            )}
-                          </Badge>
-                        ) : null}
                       </div>
 
                       {isOpeningFloatCorrectionOpen ? (
@@ -1438,11 +1445,18 @@ export function RegisterSessionViewContent({
                       ) : null}
 
                       {correctionTimeline.length > 0 ? (
-                        <div className="space-y-2 border-t border-border/70 pt-4">
-                          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                            {correctionHistoryLabel}
-                          </p>
-                          <div className="space-y-3">
+                        <details className="group border-t border-border/70 pt-3">
+                          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 rounded-md py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+                            <span>{correctionHistoryLabel}</span>
+                            <span className="inline-flex items-center gap-2">
+                              {correctionTimeline.length}{" "}
+                              {correctionTimeline.length === 1
+                                ? "entry"
+                                : "entries"}
+                              <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+                            </span>
+                          </summary>
+                          <div className="space-y-3 pt-3">
                             {correctionTimeline.map((event) => {
                               const previousOpeningFloat =
                                 getNumericEventMetadata(
@@ -1531,13 +1545,13 @@ export function RegisterSessionViewContent({
                               );
                             })}
                           </div>
-                        </div>
+                        </details>
                       ) : null}
                     </section>
                   ) : null}
 
                   <div
-                    className={`flex flex-wrap items-start justify-between gap-layout-sm ${hasPendingCloseoutApproval ? "pt-4" : ""}`}
+                    className={`order-2 flex flex-wrap items-start justify-between gap-layout-sm ${hasPendingCloseoutApproval ? "pt-4" : ""}`}
                   >
                     <div className="space-y-1">
                       <h2 className="font-display text-2xl font-semibold text-foreground">
@@ -1557,7 +1571,7 @@ export function RegisterSessionViewContent({
                   </div>
 
                   {transactions.length === 0 ? (
-                    <div className="flex min-h-[260px] items-center justify-center rounded-lg border border-dashed border-border bg-muted/25">
+                    <div className="order-2 flex min-h-[260px] items-center justify-center rounded-lg border border-dashed border-border bg-muted/25">
                       <EmptyState
                         icon={
                           <Receipt className="h-12 w-12 text-muted-foreground" />
@@ -1567,7 +1581,7 @@ export function RegisterSessionViewContent({
                       />
                     </div>
                   ) : (
-                    <div className="overflow-hidden rounded-lg border border-border bg-surface-raised">
+                    <div className="order-2 overflow-hidden rounded-lg border border-border bg-surface-raised">
                       <Table>
                         <TableHeader>
                           <TableRow className="border-b border-border hover:bg-transparent">

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
@@ -281,7 +281,9 @@ describe("CommandApprovalDialog", () => {
         "Manager review is required before this closeout can finish.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/approval request approval-1/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/approval request approval-1/i),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Got it" }));

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
@@ -121,13 +121,6 @@ export function CommandApprovalDialog({
             <DialogDescription>{approval.copy.message}</DialogDescription>
           </div>
 
-          {asyncResolution?.approvalRequestId ? (
-            <p className="rounded-md border border-border bg-surface p-layout-sm text-sm text-muted-foreground">
-              Approval request {asyncResolution.approvalRequestId} is pending in
-              the review queue.
-            </p>
-          ) : null}
-
           <div className="flex justify-end">
             <Button type="button" variant="utility" onClick={onDismiss}>
               {approval.copy.secondaryActionLabel ?? "Got it"}

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -43,6 +43,32 @@ type QueueApprovalRequest = {
   workItemTitle?: string | null;
 };
 
+function getApprovalRequestCopy(requestType: string) {
+  if (requestType === "inventory_adjustment_review") {
+    return {
+      approveLabel: "Approve batch",
+      approvedToast: "Stock adjustment approved",
+      description:
+        "Manager approval applies the queued inventory movement. Reject it to keep stock unchanged.",
+      rejectedToast: "Stock adjustment rejected",
+      rejectLabel: "Reject batch",
+    };
+  }
+
+  if (requestType === "payment_method_correction") {
+    return {
+      approveLabel: "Approve update",
+      approvedToast: "Payment method update approved",
+      description:
+        "Manager approval applies the queued payment method update. Reject it to leave the completed transaction unchanged.",
+      rejectedToast: "Payment method update rejected",
+      rejectLabel: "Reject update",
+    };
+  }
+
+  return null;
+}
+
 type OperationsQueueViewContentProps = {
   approvalRequests: QueueApprovalRequest[];
   hasFullAdminAccess: boolean;
@@ -185,63 +211,74 @@ export function OperationsQueueViewContent({
                 title="No pending approvals"
               />
             ) : (
-              approvalRequests.map((request) => (
-                <article className="rounded-xl border border-border/80 p-3" key={request._id}>
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <p className="font-medium">
-                        {request.workItemTitle ?? request.requestType}
-                      </p>
-                      <p className="text-sm text-muted-foreground">
-                        {request.requestedByStaffName ?? "Requested by admin flow"}
-                      </p>
-                    </div>
-                    <p className="text-xs uppercase text-muted-foreground">
-                      {request.status}
-                    </p>
-                  </div>
-                  {request.requestType === "inventory_adjustment_review" ? (
-                    <div className="mt-3 space-y-3 rounded-xl border border-amber-200/80 bg-amber-50/70 px-3 py-3">
-                      <p className="text-sm text-amber-950">
-                        Manager approval applies the queued inventory movement. Reject
-                        it to keep stock unchanged.
-                      </p>
-                      <div className="flex flex-wrap gap-2">
-                        <LoadingButton
-                          className="bg-amber-500 text-amber-950 hover:bg-amber-500/90"
-                          disabled={Boolean(
-                            isDecidingApprovalRequestId &&
-                              isDecidingApprovalRequestId !== request._id
-                          )}
-                          isLoading={isDecidingApprovalRequestId === request._id}
-                          onClick={() =>
-                            onDecideApprovalRequest({
-                              approvalRequestId: request._id,
-                              decision: "approved",
-                            })
-                          }
-                          size="sm"
-                        >
-                          Approve batch
-                        </LoadingButton>
-                        <Button
-                          disabled={Boolean(isDecidingApprovalRequestId)}
-                          onClick={() =>
-                            onDecideApprovalRequest({
-                              approvalRequestId: request._id,
-                              decision: "rejected",
-                            })
-                          }
-                          size="sm"
-                          variant="outline"
-                        >
-                          Reject batch
-                        </Button>
+              approvalRequests.map((request) => {
+                const approvalCopy = getApprovalRequestCopy(
+                  request.requestType
+                );
+
+                return (
+                  <article
+                    className="rounded-xl border border-border/80 p-3"
+                    key={request._id}
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <p className="font-medium">
+                          {request.workItemTitle ?? request.requestType}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {request.requestedByStaffName ??
+                            "Requested by admin flow"}
+                        </p>
                       </div>
+                      <p className="text-xs uppercase text-muted-foreground">
+                        {request.status}
+                      </p>
                     </div>
-                  ) : null}
-                </article>
-              ))
+                    {approvalCopy ? (
+                      <div className="mt-3 space-y-3 rounded-xl border border-amber-200/80 bg-amber-50/70 px-3 py-3">
+                        <p className="text-sm text-amber-950">
+                          {approvalCopy.description}
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          <LoadingButton
+                            className="bg-amber-500 text-amber-950 hover:bg-amber-500/90"
+                            disabled={Boolean(
+                              isDecidingApprovalRequestId &&
+                                isDecidingApprovalRequestId !== request._id
+                            )}
+                            isLoading={
+                              isDecidingApprovalRequestId === request._id
+                            }
+                            onClick={() =>
+                              onDecideApprovalRequest({
+                                approvalRequestId: request._id,
+                                decision: "approved",
+                              })
+                            }
+                            size="sm"
+                          >
+                            {approvalCopy.approveLabel}
+                          </LoadingButton>
+                          <Button
+                            disabled={Boolean(isDecidingApprovalRequestId)}
+                            onClick={() =>
+                              onDecideApprovalRequest({
+                                approvalRequestId: request._id,
+                                decision: "rejected",
+                              })
+                            }
+                            size="sm"
+                            variant="outline"
+                          >
+                            {approvalCopy.rejectLabel}
+                          </Button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </article>
+                );
+              })
             )}
           </section>
         </div>
@@ -311,10 +348,17 @@ export function OperationsQueueView() {
         return;
       }
 
+      const request = queue?.approvalRequests.find(
+        (approvalRequest) => approvalRequest._id === args.approvalRequestId
+      );
+      const approvalCopy = request
+        ? getApprovalRequestCopy(request.requestType)
+        : null;
+
       toast.success(
         args.decision === "approved"
-          ? "Stock adjustment approved"
-          : "Stock adjustment rejected"
+          ? (approvalCopy?.approvedToast ?? "Approval request approved")
+          : (approvalCopy?.rejectedToast ?? "Approval request rejected")
       );
     } finally {
       setDecisioningApprovalRequestId(null);

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -134,7 +134,10 @@ vi.mock("../../staff-auth/StaffAuthenticationDialog", () => ({
       username: string;
     }) => Promise<unknown>;
     onAuthenticated: (result: {
+      activeRoles?: string[];
       approvalProofId?: string;
+      approvedByStaffProfileId?: string;
+      expiresAt?: number;
       staffProfile: { firstName: string; lastName: string };
       staffProfileId: string;
     }) => void;
@@ -146,15 +149,19 @@ vi.mock("../../staff-auth/StaffAuthenticationDialog", () => ({
         <p>{copy.description}</p>
         <button
           onClick={async () => {
-            await onAuthenticate({
+            const result = await onAuthenticate({
               pinHash: "123456",
               username: "manager",
             });
-            onAuthenticated({
-              approvalProofId: "proof-1",
-              staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
-              staffProfileId: "staff_1",
-            });
+            if (
+              result &&
+              typeof result === "object" &&
+              "kind" in result &&
+              result.kind === "ok" &&
+              "data" in result
+            ) {
+              onAuthenticated(result.data as never);
+            }
           }}
           type="button"
         >
@@ -176,6 +183,11 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
       copy: { message: string; primaryActionLabel?: string; title: string };
       reason: string;
       requiredRole: "manager";
+      resolutionModes: Array<{
+        kind: string;
+        approvalRequestId?: string;
+        requestType?: string;
+      }>;
       subject: { id: string; label?: string; type: string };
     } | null;
     onAuthenticateForApproval: (args: {
@@ -205,30 +217,42 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
       <div data-testid="command-approval-dialog">
         <h2>{approval.copy.title}</h2>
         <p>{approval.copy.message}</p>
-        <button
-          onClick={async () => {
-            const result = await onAuthenticateForApproval({
-              actionKey: approval.action.key,
-              pinHash: "123456",
-              reason: approval.reason,
-              requiredRole: approval.requiredRole,
-              storeId: "store_1",
-              subject: approval.subject,
-              username: "manager",
-            });
-
-            if (result.kind === "ok" && result.data) {
-              onApproved({
-                approvalProofId: result.data.approvalProofId,
-                approvedByStaffProfileId: result.data.approvedByStaffProfileId,
-                expiresAt: result.data.expiresAt,
+        {approval.resolutionModes.some(
+          (mode) => mode.kind === "inline_manager_proof",
+        ) ? (
+          <button
+            onClick={async () => {
+              const result = await onAuthenticateForApproval({
+                actionKey: approval.action.key,
+                pinHash: "123456",
+                reason: approval.reason,
+                requiredRole: approval.requiredRole,
+                storeId: "store_1",
+                subject: approval.subject,
+                username: "manager",
               });
-            }
-          }}
-          type="button"
-        >
-          {approval.copy.primaryActionLabel ?? "Approve update"}
-        </button>
+
+              if (result.kind === "ok" && result.data) {
+                onApproved({
+                  approvalProofId: result.data.approvalProofId,
+                  approvedByStaffProfileId: result.data.approvedByStaffProfileId,
+                  expiresAt: result.data.expiresAt,
+                });
+              }
+            }}
+            type="button"
+          >
+            {approval.copy.primaryActionLabel ?? "Approve update"}
+          </button>
+        ) : (
+          <p>
+            Approval request{" "}
+            {approval.resolutionModes.find(
+              (mode) => mode.kind === "async_request",
+            )?.approvalRequestId ?? "approval-1"}{" "}
+            is pending in the review queue.
+          </p>
+        )}
       </div>
     ) : null,
 }));
@@ -672,9 +696,16 @@ describe("TransactionView", () => {
     expect(paymentMethodSelect).toHaveTextContent("Mobile Money");
   });
 
-  it("communicates manager approval before authenticating payment corrections", async () => {
+  it("queues async manager approval for payment corrections", async () => {
     const user = userEvent.setup();
-    const authMutation = vi.fn().mockResolvedValue({ kind: "ok" });
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["cashier"],
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
     const approvalMutation = vi.fn().mockResolvedValue({
       kind: "ok",
       data: {
@@ -691,13 +722,19 @@ describe("TransactionView", () => {
         copy: {
           title: "Manager approval required",
           message:
-            "Enter manager credentials to update this completed transaction payment method.",
-          primaryActionLabel: "Approve update",
+            "A manager needs to review this completed transaction payment method update before it is applied.",
+          primaryActionLabel: "Request approval",
         },
         reason:
           "Manager approval is required to correct a completed transaction payment method.",
         requiredRole: "manager",
-        resolutionModes: [{ kind: "inline_manager_proof" }],
+        resolutionModes: [
+          {
+            kind: "async_request",
+            requestType: "payment_method_correction",
+            approvalRequestId: "approval-1",
+          },
+        ],
         subject: {
           id: "txn_13",
           label: "Transaction #754489",
@@ -729,20 +766,30 @@ describe("TransactionView", () => {
     await user.click(
       screen.getByRole("button", { name: "Submit payment update" }),
     );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
 
     expect(
       await screen.findByText("Manager approval required"),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Enter manager credentials to update this completed transaction payment method.",
+        "A manager needs to review this completed transaction payment method update before it is applied.",
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Approve update" }),
+      screen.getByText(
+        "Approval request approval-1 is pending in the review queue.",
+      ),
     ).toBeInTheDocument();
+    expect(approvalMutation).not.toHaveBeenCalled();
+    expect(authMutation).toHaveBeenCalledWith({
+      allowedRoles: ["cashier", "manager"],
+      pinHash: "123456",
+      storeId: "store_1",
+      username: "manager",
+    });
     expect(paymentMutation).toHaveBeenCalledWith({
-      actorStaffProfileId: undefined,
+      actorStaffProfileId: "staff_1",
       approvalProofId: undefined,
       paymentMethod: "card",
       reason: "Wrong tender selected.",
@@ -750,9 +797,89 @@ describe("TransactionView", () => {
     });
   });
 
-  it("exits the correction workflow after a payment correction succeeds", async () => {
+  it("chains inline manager approval when the requester is a manager", async () => {
     const user = userEvent.setup();
-    const authMutation = vi.fn().mockResolvedValue({ kind: "ok" });
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["manager"],
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const approvalMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        approvalProofId: "proof-1",
+        approvedByStaffProfileId: "staff_1",
+        expiresAt: 2,
+      },
+    });
+    const customerMutation = vi.fn();
+    const paymentMutation = vi.fn().mockResolvedValue({ kind: "ok" });
+    mockTransactionMutations(
+      authMutation,
+      customerMutation,
+      paymentMutation,
+      approvalMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_19" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Update" }));
+    await user.click(screen.getByRole("button", { name: "Payment method" }));
+    await user.selectOptions(
+      screen.getByLabelText("Updated payment method"),
+      "card",
+    );
+    await user.type(
+      screen.getByLabelText("Payment method update reason"),
+      "Wrong tender selected.",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Submit payment update" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(approvalMutation).toHaveBeenCalledWith({
+        actionKey: "pos.transaction.correct_payment_method",
+        pinHash: "123456",
+        reason:
+          "Manager approval is required to correct a completed transaction payment method.",
+        requiredRole: "manager",
+        requestedByStaffProfileId: "staff_1",
+        storeId: "store_1",
+        subject: {
+          id: "txn_19",
+          label: "Transaction #POS-123456",
+          type: "pos_transaction",
+        },
+        username: "manager",
+      });
+      expect(paymentMutation).toHaveBeenCalledWith({
+        actorStaffProfileId: "staff_1",
+        approvalProofId: "proof-1",
+        paymentMethod: "card",
+        reason: "Wrong tender selected.",
+        transactionId: "txn_19",
+      });
+    });
+    expect(screen.queryByText("Manager approval required")).not.toBeInTheDocument();
+  });
+
+  it("exits the correction workflow after an async payment correction request is queued", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["cashier"],
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
     const approvalMutation = vi.fn().mockResolvedValue({
       kind: "ok",
       data: {
@@ -771,21 +898,26 @@ describe("TransactionView", () => {
           copy: {
             title: "Manager approval required",
             message:
-              "Enter manager credentials to update this completed transaction payment method.",
-            primaryActionLabel: "Approve update",
+              "A manager needs to review this completed transaction payment method update before it is applied.",
+            primaryActionLabel: "Request approval",
           },
           reason:
             "Manager approval is required to correct a completed transaction payment method.",
           requiredRole: "manager",
-          resolutionModes: [{ kind: "inline_manager_proof" }],
+          resolutionModes: [
+            {
+              kind: "async_request",
+              requestType: "payment_method_correction",
+              approvalRequestId: "approval-1",
+            },
+          ],
           subject: {
             id: "txn_11",
             label: "Transaction #754489",
             type: "pos_transaction",
           },
         },
-      })
-      .mockResolvedValueOnce({ kind: "ok" });
+      });
     mockTransactionMutations(
       authMutation,
       customerMutation,
@@ -810,35 +942,16 @@ describe("TransactionView", () => {
     await user.click(
       screen.getByRole("button", { name: "Submit payment update" }),
     );
-    await screen.findByRole("button", { name: "Approve update" });
-    await user.click(screen.getByRole("button", { name: "Approve update" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await screen.findByText(
+      "Approval request approval-1 is pending in the review queue.",
+    );
 
     await waitFor(() => {
-      expect(approvalMutation).toHaveBeenCalledWith({
-        actionKey: "pos.transaction.correct_payment_method",
-        pinHash: "123456",
-        reason:
-          "Manager approval is required to correct a completed transaction payment method.",
-        requiredRole: "manager",
-        requestedByStaffProfileId: undefined,
-        storeId: "store_1",
-        subject: {
-          id: "txn_11",
-          label: "Transaction #754489",
-          type: "pos_transaction",
-        },
-        username: "manager",
-      });
+      expect(approvalMutation).not.toHaveBeenCalled();
       expect(paymentMutation).toHaveBeenNthCalledWith(1, {
-        actorStaffProfileId: undefined,
+        actorStaffProfileId: "staff_1",
         approvalProofId: undefined,
-        paymentMethod: "card",
-        reason: "Wrong tender selected.",
-        transactionId: "txn_11",
-      });
-      expect(paymentMutation).toHaveBeenNthCalledWith(2, {
-        actorStaffProfileId: undefined,
-        approvalProofId: "proof-1",
         paymentMethod: "card",
         reason: "Wrong tender selected.",
         transactionId: "txn_11",

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -80,6 +80,11 @@ type PaymentMethodCorrectionResultData = {
   approverStaffProfileId: Id<"staffProfile">;
 };
 
+const PAYMENT_METHOD_CORRECTION_ACTION_KEY =
+  "pos.transaction.correct_payment_method";
+const PAYMENT_METHOD_CORRECTION_APPROVAL_REASON =
+  "Manager approval is required to correct a completed transaction payment method.";
+
 const PAYMENT_METHOD_OPTIONS = [
   { label: "Cash", value: "cash" },
   { label: "Card", value: "card" },
@@ -121,6 +126,16 @@ function formatPaymentMethodLabel(method: unknown) {
   return method
     .replaceAll("_", " ")
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function requiresInlineManagerProof(approval: ApprovalRequirement) {
+  return approval.resolutionModes.some(
+    (mode) => mode.kind === "inline_manager_proof",
+  );
+}
+
+function isManagerStaff(staff: StaffAuthenticationResult) {
+  return staff.activeRoles?.includes("manager") ?? false;
 }
 
 function formatCorrectionHistoryChange(event: CorrectionEvent) {
@@ -352,10 +367,7 @@ export function TransactionView() {
 
     return runCommand(() =>
       correctAuth({
-        allowedRoles:
-          args.correction === "payment_method"
-            ? ["manager"]
-            : ["cashier", "manager"],
+        allowedRoles: ["cashier", "manager"],
         pinHash: args.pinHash,
         storeId: activeStore._id,
         username: args.username,
@@ -449,6 +461,14 @@ export function TransactionView() {
 
     if (isApprovalRequiredResult(result)) {
       setPendingPaymentApproval(result.approval);
+      if (!requiresInlineManagerProof(result.approval)) {
+        setPaymentCorrectionReason("");
+        setPaymentMethodInput("");
+        setCorrectionPanelOpen(false);
+        setSelectedCorrection(null);
+        setPendingCorrection(null);
+        setCorrectionError(null);
+      }
       return;
     }
 
@@ -488,7 +508,7 @@ export function TransactionView() {
     }
 
     if (kind === "payment_method") {
-      void runPaymentMethodCorrection();
+      setPendingCorrection(kind);
       return;
     }
 
@@ -529,6 +549,47 @@ export function TransactionView() {
             correction: pendingCorrection,
             pinHash: args.pinHash,
             username: args.username,
+          }).then(async (staffResult) => {
+            if (
+              pendingCorrection !== "payment_method" ||
+              staffResult.kind !== "ok" ||
+              !isManagerStaff(staffResult.data)
+            ) {
+              return staffResult;
+            }
+
+            const approvalResult = await runCommand(
+              () =>
+                approveCommand({
+                  actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+                  pinHash: args.pinHash,
+                  reason: PAYMENT_METHOD_CORRECTION_APPROVAL_REASON,
+                  requiredRole: "manager",
+                  requestedByStaffProfileId: staffResult.data.staffProfileId,
+                  storeId: activeStore!._id,
+                  subject: {
+                    id: transactionId as Id<"posTransaction">,
+                    label: `Transaction #${transaction.transactionNumber}`,
+                    type: "pos_transaction",
+                  },
+                  username: args.username,
+                }) as Promise<CommandResult<CommandApprovalProofResult>>,
+            );
+
+            if (approvalResult.kind !== "ok") {
+              return approvalResult;
+            }
+
+            return {
+              kind: "ok" as const,
+              data: {
+                ...staffResult.data,
+                approvalProofId: approvalResult.data.approvalProofId,
+                approvedByStaffProfileId:
+                  approvalResult.data.approvedByStaffProfileId,
+                expiresAt: approvalResult.data.expiresAt,
+              },
+            };
           })
         }
         onAuthenticated={(result) => {
@@ -537,9 +598,18 @@ export function TransactionView() {
           if (correction === "customer") {
             void runCustomerCorrection(result);
           }
+          if (correction === "payment_method") {
+            void runPaymentMethodCorrection({
+              approvalProofId: result.approvalProofId,
+              staffProfileId: result.staffProfileId,
+            });
+          }
         }}
         onDismiss={() => setPendingCorrection(null)}
-        open={pendingCorrection === "customer"}
+        open={
+          pendingCorrection === "customer" ||
+          pendingCorrection === "payment_method"
+        }
       />
       <CommandApprovalDialog
         approval={pendingPaymentApproval}

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -23,6 +23,10 @@ import {
 export type StaffAuthMode = "authenticate" | "recover";
 
 export type StaffAuthenticationResult = {
+  activeRoles?: string[];
+  approvalProofId?: Id<"approvalProof">;
+  approvedByStaffProfileId?: Id<"staffProfile">;
+  expiresAt?: number;
   staffProfile: {
     firstName?: string | null;
     fullName?: string | null;

--- a/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
@@ -24,6 +24,42 @@ vi.mock("~/src/lib/security/pinHash", () => ({
   hashPin: vi.fn(async (pin: string) => `hashed:${pin}`),
 }));
 
+vi.mock("../ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children?: React.ReactNode;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  }) => (
+    <select
+      aria-label="Role"
+      onChange={(event) => onValueChange?.(event.target.value)}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children?: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <option value="">{placeholder}</option>
+  ),
+}));
+
 vi.mock("../pos/PinInput", () => ({
   PinInput: ({
     disabled,
@@ -128,8 +164,11 @@ async function chooseRole(
   user: ReturnType<typeof userEvent.setup>,
   role: RegExp,
 ) {
-  await user.click(screen.getByRole("combobox", { name: /role/i }));
-  await user.click(await screen.findByRole("option", { name: role }));
+  const roleOption = screen.getByRole("option", { name: role });
+  await user.selectOptions(
+    screen.getByRole("combobox", { name: /role/i }),
+    roleOption,
+  );
 }
 
 describe("StaffManagement", () => {


### PR DESCRIPTION
## Summary
- make linked transactions primary on register-session cash controls and collapse opening-float correction history by default
- route completed-transaction payment method corrections through staff authentication and async manager approval
- allow manager requesters to authenticate once and approve inline in the correction flow
- stabilize the staff-management test harness select interaction that was crashing the full webapp suite

## Validation
- bun run --filter '@athena/webapp' test
- bunx vitest run --shard=2/4 --silent=passed-only --maxWorkers=1 --minWorkers=1 --logHeapUsage
- bun run graphify:rebuild
- git push pre-push validation suite