### PR TITLE
[V26-432] Quiet Athena webapp test harness output

### DIFF
--- a/docs/solutions/harness/expected-console-output-in-tests-2026-05-02.md
+++ b/docs/solutions/harness/expected-console-output-in-tests-2026-05-02.md
@@ -1,0 +1,42 @@
+---
+title: Expected Console Output in Tests Must Be Asserted and Suppressed
+date: 2026-05-02
+category: harness
+module: athena-webapp
+problem_type: noisy_test_output
+component: vitest
+symptoms:
+  - "negative-path tests pass but print expected warnings or errors"
+  - "useful harness failures are hard to spot in noisy package output"
+  - "debug console.log calls leak from app code into routine test runs"
+root_cause: unscoped_expected_console_output
+resolution_type: test_harness_cleanup
+severity: low
+tags:
+  - harness
+  - vitest
+  - console-output
+  - webapp
+---
+
+# Expected Console Output in Tests Must Be Asserted and Suppressed
+
+## Problem
+
+Expected failure-path tests often exercise code that logs warnings or errors. When those logs are left unsuppressed, the package test suite can pass while still looking broken. That makes real harness failures harder to notice and weakens the signal from pre-push output.
+
+Debug-only `console.log` calls in core app paths create the same problem. They do not describe expected behavior and should not ship in code covered by routine package tests.
+
+## Solution
+
+For expected warnings or errors, spy on the matching console method inside the specific test, replace its implementation with a no-op, and assert the exact log shape that proves the expected path ran. Keep the spy scoped to that test or restore it before the test exits.
+
+Do not add broad suite-level console suppression. Broad suppression can hide unexpected failures or interfere with module-level `vi.fn()` mocks that late cleanup work still depends on.
+
+Remove debug `console.log` calls from production or test-covered runtime paths unless the log is intentional product instrumentation.
+
+## Prevention
+
+- Treat visible stderr/stdout during `bun run --filter '@athena/webapp' test` as a harness issue unless it is an actual failing assertion.
+- For negative-path tests, pair every expected `console.warn` or `console.error` with a local spy and an assertion.
+- Prefer focused console spies over global `vi.restoreAllMocks()` in files with shared command mocks and async unmount cleanup.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -8531,7 +8531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L145",
+      "source_location": "L149",
       "target": "expensesessions_test_buildsession",
       "weight": 1
     },
@@ -8543,7 +8543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L35",
+      "source_location": "L39",
       "target": "expensesessions_test_createmutationctx",
       "weight": 1
     },
@@ -8555,7 +8555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L160",
+      "source_location": "L164",
       "target": "expensesessions_test_gethandler",
       "weight": 1
     },
@@ -8975,7 +8975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L303",
+      "source_location": "L301",
       "target": "sessionvalidation_isvalidemail",
       "weight": 1
     },
@@ -8987,7 +8987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L191",
+      "source_location": "L189",
       "target": "sessionvalidation_validatecartitems",
       "weight": 1
     },
@@ -8999,7 +8999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L275",
+      "source_location": "L273",
       "target": "sessionvalidation_validatecustomerinfo",
       "weight": 1
     },
@@ -9011,7 +9011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L248",
+      "source_location": "L246",
       "target": "sessionvalidation_validateitembelongstosession",
       "weight": 1
     },
@@ -9023,7 +9023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L311",
+      "source_location": "L309",
       "target": "sessionvalidation_validatepaymentdetails",
       "weight": 1
     },
@@ -9059,7 +9059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L95",
+      "source_location": "L93",
       "target": "sessionvalidation_validatesessionmodifiable",
       "weight": 1
     },
@@ -9071,7 +9071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L140",
+      "source_location": "L138",
       "target": "sessionvalidation_validatesessionownership",
       "weight": 1
     },
@@ -13643,7 +13643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2348",
+      "source_location": "L2359",
       "target": "sessioncommands_test_builditem",
       "weight": 1
     },
@@ -13655,7 +13655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2342",
+      "source_location": "L2353",
       "target": "sessioncommands_test_buildregistersession",
       "weight": 1
     },
@@ -13667,7 +13667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2338",
+      "source_location": "L2349",
       "target": "sessioncommands_test_buildsession",
       "weight": 1
     },
@@ -13679,7 +13679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2358",
+      "source_location": "L2369",
       "target": "sessioncommands_test_createcommandservice",
       "weight": 1
     },
@@ -13691,7 +13691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2104",
+      "source_location": "L2115",
       "target": "sessioncommands_test_createdependencies",
       "weight": 1
     },
@@ -13703,7 +13703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2194",
+      "source_location": "L2205",
       "target": "sessioncommands_test_createfakerepository",
       "weight": 1
     },
@@ -13715,7 +13715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2086",
+      "source_location": "L2097",
       "target": "sessioncommands_test_loadcommandservice",
       "weight": 1
     },
@@ -42191,7 +42191,7 @@
       "relation": "calls",
       "source": "sessionvalidation_validatecustomerinfo",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L290",
+      "source_location": "L288",
       "target": "sessionvalidation_isvalidemail",
       "weight": 1
     },
@@ -57475,7 +57475,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L145"
+      "source_location": "L149"
     },
     {
       "community": 204,
@@ -57484,7 +57484,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L35"
+      "source_location": "L39"
     },
     {
       "community": 204,
@@ -57493,7 +57493,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L160"
+      "source_location": "L164"
     },
     {
       "community": 204,
@@ -70858,7 +70858,7 @@
       "label": "isValidEmail()",
       "norm_label": "isvalidemail()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L303"
+      "source_location": "L301"
     },
     {
       "community": 53,
@@ -70867,7 +70867,7 @@
       "label": "validateCartItems()",
       "norm_label": "validatecartitems()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L191"
+      "source_location": "L189"
     },
     {
       "community": 53,
@@ -70876,7 +70876,7 @@
       "label": "validateCustomerInfo()",
       "norm_label": "validatecustomerinfo()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L275"
+      "source_location": "L273"
     },
     {
       "community": 53,
@@ -70885,7 +70885,7 @@
       "label": "validateItemBelongsToSession()",
       "norm_label": "validateitembelongstosession()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L248"
+      "source_location": "L246"
     },
     {
       "community": 53,
@@ -70894,7 +70894,7 @@
       "label": "validatePaymentDetails()",
       "norm_label": "validatepaymentdetails()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L311"
+      "source_location": "L309"
     },
     {
       "community": 53,
@@ -70921,7 +70921,7 @@
       "label": "validateSessionModifiable()",
       "norm_label": "validatesessionmodifiable()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L95"
+      "source_location": "L93"
     },
     {
       "community": 53,
@@ -70930,7 +70930,7 @@
       "label": "validateSessionOwnership()",
       "norm_label": "validatesessionownership()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L140"
+      "source_location": "L138"
     },
     {
       "community": 530,
@@ -78112,7 +78112,7 @@
       "label": "buildItem()",
       "norm_label": "builditem()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2348"
+      "source_location": "L2359"
     },
     {
       "community": 79,
@@ -78121,7 +78121,7 @@
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2342"
+      "source_location": "L2353"
     },
     {
       "community": 79,
@@ -78130,7 +78130,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2338"
+      "source_location": "L2349"
     },
     {
       "community": 79,
@@ -78139,7 +78139,7 @@
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2358"
+      "source_location": "L2369"
     },
     {
       "community": 79,
@@ -78148,7 +78148,7 @@
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2104"
+      "source_location": "L2115"
     },
     {
       "community": 79,
@@ -78157,7 +78157,7 @@
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2194"
+      "source_location": "L2205"
     },
     {
       "community": 79,
@@ -78166,7 +78166,7 @@
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2086"
+      "source_location": "L2097"
     },
     {
       "community": 790,

--- a/packages/athena-webapp/convex/inventory/expenseSessions.test.ts
+++ b/packages/athena-webapp/convex/inventory/expenseSessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ok } from "../../shared/commandResult";
 
 const mocks = vi.hoisted(() => ({
@@ -16,6 +16,10 @@ import {
   releaseExpenseSessionInventoryHoldsAndDeleteItems,
   updateExpenseSession,
 } from "./expenseSessions";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 type SessionRecord = {
   _id: string;
@@ -262,6 +266,7 @@ describe("expense session command results", () => {
   });
 
   it("treats stale completed session note updates as a no-op for the owning staff member", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const ctx = createMutationCtx({
       sessions: [
         buildSession({
@@ -287,6 +292,9 @@ describe("expense session command results", () => {
       },
     });
     expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Attempted to update completed expense session expense-session-1. Ignoring update.",
+    );
   });
 
   it("returns a user_error when clearing holds for a missing expense session", async () => {

--- a/packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts
+++ b/packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts
@@ -44,8 +44,6 @@ export async function validateSessionActive(
   const session = await db.get("posSession", sessionId);
   const now = Date.now();
 
-  console.log("session in validateSessionActive", session);
-
   if (!session) {
     return {
       success: false,

--- a/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
@@ -1473,6 +1473,9 @@ describe("pos session lifecycle trace handlers", () => {
   });
 
   it("keeps checkout-state sync successful when trace recording fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const ctx = createMutationCtx({
       sessions: [
         buildSession({
@@ -1503,9 +1506,14 @@ describe("pos session lifecycle trace handlers", () => {
     expect(
       ctx.sessions.find((session) => session._id === "session-trace-failure")?.payments,
     ).toEqual([{ method: "cash", amount: 115, timestamp: 1_000 }]);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[workflow-trace] pos.session.lifecycle.paymentAdded",
+      expect.any(Error),
+    );
   });
 
   it("does not overwrite a voided session trace when cron expires old sessions", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
     const ctx = createMutationCtx({
       sessions: [
         buildSession({
@@ -1571,9 +1579,13 @@ describe("pos session lifecycle trace handlers", () => {
     expect(ctx.sessions.find((session) => session._id === "session-void")?.notes).toBe(
       "Cashier voided this session",
     );
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[POS] Found 2 expired sessions to process",
+    );
   });
 
   it("releases expired held sessions through cron", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
     const ctx = createMutationCtx({
       sessions: [
         buildSession({
@@ -1605,6 +1617,9 @@ describe("pos session lifecycle trace handlers", () => {
       notes: "Session expired - inventory holds released",
     });
     expect(mocks.traceRecord).toHaveBeenCalledTimes(1);
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[POS] Found 1 expired sessions to process",
+    );
   });
 
   it("expires other-terminal sessions immediately during cashier recovery", async () => {

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -756,8 +756,6 @@ export const updateSku = mutation({
       };
     }
 
-    console.log("args.barcode", args.barcode);
-
     if (args.barcode) {
       const skuWithBarcode = await ctx.db
         .query("productSku")

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
@@ -163,6 +163,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
   });
 
   it("falls back to GHS when the store currency is invalid", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
     vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
       "lookup-1" as never,
@@ -186,6 +189,13 @@ describe("recordRegisterSessionTraceBestEffort", () => {
         message: `Recorded sale cash movement of ${formatStoredTraceAmount("GHS", 12_345)}.`,
         occurredAt: 222,
         step: "register_session_sale_recorded",
+      }),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[workflow-trace] register.session.trace.currency-format",
+      expect.objectContaining({
+        currency: "not-a-currency",
+        error: expect.any(RangeError),
       }),
     );
   });
@@ -293,6 +303,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
   });
 
   it("reports traceCreated false when the trace row write fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     vi.mocked(createWorkflowTraceWithCtx).mockRejectedValue(
       new Error("trace unavailable"),
     );
@@ -315,5 +328,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
       traceCreated: false,
       traceId: "register_session:session-1",
     });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[workflow-trace] register.session.trace.create",
+      expect.any(Error),
+    );
   });
 });

--- a/packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts
+++ b/packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts
@@ -240,6 +240,9 @@ describe("recordPosSessionTraceBestEffort", () => {
   });
 
   it("reports traceCreated false when the trace row write fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const traceSeed = buildPosSessionTraceSeed({
       storeId: "store-1" as Id<"store">,
       sessionNumber: "SES-001",
@@ -266,5 +269,9 @@ describe("recordPosSessionTraceBestEffort", () => {
       traceCreated: false,
       traceId: traceSeed.trace.traceId,
     });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[workflow-trace] pos.session.trace.create",
+      expect.any(Error),
+    );
   });
 });

--- a/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 type SessionRecord = {
   _id: string;
@@ -63,6 +63,10 @@ type TraceCall = {
 };
 
 describe("createPosSessionCommandService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("creates a fresh active session when no matching active session exists", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -520,6 +524,9 @@ describe("createPosSessionCommandService", () => {
   });
 
   it("keeps session start successful when lifecycle tracing fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
       registerSessions: [
@@ -554,6 +561,10 @@ describe("createPosSessionCommandService", () => {
         expiresAt: 61_000,
       },
     });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[workflow-trace] pos.session.lifecycle.started",
+      expect.any(Error),
+    );
     expect(repository.getSession("session-1")).not.toHaveProperty(
       "workflowTraceId",
     );

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { forwardRef } from "react";
 
 import { InputOTPForm } from "./InputOTP";
 import { PENDING_ATHENA_AUTH_SYNC_KEY } from "~/src/lib/constants";
@@ -17,13 +18,14 @@ vi.mock("@convex-dev/auth/react", () => ({
 }));
 
 vi.mock("@/components/ui/input-otp", () => ({
-  InputOTP: (props: any) => (
+  InputOTP: forwardRef<HTMLInputElement, any>((props, ref) => (
     <input
       aria-label="Verification code"
+      ref={ref}
       onChange={(event) => props.onChange?.(event.target.value)}
       value={props.value ?? ""}
     />
-  ),
+  )),
   InputOTPGroup: ({ children }: any) => <div>{children}</div>,
   InputOTPSlot: () => null,
 }));

--- a/packages/athena-webapp/src/hooks/useExpenseSessions.test.ts
+++ b/packages/athena-webapp/src/hooks/useExpenseSessions.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useMutation } from "convex/react";
 
 import { useExpenseSessionCreate } from "./useExpenseSessions";
@@ -18,6 +18,10 @@ vi.mock("../lib/logger", () => ({
 
 const mockedUseMutation = vi.mocked(useMutation);
 const createExpenseSessionMutation = vi.fn();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("useExpenseSessionCreate", () => {
   beforeEach(() => {
@@ -46,6 +50,9 @@ describe("useExpenseSessionCreate", () => {
   });
 
   it("collapses unexpected failures to the shared generic fallback message", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     createExpenseSessionMutation.mockRejectedValue(new Error("database offline"));
 
     const { result } = renderHook(() => useExpenseSessionCreate());
@@ -57,5 +64,9 @@ describe("useExpenseSessionCreate", () => {
         "staff-1" as never,
       ),
     ).rejects.toThrow("Please try again.");
+    expect(consoleError).toHaveBeenCalledWith(
+      "Unexpected command failure",
+      expect.any(Error),
+    );
   });
 });

--- a/packages/athena-webapp/src/hooks/usePrint.ts
+++ b/packages/athena-webapp/src/hooks/usePrint.ts
@@ -2,11 +2,6 @@ import { useCallback } from "react";
 
 export const usePrint = () => {
   const printReceipt = useCallback((receiptContent: string) => {
-    console.log(
-      "printReceipt called with content length:",
-      receiptContent.length
-    );
-
     // Create a new window for printing with specific dimensions for receipt
     const printWindow = window.open(
       "",
@@ -36,14 +31,11 @@ export const usePrint = () => {
       return;
     }
 
-    console.log("Print window opened successfully");
-
     // Set up close event handler to prevent reopening
     let isClosing = false;
     const handleClose = () => {
       if (!isClosing) {
         isClosing = true;
-        console.log("Print window closing event triggered");
       }
     };
 

--- a/packages/athena-webapp/src/lib/pos/displayAmounts.test.ts
+++ b/packages/athena-webapp/src/lib/pos/displayAmounts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { formatStoredAmount, parseDisplayAmountInput } from "./displayAmounts";
 import { validatePaymentAmount, validatePayments } from "./validation";
@@ -6,6 +6,10 @@ import { validatePaymentAmount, validatePayments } from "./validation";
 const formatter = new Intl.NumberFormat("en-GH", {
   style: "currency",
   currency: "GHS",
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("POS display amounts", () => {
@@ -36,20 +40,28 @@ describe("POS display amounts", () => {
   });
 
   it("renders payment validation errors in display units", () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const validation = validatePaymentAmount(15000, 10000, formatter, "card");
 
     expect(validation.isValid).toBe(false);
     expect(validation.errors[0]).toContain(formatter.format(150));
     expect(validation.errors[0]).toContain(formatter.format(100));
     expect(validation.errors[0]).not.toContain(formatter.format(15000));
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("[POS] Payment amount validation failed"),
+    );
   });
 
   it("renders total-paid validation errors in display units", () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const validation = validatePayments([{ amount: 15000 }], 20000, formatter);
 
     expect(validation.isValid).toBe(false);
     expect(validation.errors[0]).toContain(formatter.format(200));
     expect(validation.errors[0]).toContain(formatter.format(150));
     expect(validation.errors[0]).not.toContain(formatter.format(20000));
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("[POS] Payments validation failed"),
+    );
   });
 });

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -899,6 +899,7 @@ describe("useRegisterViewModel", () => {
   });
 
   it("gates an active POS session assigned to a different open drawer", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockRegisterState = {
       phase: "active",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -942,6 +943,12 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(mockSyncSessionCheckoutState).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[POS] Skipped checkout sync while drawer recovery is required",
+      ),
+    );
+    consoleWarn.mockRestore();
   });
 
   it("does not add products through direct handlers while an active session lacks drawer assignment", async () => {
@@ -1602,6 +1609,7 @@ describe("useRegisterViewModel", () => {
   });
 
   it("keeps local payment draft state but skips payment sync while drawer recovery is required", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockRegisterState = {
       phase: "active",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1632,6 +1640,12 @@ describe("useRegisterViewModel", () => {
       expect.objectContaining({ method: "cash", amount: 120 }),
     ]);
     expect(mockSyncSessionCheckoutState).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[POS] Skipped checkout sync while drawer recovery is required",
+      ),
+    );
+    consoleWarn.mockRestore();
   });
 
   it("blocks cart mutation handlers while drawer recovery is required", async () => {

--- a/packages/athena-webapp/src/tests/pos/usePrint.test.ts
+++ b/packages/athena-webapp/src/tests/pos/usePrint.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { usePrint } from "@/hooks/usePrint";
 
@@ -29,6 +29,10 @@ describe("usePrint Hook", () => {
     mockPrintWindow.closed = false;
     mockPrintWindow.onload = null;
     mockPrintWindow.document.readyState = "complete";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("Basic Functionality", () => {
@@ -198,6 +202,9 @@ describe("usePrint Hook", () => {
 
   describe("Error Handling", () => {
     it("should handle blocked popup window", () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       const { result } = renderHook(() => usePrint());
 
       // Mock window.open returning null (blocked popup)
@@ -214,9 +221,15 @@ describe("usePrint Hook", () => {
         "_blank",
         "width=300,height=600,scrollbars=yes"
       );
+      expect(consoleError).toHaveBeenCalledWith(
+        "Could not open print window - may be blocked by popup blocker"
+      );
     });
 
     it("should handle print errors gracefully", () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       const { result } = renderHook(() => usePrint());
 
       // Mock print to throw an error
@@ -238,9 +251,16 @@ describe("usePrint Hook", () => {
       }).not.toThrow();
 
       expect(mockPrintWindow.print).toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        "Error during printing:",
+        expect.any(Error)
+      );
     });
 
     it("should handle document.write errors", () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       const { result } = renderHook(() => usePrint());
 
       // Mock document.write to throw an error
@@ -253,6 +273,10 @@ describe("usePrint Hook", () => {
           result.current.printReceipt("<div>Test</div>");
         });
       }).not.toThrow();
+      expect(consoleError).toHaveBeenCalledWith(
+        "Error preparing print window:",
+        expect.any(Error)
+      );
     });
 
     it("should handle empty content gracefully", () => {
@@ -313,6 +337,9 @@ describe("usePrint Hook", () => {
 
   describe("Fallback Behavior", () => {
     it("should use document body fallback when popup is blocked", () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       const { result } = renderHook(() => usePrint());
 
       // Mock window.open returning null (blocked popup)
@@ -340,6 +367,9 @@ describe("usePrint Hook", () => {
 
       expect(document.createElement).toHaveBeenCalledWith("div");
       expect(document.body.appendChild).toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        "Could not open print window - may be blocked by popup blocker"
+      );
 
       // Restore original methods
       document.createElement = originalCreateElement;


### PR DESCRIPTION
## Summary
- suppress and assert expected negative-path console output in Athena webapp tests
- remove stray debug console logs from POS/session/product/print paths
- add a harness solution note for expected console output conventions
- refresh graphify artifacts after code changes

## Validation
- bun run --filter '@athena/webapp' test\n- bun run --filter '@athena/webapp' build\n- bun run graphify:rebuild\n- bun scripts/pre-push-review.ts\n- git push pre-push hook: bun scripts/pre-push-review.ts\n\nLinear: V26-432