### PR TITLE
Update GitHub checkout action runtime

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -210,7 +210,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/athena-production-rollback.yml
+++ b/.github/workflows/athena-production-rollback.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate deploy script
         run: bash -n scripts/deploy-vps.sh

--- a/.github/workflows/athena-qa-deploy.yml
+++ b/.github/workflows/athena-qa-deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate deploy scripts
         run: bash -n scripts/deploy-vps.sh scripts/deploy-qa-vps.sh


### PR DESCRIPTION
## Summary
- update all workflow checkout steps from `actions/checkout@v4` to `actions/checkout@v6`
- remove the Node 20 action runtime warning emitted by the QA deploy workflow

## Validation
- `git diff --check`
- workflow YAML parse check
- no remaining `actions/checkout@v4` references
- pre-push validation suite

Source: the official `actions/checkout` README documents `actions/checkout@v6` usage and notes that the newer checkout releases use the Node 24 runtime.