### PR TITLE
[V26-433]: Explore harness auto-install for missing Playwright browser binaries

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4123 nodes · 3749 edges · 1474 communities detected
+- 4131 nodes · 3767 edges · 1474 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1524,24 +1524,24 @@ Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 3 - "Community 3"
+Cohesion: 0.12
+Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+
+### Community 4 - "Community 4"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 4 - "Community 4"
+### Community 5 - "Community 5"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
 Cohesion: 0.11
 Nodes (16): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), handleAuthenticatedCloseoutStaff(), handleOpeningFloatApprovalApproved(), handleRecordDeposit() (+8 more)
-
-### Community 7 - "Community 7"
-Cohesion: 0.13
-Nodes (22): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+14 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.15
@@ -1696,24 +1696,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 46 - "Community 46"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 47 - "Community 47"
 Cohesion: 0.25
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 50 - "Community 50"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 51 - "Community 51"
 Cohesion: 0.18
@@ -1956,16 +1956,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 111 - "Community 111"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 112 - "Community 112"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 113 - "Community 113"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 114 - "Community 114"
 Cohesion: 0.52
@@ -2193,7 +2193,7 @@ Nodes (0):
 
 ### Community 170 - "Community 170"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 171 - "Community 171"
 Cohesion: 0.4
@@ -2208,12 +2208,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 174 - "Community 174"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 175 - "Community 175"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 175 - "Community 175"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 176 - "Community 176"
 Cohesion: 0.4
@@ -2225,7 +2225,7 @@ Nodes (0):
 
 ### Community 178 - "Community 178"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.5
@@ -2316,16 +2316,16 @@ Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 201 - "Community 201"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 202 - "Community 202"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
-
-### Community 203 - "Community 203"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 204 - "Community 204"
 Cohesion: 0.5
@@ -2336,12 +2336,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 206 - "Community 206"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 207 - "Community 207"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 207 - "Community 207"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.5
@@ -2352,64 +2352,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 210 - "Community 210"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 211 - "Community 211"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 217 - "Community 217"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 219 - "Community 219"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 221 - "Community 221"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 223 - "Community 223"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 224 - "Community 224"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.5
@@ -2420,24 +2420,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 227 - "Community 227"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 228 - "Community 228"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 230 - "Community 230"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 231 - "Community 231"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.5
@@ -2456,12 +2456,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 236 - "Community 236"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 237 - "Community 237"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 237 - "Community 237"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.5
@@ -2472,16 +2472,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 240 - "Community 240"
-Cohesion: 0.67
-Nodes (2): getApprovalRequestCopy(), handleDecideApprovalRequest()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 241 - "Community 241"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Nodes (2): getApprovalRequestCopy(), handleDecideApprovalRequest()
 
 ### Community 242 - "Community 242"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.5
@@ -2504,68 +2504,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 249 - "Community 249"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 249 - "Community 249"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 251 - "Community 251"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 252 - "Community 252"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 253 - "Community 253"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 254 - "Community 254"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 256 - "Community 256"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 257 - "Community 257"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.5
@@ -2592,51 +2592,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 270 - "Community 270"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 272 - "Community 272"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 275 - "Community 275"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 276 - "Community 276"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 277 - "Community 277"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 278 - "Community 278"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 279 - "Community 279"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 280 - "Community 280"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 281 - "Community 281"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 282 - "Community 282"
@@ -2689,35 +2689,35 @@ Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 297 - "Community 297"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 298 - "Community 298"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 301 - "Community 301"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 301 - "Community 301"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.67
@@ -2728,36 +2728,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 307 - "Community 307"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 309 - "Community 309"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 310 - "Community 310"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 310 - "Community 310"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
@@ -2772,24 +2772,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 315 - "Community 315"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
@@ -2797,27 +2797,27 @@ Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 323 - "Community 323"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 326 - "Community 326"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 326 - "Community 326"
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.67
@@ -2876,84 +2876,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 341 - "Community 341"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 342 - "Community 342"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 360 - "Community 360"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
@@ -2981,11 +2981,11 @@ Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.67
@@ -3000,16 +3000,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 372 - "Community 372"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 373 - "Community 373"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 373 - "Community 373"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 374 - "Community 374"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 375 - "Community 375"
 Cohesion: 0.67
@@ -3021,15 +3021,15 @@ Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 378 - "Community 378"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 379 - "Community 379"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.67
@@ -3040,56 +3040,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 382 - "Community 382"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 383 - "Community 383"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 384 - "Community 384"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 389 - "Community 389"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 390 - "Community 390"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 391 - "Community 391"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 392 - "Community 392"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 393 - "Community 393"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 394 - "Community 394"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.67
@@ -3100,12 +3100,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 397 - "Community 397"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 398 - "Community 398"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 398 - "Community 398"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
@@ -3116,12 +3116,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 401 - "Community 401"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 402 - "Community 402"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 402 - "Community 402"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.67
@@ -3196,12 +3196,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 421 - "Community 421"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 422 - "Community 422"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 423 - "Community 423"
 Cohesion: 1.0
@@ -9504,10 +9504,10 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
-- **Should `Community 6` be split into smaller, more focused modules?**
-  _Cohesion score 0.11 - nodes in this community are weakly interconnected._
+- **Should `Community 3` be split into smaller, more focused modules?**
+  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 7` be split into smaller, more focused modules?**
-  _Cohesion score 0.13 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 13` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 16` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3167,7 +3167,7 @@
       "relation": "calls",
       "source": "harness_behavior_asregexp",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L300",
+      "source_location": "L304",
       "target": "harness_behavior_escaperegexp",
       "weight": 1
     },
@@ -3179,7 +3179,7 @@
       "relation": "calls",
       "source": "harness_behavior_asregexp",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L671",
+      "source_location": "L697",
       "target": "harness_behavior_collectruntimesignalmatches",
       "weight": 1
     },
@@ -3191,8 +3191,92 @@
       "relation": "method",
       "source": "harness_behavior_harnessbehaviorphaseerror",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L227",
+      "source_location": "L231",
       "target": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_installplaywrightchromium",
+      "_tgt": "harness_behavior_runshellcommand",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_runshellcommand",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L902",
+      "target": "harness_behavior_installplaywrightchromium",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_ismissingplaywrightchromiumerror",
+      "_tgt": "harness_behavior_formaterror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_formaterror",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L880",
+      "target": "harness_behavior_ismissingplaywrightchromiumerror",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_launchplaywrightchromium",
+      "_tgt": "harness_behavior_formaterror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_formaterror",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L933",
+      "target": "harness_behavior_launchplaywrightchromium",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_launchplaywrightchromium",
+      "_tgt": "harness_behavior_ismissingplaywrightchromiumerror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_ismissingplaywrightchromiumerror",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L916",
+      "target": "harness_behavior_launchplaywrightchromium",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_launchplaywrightchromium",
+      "_tgt": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L922",
+      "target": "harness_behavior_launchplaywrightchromium",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_launchplaywrightchromium",
+      "_tgt": "harness_behavior_shouldautoinstallplaywrightchromium",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_shouldautoinstallplaywrightchromium",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L921",
+      "target": "harness_behavior_launchplaywrightchromium",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "_tgt": "harness_behavior_formaterror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_formaterror",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L894",
+      "target": "harness_behavior_missingplaywrightchromiumdiagnostic",
       "weight": 1
     },
     {
@@ -3203,7 +3287,7 @@
       "relation": "calls",
       "source": "harness_behavior_parseharnessbehaviorargs",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1305",
+      "source_location": "L1392",
       "target": "harness_behavior_runharnessbehaviorcli",
       "weight": 1
     },
@@ -3215,7 +3299,7 @@
       "relation": "calls",
       "source": "harness_behavior_printharnessbehaviorusage",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1308",
+      "source_location": "L1395",
       "target": "harness_behavior_runharnessbehaviorcli",
       "weight": 1
     },
@@ -3227,7 +3311,7 @@
       "relation": "calls",
       "source": "harness_behavior_runharnessbehaviorscenario",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1377",
+      "source_location": "L1464",
       "target": "harness_behavior_runharnessbehaviorcli",
       "weight": 1
     },
@@ -3239,7 +3323,7 @@
       "relation": "calls",
       "source": "harness_behavior_collectlatencydiagnostics",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1153",
+      "source_location": "L1240",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "weight": 1
     },
@@ -3251,7 +3335,7 @@
       "relation": "calls",
       "source": "harness_behavior_collectruntimesignaldiagnostics",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1149",
+      "source_location": "L1236",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "weight": 1
     },
@@ -3263,7 +3347,7 @@
       "relation": "calls",
       "source": "harness_behavior_formatassertiondiagnostics",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1163",
+      "source_location": "L1250",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "weight": 1
     },
@@ -3275,7 +3359,7 @@
       "relation": "calls",
       "source": "harness_behavior_wrapphaseerror",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1113",
+      "source_location": "L1200",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "weight": 1
     },
@@ -3287,7 +3371,7 @@
       "relation": "calls",
       "source": "harness_behavior_formaterror",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L650",
+      "source_location": "L676",
       "target": "harness_behavior_runhttpreadinesscheck",
       "weight": 1
     },
@@ -3299,8 +3383,44 @@
       "relation": "calls",
       "source": "harness_behavior_formaterror",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L933",
+      "source_location": "L1020",
       "target": "harness_behavior_runplaywrightflow",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_runplaywrightflow",
+      "_tgt": "harness_behavior_launchplaywrightchromium",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_launchplaywrightchromium",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L989",
+      "target": "harness_behavior_runplaywrightflow",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_runshellcommand",
+      "_tgt": "harness_behavior_consumelines",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_consumelines",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L615",
+      "target": "harness_behavior_runshellcommand",
+      "weight": 1
+    },
+    {
+      "_src": "harness_behavior_runshellcommand",
+      "_tgt": "harness_behavior_spawncommand",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_behavior_spawncommand",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L609",
+      "target": "harness_behavior_runshellcommand",
       "weight": 1
     },
     {
@@ -3311,7 +3431,7 @@
       "relation": "calls",
       "source": "harness_behavior_spawncommand",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L555",
+      "source_location": "L559",
       "target": "harness_behavior_resolveharnessbehaviorshell",
       "weight": 1
     },
@@ -3323,7 +3443,7 @@
       "relation": "calls",
       "source": "harness_behavior_asregexp",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L522",
+      "source_location": "L526",
       "target": "harness_behavior_startprocess",
       "weight": 1
     },
@@ -3335,7 +3455,7 @@
       "relation": "calls",
       "source": "harness_behavior_consumelines",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L452",
+      "source_location": "L456",
       "target": "harness_behavior_startprocess",
       "weight": 1
     },
@@ -3347,7 +3467,7 @@
       "relation": "calls",
       "source": "harness_behavior_logphase",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L427",
+      "source_location": "L431",
       "target": "harness_behavior_startprocess",
       "weight": 1
     },
@@ -3359,7 +3479,7 @@
       "relation": "calls",
       "source": "harness_behavior_startprocess",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L429",
+      "source_location": "L433",
       "target": "harness_behavior_spawncommand",
       "weight": 1
     },
@@ -3371,7 +3491,7 @@
       "relation": "calls",
       "source": "harness_behavior_sleep",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L405",
+      "source_location": "L409",
       "target": "harness_behavior_stopprocess",
       "weight": 1
     },
@@ -3383,7 +3503,7 @@
       "relation": "calls",
       "source": "harness_behavior_formaterror",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L965",
+      "source_location": "L1052",
       "target": "harness_behavior_wrapphaseerror",
       "weight": 1
     },
@@ -38273,14 +38393,38 @@
     },
     {
       "_src": "scripts_harness_behavior_test_ts",
+      "_tgt": "harness_behavior_test_createbrowser",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_test_ts",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L52",
+      "target": "harness_behavior_test_createbrowser",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_test_ts",
       "_tgt": "harness_behavior_test_createfixtureroot",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "scripts_harness_behavior_test_ts",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L21",
+      "source_location": "L22",
       "target": "harness_behavior_test_createfixtureroot",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_test_ts",
+      "_tgt": "harness_behavior_test_createplaywrightmodule",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_test_ts",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L44",
+      "target": "harness_behavior_test_createplaywrightmodule",
       "weight": 1
     },
     {
@@ -38291,7 +38435,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_test_ts",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L15",
+      "source_location": "L16",
       "target": "harness_behavior_test_write",
       "weight": 1
     },
@@ -38303,7 +38447,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L295",
+      "source_location": "L299",
       "target": "harness_behavior_asregexp",
       "weight": 1
     },
@@ -38315,7 +38459,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L753",
+      "source_location": "L779",
       "target": "harness_behavior_collectlatencydiagnostics",
       "weight": 1
     },
@@ -38327,7 +38471,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L720",
+      "source_location": "L746",
       "target": "harness_behavior_collectruntimesignaldiagnostics",
       "weight": 1
     },
@@ -38339,7 +38483,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L663",
+      "source_location": "L689",
       "target": "harness_behavior_collectruntimesignalmatches",
       "weight": 1
     },
@@ -38351,7 +38495,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L328",
+      "source_location": "L332",
       "target": "harness_behavior_consumelines",
       "weight": 1
     },
@@ -38363,7 +38507,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L303",
+      "source_location": "L307",
       "target": "harness_behavior_escaperegexp",
       "weight": 1
     },
@@ -38375,7 +38519,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L801",
+      "source_location": "L827",
       "target": "harness_behavior_formatassertiondiagnostics",
       "weight": 1
     },
@@ -38387,7 +38531,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L307",
+      "source_location": "L311",
       "target": "harness_behavior_formaterror",
       "weight": 1
     },
@@ -38399,7 +38543,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L315",
+      "source_location": "L319",
       "target": "harness_behavior_getlinesforsource",
       "weight": 1
     },
@@ -38411,8 +38555,44 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L222",
+      "source_location": "L226",
       "target": "harness_behavior_harnessbehaviorphaseerror",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_installplaywrightchromium",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_ts",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L901",
+      "target": "harness_behavior_installplaywrightchromium",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_ismissingplaywrightchromiumerror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_ts",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L879",
+      "target": "harness_behavior_ismissingplaywrightchromiumerror",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_launchplaywrightchromium",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_ts",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L905",
+      "target": "harness_behavior_launchplaywrightchromium",
       "weight": 1
     },
     {
@@ -38423,8 +38603,20 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L281",
+      "source_location": "L285",
       "target": "harness_behavior_logphase",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_ts",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L892",
+      "target": "harness_behavior_missingplaywrightchromiumdiagnostic",
       "weight": 1
     },
     {
@@ -38435,7 +38627,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1215",
+      "source_location": "L1302",
       "target": "harness_behavior_parseharnessbehaviorargs",
       "weight": 1
     },
@@ -38447,7 +38639,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1287",
+      "source_location": "L1374",
       "target": "harness_behavior_printharnessbehaviorusage",
       "weight": 1
     },
@@ -38459,7 +38651,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L604",
+      "source_location": "L630",
       "target": "harness_behavior_resolveharnessbehaviorshell",
       "weight": 1
     },
@@ -38471,7 +38663,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1295",
+      "source_location": "L1382",
       "target": "harness_behavior_runharnessbehaviorcli",
       "weight": 1
     },
@@ -38483,7 +38675,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L981",
+      "source_location": "L1068",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "weight": 1
     },
@@ -38495,7 +38687,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L631",
+      "source_location": "L657",
       "target": "harness_behavior_runhttpreadinesscheck",
       "weight": 1
     },
@@ -38507,7 +38699,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L968",
+      "source_location": "L1055",
       "target": "harness_behavior_runphasewithduration",
       "weight": 1
     },
@@ -38519,8 +38711,32 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L853",
+      "source_location": "L942",
       "target": "harness_behavior_runplaywrightflow",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_runshellcommand",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_ts",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L608",
+      "target": "harness_behavior_runshellcommand",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_shouldautoinstallplaywrightchromium",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_behavior_ts",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L888",
+      "target": "harness_behavior_shouldautoinstallplaywrightchromium",
       "weight": 1
     },
     {
@@ -38531,7 +38747,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L289",
+      "source_location": "L293",
       "target": "harness_behavior_sleep",
       "weight": 1
     },
@@ -38543,7 +38759,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L550",
+      "source_location": "L554",
       "target": "harness_behavior_spawncommand",
       "weight": 1
     },
@@ -38555,7 +38771,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L416",
+      "source_location": "L420",
       "target": "harness_behavior_startprocess",
       "weight": 1
     },
@@ -38567,7 +38783,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L394",
+      "source_location": "L398",
       "target": "harness_behavior_stopprocess",
       "weight": 1
     },
@@ -38579,7 +38795,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_ts",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L957",
+      "source_location": "L1044",
       "target": "harness_behavior_wrapphaseerror",
       "weight": 1
     },
@@ -47904,65 +48120,65 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1110,
@@ -48057,65 +48273,65 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1120,
@@ -48210,65 +48426,65 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1130,
@@ -55329,51 +55545,6 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
       "norm_label": "formatrequestdelay()",
@@ -55381,7 +55552,7 @@
       "source_location": "L36"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -55390,7 +55561,7 @@
       "source_location": "L84"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -55399,7 +55570,7 @@
       "source_location": "L123"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -55408,7 +55579,7 @@
       "source_location": "L92"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -55417,7 +55588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -55426,7 +55597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -55435,7 +55606,7 @@
       "source_location": "L30"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -55444,7 +55615,7 @@
       "source_location": "L8"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -55453,7 +55624,7 @@
       "source_location": "L49"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -55462,7 +55633,7 @@
       "source_location": "L66"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -55471,7 +55642,7 @@
       "source_location": "L20"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -55480,7 +55651,7 @@
       "source_location": "L50"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -55489,7 +55660,7 @@
       "source_location": "L342"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -55498,7 +55669,7 @@
       "source_location": "L322"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -55507,7 +55678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -55516,7 +55687,7 @@
       "source_location": "L61"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -55525,7 +55696,7 @@
       "source_location": "L57"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -55534,7 +55705,7 @@
       "source_location": "L98"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -55543,7 +55714,7 @@
       "source_location": "L134"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -55552,7 +55723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -55561,7 +55732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -55570,7 +55741,7 @@
       "source_location": "L38"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -55579,7 +55750,7 @@
       "source_location": "L64"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -55588,7 +55759,7 @@
       "source_location": "L135"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -55597,7 +55768,7 @@
       "source_location": "L43"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -55606,7 +55777,7 @@
       "source_location": "L58"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -55615,7 +55786,7 @@
       "source_location": "L63"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -55624,7 +55795,7 @@
       "source_location": "L50"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -55633,7 +55804,7 @@
       "source_location": "L53"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -55642,7 +55813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -55651,7 +55822,7 @@
       "source_location": "L140"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -55660,7 +55831,7 @@
       "source_location": "L177"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -55669,7 +55840,7 @@
       "source_location": "L195"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -55678,7 +55849,7 @@
       "source_location": "L45"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -55687,7 +55858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -55696,7 +55867,7 @@
       "source_location": "L92"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -55705,7 +55876,7 @@
       "source_location": "L307"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -55714,7 +55885,7 @@
       "source_location": "L70"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -55723,12 +55894,57 @@
       "source_location": "L50"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -57516,6 +57732,51 @@
     {
       "community": 201,
       "file_type": "code",
+      "id": "harness_behavior_test_createbrowser",
+      "label": "createBrowser()",
+      "norm_label": "createbrowser()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "harness_behavior_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "harness_behavior_test_createplaywrightmodule",
+      "label": "createPlaywrightModule()",
+      "norm_label": "createplaywrightmodule()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "harness_behavior_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_test_ts",
+      "label": "harness-behavior.test.ts",
+      "norm_label": "harness-behavior.test.ts",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
       "norm_label": "collectharnessrepovalidationselection()",
@@ -57523,7 +57784,7 @@
       "source_location": "L45"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -57532,7 +57793,7 @@
       "source_location": "L37"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -57541,7 +57802,7 @@
       "source_location": "L27"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -57550,7 +57811,7 @@
       "source_location": "L31"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -57559,7 +57820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -57568,7 +57829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -57577,7 +57838,7 @@
       "source_location": "L8"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -57586,7 +57847,7 @@
       "source_location": "L59"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -57595,7 +57856,7 @@
       "source_location": "L36"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -57604,7 +57865,7 @@
       "source_location": "L50"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -57613,7 +57874,7 @@
       "source_location": "L12"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -57622,7 +57883,7 @@
       "source_location": "L26"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -57631,7 +57892,7 @@
       "source_location": "L20"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -57640,7 +57901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -57649,7 +57910,7 @@
       "source_location": "L109"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -57658,7 +57919,7 @@
       "source_location": "L84"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -57667,7 +57928,7 @@
       "source_location": "L95"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -57676,7 +57937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -57685,7 +57946,7 @@
       "source_location": "L149"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -57694,7 +57955,7 @@
       "source_location": "L39"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -57703,7 +57964,7 @@
       "source_location": "L164"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -57712,7 +57973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -57721,7 +57982,7 @@
       "source_location": "L50"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -57730,7 +57991,7 @@
       "source_location": "L23"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -57739,7 +58000,7 @@
       "source_location": "L37"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -57748,7 +58009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -57757,7 +58018,7 @@
       "source_location": "L21"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -57766,7 +58027,7 @@
       "source_location": "L35"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -57775,7 +58036,7 @@
       "source_location": "L45"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -57784,7 +58045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -57793,7 +58054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -57802,7 +58063,7 @@
       "source_location": "L21"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -57811,49 +58072,13 @@
       "source_location": "L35"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
       "norm_label": "getsessionexpirydurationminutes()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
-      "label": "posSessions.trace.test.ts",
-      "norm_label": "possessions.trace.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "possessions_trace_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L247"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "possessions_trace_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "possessions_trace_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L264"
     },
     {
       "community": 21,
@@ -58020,6 +58245,42 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
+      "label": "posSessions.trace.test.ts",
+      "norm_label": "possessions.trace.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "possessions_trace_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "possessions_trace_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "possessions_trace_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
+      "source_location": "L264"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
       "norm_label": "todisplayamount()",
@@ -58027,7 +58288,7 @@
       "source_location": "L5"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -58036,7 +58297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -58045,7 +58306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -58054,7 +58315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -58063,7 +58324,7 @@
       "source_location": "L26"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -58072,7 +58333,7 @@
       "source_location": "L79"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -58081,7 +58342,7 @@
       "source_location": "L33"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -58090,7 +58351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -58099,7 +58360,7 @@
       "source_location": "L10"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -58108,7 +58369,7 @@
       "source_location": "L18"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -58117,7 +58378,7 @@
       "source_location": "L52"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -58126,7 +58387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -58135,7 +58396,7 @@
       "source_location": "L98"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -58144,7 +58405,7 @@
       "source_location": "L56"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -58153,7 +58414,7 @@
       "source_location": "L49"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -58162,7 +58423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -58171,7 +58432,7 @@
       "source_location": "L28"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -58180,7 +58441,7 @@
       "source_location": "L42"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -58189,7 +58450,7 @@
       "source_location": "L73"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -58198,7 +58459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -58207,7 +58468,7 @@
       "source_location": "L8"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -58216,7 +58477,7 @@
       "source_location": "L32"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -58225,7 +58486,7 @@
       "source_location": "L64"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -58234,7 +58495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -58243,7 +58504,7 @@
       "source_location": "L18"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -58252,7 +58513,7 @@
       "source_location": "L25"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -58261,7 +58522,7 @@
       "source_location": "L11"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -58270,7 +58531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -58279,7 +58540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -58288,7 +58549,7 @@
       "source_location": "L33"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -58297,7 +58558,7 @@
       "source_location": "L19"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -58306,7 +58567,7 @@
       "source_location": "L42"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -58315,7 +58576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -58324,7 +58585,7 @@
       "source_location": "L31"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -58333,49 +58594,13 @@
       "source_location": "L48"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
       "source_location": "L131"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "serviceintake_resolveserviceintakecustomerprofile",
-      "label": "resolveServiceIntakeCustomerProfile()",
-      "norm_label": "resolveserviceintakecustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "serviceintake_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "serviceintake_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L19"
     },
     {
       "community": 22,
@@ -58542,6 +58767,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "serviceintake_resolveserviceintakecustomerprofile",
+      "label": "resolveServiceIntakeCustomerProfile()",
+      "norm_label": "resolveserviceintakecustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "serviceintake_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "serviceintake_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -58549,7 +58810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -58558,7 +58819,7 @@
       "source_location": "L31"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -58567,7 +58828,7 @@
       "source_location": "L26"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -58576,7 +58837,7 @@
       "source_location": "L53"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -58585,7 +58846,7 @@
       "source_location": "L36"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -58594,7 +58855,7 @@
       "source_location": "L96"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -58603,7 +58864,7 @@
       "source_location": "L71"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -58612,7 +58873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -58621,7 +58882,7 @@
       "source_location": "L21"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -58630,7 +58891,7 @@
       "source_location": "L42"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -58639,7 +58900,7 @@
       "source_location": "L80"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -58648,7 +58909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -58657,7 +58918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -58666,7 +58927,7 @@
       "source_location": "L122"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -58675,7 +58936,7 @@
       "source_location": "L34"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -58684,7 +58945,7 @@
       "source_location": "L72"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -58693,7 +58954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -58702,7 +58963,7 @@
       "source_location": "L162"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -58711,7 +58972,7 @@
       "source_location": "L56"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -58720,7 +58981,7 @@
       "source_location": "L180"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -58729,7 +58990,7 @@
       "source_location": "L31"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -58738,7 +58999,7 @@
       "source_location": "L176"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -58747,7 +59008,7 @@
       "source_location": "L27"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -58756,7 +59017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -58765,7 +59026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -58774,7 +59035,7 @@
       "source_location": "L23"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -58783,7 +59044,7 @@
       "source_location": "L9"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -58792,7 +59053,7 @@
       "source_location": "L13"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -58801,7 +59062,7 @@
       "source_location": "L19"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -58810,7 +59071,7 @@
       "source_location": "L26"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -58819,7 +59080,7 @@
       "source_location": "L12"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -58828,7 +59089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -58837,7 +59098,7 @@
       "source_location": "L21"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -58846,7 +59107,7 @@
       "source_location": "L63"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -58855,49 +59116,13 @@
       "source_location": "L71"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
       "norm_label": "customerengagementevents.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 23,
@@ -59055,6 +59280,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
       "norm_label": "staffdisplayname.ts",
@@ -59062,7 +59323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -59071,7 +59332,7 @@
       "source_location": "L12"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -59080,7 +59341,7 @@
       "source_location": "L46"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -59089,7 +59350,7 @@
       "source_location": "L7"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -59098,7 +59359,7 @@
       "source_location": "L227"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -59107,7 +59368,7 @@
       "source_location": "L46"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -59116,7 +59377,7 @@
       "source_location": "L27"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -59125,7 +59386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -59134,7 +59395,7 @@
       "source_location": "L55"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -59143,7 +59404,7 @@
       "source_location": "L32"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -59152,7 +59413,7 @@
       "source_location": "L211"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -59161,7 +59422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -59170,7 +59431,7 @@
       "source_location": "L52"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -59179,7 +59440,7 @@
       "source_location": "L27"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -59188,7 +59449,7 @@
       "source_location": "L288"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -59197,7 +59458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -59206,7 +59467,7 @@
       "source_location": "L48"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -59215,7 +59476,7 @@
       "source_location": "L88"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -59224,7 +59485,7 @@
       "source_location": "L14"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -59233,7 +59494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -59242,7 +59503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -59251,7 +59512,7 @@
       "source_location": "L15"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -59260,7 +59521,7 @@
       "source_location": "L28"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -59269,7 +59530,7 @@
       "source_location": "L19"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -59278,7 +59539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -59287,7 +59548,7 @@
       "source_location": "L52"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -59296,7 +59557,7 @@
       "source_location": "L3"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -59305,7 +59566,7 @@
       "source_location": "L90"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -59314,7 +59575,7 @@
       "source_location": "L86"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -59323,7 +59584,7 @@
       "source_location": "L76"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -59332,7 +59593,7 @@
       "source_location": "L52"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -59341,7 +59602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -59350,7 +59611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -59359,7 +59620,7 @@
       "source_location": "L67"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -59368,49 +59629,13 @@
       "source_location": "L90"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
       "norm_label": "ondragend()",
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "commandapprovaldialog_getasyncresolution",
-      "label": "getAsyncResolution()",
-      "norm_label": "getasyncresolution()",
-      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "commandapprovaldialog_getinlinemanagerresolution",
-      "label": "getInlineManagerResolution()",
-      "norm_label": "getinlinemanagerresolution()",
-      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "commandapprovaldialog_tostaffauthenticationresult",
-      "label": "toStaffAuthenticationResult()",
-      "norm_label": "tostaffauthenticationresult()",
-      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
-      "label": "CommandApprovalDialog.tsx",
-      "norm_label": "commandapprovaldialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L1"
     },
     {
       "community": 24,
@@ -59568,6 +59793,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "commandapprovaldialog_getasyncresolution",
+      "label": "getAsyncResolution()",
+      "norm_label": "getasyncresolution()",
+      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "commandapprovaldialog_getinlinemanagerresolution",
+      "label": "getInlineManagerResolution()",
+      "norm_label": "getinlinemanagerresolution()",
+      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "commandapprovaldialog_tostaffauthenticationresult",
+      "label": "toStaffAuthenticationResult()",
+      "norm_label": "tostaffauthenticationresult()",
+      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
+      "label": "CommandApprovalDialog.tsx",
+      "norm_label": "commandapprovaldialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "operationsqueueview_getapprovalrequestcopy",
       "label": "getApprovalRequestCopy()",
       "norm_label": "getapprovalrequestcopy()",
@@ -59575,7 +59836,7 @@
       "source_location": "L46"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -59584,7 +59845,7 @@
       "source_location": "L332"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -59593,7 +59854,7 @@
       "source_location": "L322"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -59602,7 +59863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -59611,7 +59872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -59620,7 +59881,7 @@
       "source_location": "L105"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -59629,7 +59890,7 @@
       "source_location": "L97"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -59638,7 +59899,7 @@
       "source_location": "L83"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -59647,7 +59908,7 @@
       "source_location": "L91"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -59656,7 +59917,7 @@
       "source_location": "L68"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -59665,7 +59926,7 @@
       "source_location": "L22"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -59674,7 +59935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -59683,7 +59944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -59692,7 +59953,7 @@
       "source_location": "L22"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -59701,7 +59962,7 @@
       "source_location": "L27"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -59710,7 +59971,7 @@
       "source_location": "L40"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -59719,7 +59980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -59728,7 +59989,7 @@
       "source_location": "L78"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -59737,7 +59998,7 @@
       "source_location": "L118"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -59746,7 +60007,7 @@
       "source_location": "L89"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -59755,7 +60016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -59764,7 +60025,7 @@
       "source_location": "L63"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -59773,7 +60034,7 @@
       "source_location": "L54"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -59782,7 +60043,7 @@
       "source_location": "L11"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -59791,7 +60052,7 @@
       "source_location": "L16"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -59800,7 +60061,7 @@
       "source_location": "L35"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -59809,7 +60070,7 @@
       "source_location": "L6"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -59818,7 +60079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -59827,7 +60088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -59836,7 +60097,7 @@
       "source_location": "L5"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -59845,7 +60106,7 @@
       "source_location": "L30"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -59854,7 +60115,7 @@
       "source_location": "L21"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -59863,7 +60124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -59872,7 +60133,7 @@
       "source_location": "L178"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -59881,49 +60142,13 @@
       "source_location": "L205"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
       "norm_label": "withsavestate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
       "source_location": "L806"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "label": "WorkflowTraceView.tsx",
-      "norm_label": "workflowtraceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "workflowtraceview_formattracelabel",
-      "label": "formatTraceLabel()",
-      "norm_label": "formattracelabel()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "workflowtraceview_getstatustone",
-      "label": "getStatusTone()",
-      "norm_label": "getstatustone()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "workflowtraceview_workflowtraceheader",
-      "label": "WorkflowTraceHeader()",
-      "norm_label": "workflowtraceheader()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L65"
     },
     {
       "community": 25,
@@ -60081,6 +60306,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
+      "label": "WorkflowTraceView.tsx",
+      "norm_label": "workflowtraceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "workflowtraceview_formattracelabel",
+      "label": "formatTraceLabel()",
+      "norm_label": "formattracelabel()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "workflowtraceview_getstatustone",
+      "label": "getStatusTone()",
+      "norm_label": "getstatustone()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "workflowtraceview_workflowtraceheader",
+      "label": "WorkflowTraceHeader()",
+      "norm_label": "workflowtraceheader()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
       "norm_label": "formatlastactivity()",
@@ -60088,7 +60349,7 @@
       "source_location": "L75"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -60097,7 +60358,7 @@
       "source_location": "L82"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -60106,7 +60367,7 @@
       "source_location": "L93"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -60115,7 +60376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -60124,7 +60385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -60133,7 +60394,7 @@
       "source_location": "L15"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -60142,7 +60403,7 @@
       "source_location": "L28"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -60151,7 +60412,7 @@
       "source_location": "L54"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -60160,7 +60421,7 @@
       "source_location": "L66"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -60169,7 +60430,7 @@
       "source_location": "L121"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -60178,7 +60439,7 @@
       "source_location": "L74"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -60187,7 +60448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -60196,7 +60457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -60205,7 +60466,7 @@
       "source_location": "L34"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -60214,7 +60475,7 @@
       "source_location": "L28"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -60223,7 +60484,7 @@
       "source_location": "L48"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -60232,7 +60493,7 @@
       "source_location": "L51"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -60241,7 +60502,7 @@
       "source_location": "L92"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -60250,7 +60511,7 @@
       "source_location": "L16"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -60259,7 +60520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -60268,7 +60529,7 @@
       "source_location": "L22"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -60277,7 +60538,7 @@
       "source_location": "L10"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -60286,7 +60547,7 @@
       "source_location": "L57"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -60295,7 +60556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -60304,7 +60565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -60313,7 +60574,7 @@
       "source_location": "L83"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -60322,7 +60583,7 @@
       "source_location": "L100"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -60331,7 +60592,7 @@
       "source_location": "L79"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -60340,7 +60601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -60349,7 +60610,7 @@
       "source_location": "L38"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -60358,7 +60619,7 @@
       "source_location": "L65"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -60367,7 +60628,7 @@
       "source_location": "L91"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -60376,7 +60637,7 @@
       "source_location": "L4"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -60385,7 +60646,7 @@
       "source_location": "L20"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -60394,49 +60655,13 @@
       "source_location": "L42"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
       "norm_label": "fingerprint.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
-      "label": "useExpenseRegisterViewModel.ts",
-      "norm_label": "useexpenseregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
-      "label": "getExpenseSessionLoadKey()",
-      "norm_label": "getexpensesessionloadkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
-      "label": "useExpenseRegisterViewModel()",
-      "norm_label": "useexpenseregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L64"
     },
     {
       "community": 26,
@@ -60585,6 +60810,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
+      "label": "useExpenseRegisterViewModel.ts",
+      "norm_label": "useexpenseregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
+      "label": "getExpenseSessionLoadKey()",
+      "norm_label": "getexpensesessionloadkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
+      "label": "useExpenseRegisterViewModel()",
+      "norm_label": "useexpenseregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
@@ -60592,7 +60853,7 @@
       "source_location": "L13"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -60601,7 +60862,7 @@
       "source_location": "L46"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -60610,7 +60871,7 @@
       "source_location": "L21"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -60619,7 +60880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -60628,7 +60889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -60637,7 +60898,7 @@
       "source_location": "L8"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -60646,7 +60907,7 @@
       "source_location": "L5"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -60655,7 +60916,7 @@
       "source_location": "L20"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -60664,7 +60925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -60673,7 +60934,7 @@
       "source_location": "L11"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -60682,7 +60943,7 @@
       "source_location": "L9"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -60691,7 +60952,7 @@
       "source_location": "L25"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -60700,7 +60961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -60709,7 +60970,7 @@
       "source_location": "L50"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -60718,7 +60979,7 @@
       "source_location": "L92"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -60727,7 +60988,7 @@
       "source_location": "L74"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -60736,7 +60997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -60745,7 +61006,7 @@
       "source_location": "L62"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -60754,7 +61015,7 @@
       "source_location": "L109"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -60763,7 +61024,7 @@
       "source_location": "L177"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -60772,7 +61033,7 @@
       "source_location": "L18"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -60781,7 +61042,7 @@
       "source_location": "L52"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -60790,7 +61051,7 @@
       "source_location": "L68"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -60799,7 +61060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -60808,7 +61069,7 @@
       "source_location": "L68"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -60817,7 +61078,7 @@
       "source_location": "L26"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -60826,7 +61087,7 @@
       "source_location": "L7"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -60835,7 +61096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -60844,7 +61105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -60853,7 +61114,7 @@
       "source_location": "L81"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -60862,7 +61123,7 @@
       "source_location": "L85"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -60871,7 +61132,7 @@
       "source_location": "L27"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -60880,7 +61141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -60889,7 +61150,7 @@
       "source_location": "L43"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -60898,49 +61159,13 @@
       "source_location": "L13"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
       "norm_label": "shippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "label": "UpsellModal.tsx",
-      "norm_label": "upsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "upsellmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L111"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "upsellmodal_handlescroll",
-      "label": "handleScroll()",
-      "norm_label": "handlescroll()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "upsellmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L127"
     },
     {
       "community": 27,
@@ -61089,6 +61314,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
+      "label": "UpsellModal.tsx",
+      "norm_label": "upsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "upsellmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L111"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "upsellmodal_handlescroll",
+      "label": "handleScroll()",
+      "norm_label": "handlescroll()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "upsellmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
       "norm_label": "storecontext.tsx",
@@ -61096,7 +61357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -61105,7 +61366,7 @@
       "source_location": "L25"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -61114,7 +61375,7 @@
       "source_location": "L90"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -61123,7 +61384,7 @@
       "source_location": "L82"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -61132,7 +61393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -61141,7 +61402,7 @@
       "source_location": "L115"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -61150,7 +61411,7 @@
       "source_location": "L105"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -61159,7 +61420,7 @@
       "source_location": "L110"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -61168,7 +61429,7 @@
       "source_location": "L121"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -61177,7 +61438,7 @@
       "source_location": "L26"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -61186,7 +61447,7 @@
       "source_location": "L71"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -61195,7 +61456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -61204,7 +61465,7 @@
       "source_location": "L46"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -61213,7 +61474,7 @@
       "source_location": "L24"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -61222,7 +61483,7 @@
       "source_location": "L20"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -61231,7 +61492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61240,7 +61501,7 @@
       "source_location": "L17"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -61249,7 +61510,7 @@
       "source_location": "L11"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -61258,7 +61519,7 @@
       "source_location": "L24"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -61267,7 +61528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61276,7 +61537,7 @@
       "source_location": "L20"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -61285,7 +61546,7 @@
       "source_location": "L65"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -61294,7 +61555,7 @@
       "source_location": "L14"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -61303,7 +61564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -61312,7 +61573,7 @@
       "source_location": "L126"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -61321,7 +61582,7 @@
       "source_location": "L130"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -61330,7 +61591,7 @@
       "source_location": "L876"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -61339,7 +61600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -61348,7 +61609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -61357,7 +61618,7 @@
       "source_location": "L8"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -61366,7 +61627,7 @@
       "source_location": "L79"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -61375,7 +61636,7 @@
       "source_location": "L61"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61384,7 +61645,7 @@
       "source_location": "L49"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -61393,7 +61654,7 @@
       "source_location": "L17"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -61402,48 +61663,12 @@
       "source_location": "L11"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
       "norm_label": "harness-scorecard.test.ts",
       "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "harness_test_collectharnesstesttargets",
-      "label": "collectHarnessTestTargets()",
-      "norm_label": "collectharnesstesttargets()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "harness_test_parseharnesstestcliargs",
-      "label": "parseHarnessTestCliArgs()",
-      "norm_label": "parseharnesstestcliargs()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "harness_test_runharnesstest",
-      "label": "runHarnessTest()",
-      "norm_label": "runharnesstest()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "scripts_harness_test_ts",
-      "label": "harness-test.ts",
-      "norm_label": "harness-test.ts",
-      "source_file": "scripts/harness-test.ts",
       "source_location": "L1"
     },
     {
@@ -61593,6 +61818,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "harness_test_collectharnesstesttargets",
+      "label": "collectHarnessTestTargets()",
+      "norm_label": "collectharnesstesttargets()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "harness_test_parseharnesstestcliargs",
+      "label": "parseHarnessTestCliArgs()",
+      "norm_label": "parseharnesstestcliargs()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "harness_test_runharnesstest",
+      "label": "runHarnessTest()",
+      "norm_label": "runharnesstest()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "scripts_harness_test_ts",
+      "label": "harness-test.ts",
+      "norm_label": "harness-test.ts",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
       "norm_label": "error()",
@@ -61600,7 +61861,7 @@
       "source_location": "L96"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -61609,7 +61870,7 @@
       "source_location": "L94"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -61618,7 +61879,7 @@
       "source_location": "L95"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -61627,7 +61888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -61636,7 +61897,7 @@
       "source_location": "L14"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -61645,7 +61906,7 @@
       "source_location": "L10"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -61654,7 +61915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -61663,7 +61924,7 @@
       "source_location": "L98"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -61672,7 +61933,7 @@
       "source_location": "L33"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -61681,7 +61942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -61690,7 +61951,7 @@
       "source_location": "L85"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -61699,7 +61960,7 @@
       "source_location": "L31"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -61708,7 +61969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -61717,7 +61978,7 @@
       "source_location": "L12"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -61726,7 +61987,7 @@
       "source_location": "L21"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -61735,7 +61996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -61744,7 +62005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -61753,7 +62014,7 @@
       "source_location": "L5"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -61762,7 +62023,7 @@
       "source_location": "L12"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -61771,7 +62032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -61780,7 +62041,7 @@
       "source_location": "L14"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -61789,7 +62050,7 @@
       "source_location": "L10"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -61798,7 +62059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61807,7 +62068,7 @@
       "source_location": "L6"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -61816,7 +62077,7 @@
       "source_location": "L9"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -61825,7 +62086,7 @@
       "source_location": "L43"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -61834,40 +62095,13 @@
       "source_location": "L11"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
       "norm_label": "analyticsutils.ts",
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
-      "label": "staffCredentials.test.ts",
-      "norm_label": "staffcredentials.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
-      "label": "createStaffCredentialsMutationCtx()",
-      "norm_label": "createstaffcredentialsmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "staffcredentials_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L118"
     },
     {
       "community": 29,
@@ -62016,6 +62250,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
+      "label": "staffCredentials.test.ts",
+      "norm_label": "staffcredentials.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
+      "label": "createStaffCredentialsMutationCtx()",
+      "norm_label": "createstaffcredentialsmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "staffcredentials_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
       "norm_label": "staffprofiles.test.ts",
@@ -62023,7 +62284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -62032,7 +62293,7 @@
       "source_location": "L16"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -62041,7 +62302,7 @@
       "source_location": "L92"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -62050,7 +62311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -62059,7 +62320,7 @@
       "source_location": "L21"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -62068,7 +62329,7 @@
       "source_location": "L31"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -62077,7 +62338,7 @@
       "source_location": "L7"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -62086,7 +62347,7 @@
       "source_location": "L109"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -62095,7 +62356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -62104,7 +62365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -62113,7 +62374,7 @@
       "source_location": "L18"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -62122,7 +62383,7 @@
       "source_location": "L9"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -62131,7 +62392,7 @@
       "source_location": "L8"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -62140,7 +62401,7 @@
       "source_location": "L9"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -62149,7 +62410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -62158,7 +62419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -62167,7 +62428,7 @@
       "source_location": "L7"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -62176,7 +62437,7 @@
       "source_location": "L29"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -62185,7 +62446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -62194,7 +62455,7 @@
       "source_location": "L13"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -62203,7 +62464,7 @@
       "source_location": "L45"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -62212,7 +62473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -62221,7 +62482,7 @@
       "source_location": "L36"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -62230,7 +62491,7 @@
       "source_location": "L13"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -62239,7 +62500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -62248,7 +62509,7 @@
       "source_location": "L14"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -62257,309 +62518,291 @@
       "source_location": "L18"
     },
     {
-      "community": 299,
+      "community": 3,
       "file_type": "code",
-      "id": "appointments_buildserviceappointment",
-      "label": "buildServiceAppointment()",
-      "norm_label": "buildserviceappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "appointments_findoverlappingappointment",
-      "label": "findOverlappingAppointment()",
-      "norm_label": "findoverlappingappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
-      "label": "appointments.ts",
-      "norm_label": "appointments.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L1"
+      "id": "harness_behavior_asregexp",
+      "label": "asRegExp()",
+      "norm_label": "asregexp()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L299"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_builddiscoveryindex",
-      "label": "buildDiscoveryIndex()",
-      "norm_label": "builddiscoveryindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L386"
+      "id": "harness_behavior_collectlatencydiagnostics",
+      "label": "collectLatencyDiagnostics()",
+      "norm_label": "collectlatencydiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L779"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_buildgenerateddoc",
-      "label": "buildGeneratedDoc()",
-      "norm_label": "buildgenerateddoc()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L376"
+      "id": "harness_behavior_collectruntimesignaldiagnostics",
+      "label": "collectRuntimeSignalDiagnostics()",
+      "norm_label": "collectruntimesignaldiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L746"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_buildkeyfolderindex",
-      "label": "buildKeyFolderIndex()",
-      "norm_label": "buildkeyfolderindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L478"
+      "id": "harness_behavior_collectruntimesignalmatches",
+      "label": "collectRuntimeSignalMatches()",
+      "norm_label": "collectruntimesignalmatches()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L689"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_buildtestindex",
-      "label": "buildTestIndex()",
-      "norm_label": "buildtestindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L421"
+      "id": "harness_behavior_consumelines",
+      "label": "consumeLines()",
+      "norm_label": "consumelines()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L332"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_buildvalidationguide",
-      "label": "buildValidationGuide()",
-      "norm_label": "buildvalidationguide()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L511"
+      "id": "harness_behavior_escaperegexp",
+      "label": "escapeRegExp()",
+      "norm_label": "escaperegexp()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L307"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_buildvalidationmap",
-      "label": "buildValidationMap()",
-      "norm_label": "buildvalidationmap()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L553"
+      "id": "harness_behavior_formatassertiondiagnostics",
+      "label": "formatAssertionDiagnostics()",
+      "norm_label": "formatassertiondiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L827"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_collectfolderfacts",
-      "label": "collectFolderFacts()",
-      "norm_label": "collectfolderfacts()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L272"
+      "id": "harness_behavior_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L311"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_collectroutegroups",
-      "label": "collectRouteGroups()",
-      "norm_label": "collectroutegroups()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L126"
+      "id": "harness_behavior_getlinesforsource",
+      "label": "getLinesForSource()",
+      "norm_label": "getlinesforsource()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L319"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_collectservicedocumentedentries",
-      "label": "collectServiceDocumentedEntries()",
-      "norm_label": "collectservicedocumentedentries()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 3,
-      "file_type": "code",
-      "id": "harness_generate_collectserviceentrygroups",
-      "label": "collectServiceEntryGroups()",
-      "norm_label": "collectserviceentrygroups()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 3,
-      "file_type": "code",
-      "id": "harness_generate_collecttestfiles",
-      "label": "collectTestFiles()",
-      "norm_label": "collecttestfiles()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 3,
-      "file_type": "code",
-      "id": "harness_generate_collecttestsurfaceroots",
-      "label": "collectTestSurfaceRoots()",
-      "norm_label": "collecttestsurfaceroots()",
-      "source_file": "scripts/harness-generate.ts",
+      "id": "harness_behavior_harnessbehaviorphaseerror",
+      "label": "HarnessBehaviorPhaseError",
+      "norm_label": "harnessbehaviorphaseerror",
+      "source_file": "scripts/harness-behavior.ts",
       "source_location": "L226"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L32"
+      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L231"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_formatmarkdownlink",
-      "label": "formatMarkdownLink()",
-      "norm_label": "formatmarkdownlink()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L85"
+      "id": "harness_behavior_installplaywrightchromium",
+      "label": "installPlaywrightChromium()",
+      "norm_label": "installplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L901"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_formatscriptcommand",
-      "label": "formatScriptCommand()",
-      "norm_label": "formatscriptcommand()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L316"
+      "id": "harness_behavior_ismissingplaywrightchromiumerror",
+      "label": "isMissingPlaywrightChromiumError()",
+      "norm_label": "ismissingplaywrightchromiumerror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L879"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_formatvalidationcommandfordoc",
-      "label": "formatValidationCommandForDoc()",
-      "norm_label": "formatvalidationcommandfordoc()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L338"
+      "id": "harness_behavior_launchplaywrightchromium",
+      "label": "launchPlaywrightChromium()",
+      "norm_label": "launchplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L905"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_generateharnessdocs",
-      "label": "generateHarnessDocs()",
-      "norm_label": "generateharnessdocs()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L560"
+      "id": "harness_behavior_logphase",
+      "label": "logPhase()",
+      "norm_label": "logphase()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L285"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_headingfromsegment",
-      "label": "headingFromSegment()",
-      "norm_label": "headingfromsegment()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L89"
+      "id": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "label": "missingPlaywrightChromiumDiagnostic()",
+      "norm_label": "missingplaywrightchromiumdiagnostic()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L892"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_iswithinfolder",
-      "label": "isWithinFolder()",
-      "norm_label": "iswithinfolder()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L105"
+      "id": "harness_behavior_parseharnessbehaviorargs",
+      "label": "parseHarnessBehaviorArgs()",
+      "norm_label": "parseharnessbehaviorargs()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1302"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L24"
+      "id": "harness_behavior_printharnessbehaviorusage",
+      "label": "printHarnessBehaviorUsage()",
+      "norm_label": "printharnessbehaviorusage()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1374"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_readpackageconfig",
-      "label": "readPackageConfig()",
-      "norm_label": "readpackageconfig()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L63"
+      "id": "harness_behavior_resolveharnessbehaviorshell",
+      "label": "resolveHarnessBehaviorShell()",
+      "norm_label": "resolveharnessbehaviorshell()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L630"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_shouldskipgeneratedentry",
-      "label": "shouldSkipGeneratedEntry()",
-      "norm_label": "shouldskipgeneratedentry()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L28"
+      "id": "harness_behavior_runharnessbehaviorcli",
+      "label": "runHarnessBehaviorCli()",
+      "norm_label": "runharnessbehaviorcli()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1382"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_slugifytitle",
-      "label": "slugifyTitle()",
-      "norm_label": "slugifytitle()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L331"
+      "id": "harness_behavior_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1068"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_summarizechildren",
-      "label": "summarizeChildren()",
-      "norm_label": "summarizechildren()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L97"
+      "id": "harness_behavior_runhttpreadinesscheck",
+      "label": "runHttpReadinessCheck()",
+      "norm_label": "runhttpreadinesscheck()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L657"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_todocpath",
-      "label": "toDocPath()",
-      "norm_label": "todocpath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L81"
+      "id": "harness_behavior_runphasewithduration",
+      "label": "runPhaseWithDuration()",
+      "norm_label": "runphasewithduration()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1055"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_togeneratedvalidationmap",
-      "label": "toGeneratedValidationMap()",
-      "norm_label": "togeneratedvalidationmap()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L347"
+      "id": "harness_behavior_runplaywrightflow",
+      "label": "runPlaywrightFlow()",
+      "norm_label": "runplaywrightflow()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L942"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_topackagerelativegenerateddocpaths",
-      "label": "toPackageRelativeGeneratedDocPaths()",
-      "norm_label": "topackagerelativegenerateddocpaths()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L116"
+      "id": "harness_behavior_runshellcommand",
+      "label": "runShellCommand()",
+      "norm_label": "runshellcommand()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L608"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_torepovalidationpath",
-      "label": "toRepoValidationPath()",
-      "norm_label": "torepovalidationpath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L326"
+      "id": "harness_behavior_shouldautoinstallplaywrightchromium",
+      "label": "shouldAutoInstallPlaywrightChromium()",
+      "norm_label": "shouldautoinstallplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L888"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_walkfiles",
-      "label": "walkFiles()",
-      "norm_label": "walkfiles()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L41"
+      "id": "harness_behavior_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L293"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_generate_writegeneratedharnessdocs",
-      "label": "writeGeneratedHarnessDocs()",
-      "norm_label": "writegeneratedharnessdocs()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L590"
+      "id": "harness_behavior_spawncommand",
+      "label": "spawnCommand()",
+      "norm_label": "spawncommand()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L554"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "scripts_harness_generate_ts",
-      "label": "harness-generate.ts",
-      "norm_label": "harness-generate.ts",
-      "source_file": "scripts/harness-generate.ts",
+      "id": "harness_behavior_startprocess",
+      "label": "startProcess()",
+      "norm_label": "startprocess()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L420"
+    },
+    {
+      "community": 3,
+      "file_type": "code",
+      "id": "harness_behavior_stopprocess",
+      "label": "stopProcess()",
+      "norm_label": "stopprocess()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L398"
+    },
+    {
+      "community": 3,
+      "file_type": "code",
+      "id": "harness_behavior_wrapphaseerror",
+      "label": "wrapPhaseError()",
+      "norm_label": "wrapphaseerror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1044"
+    },
+    {
+      "community": 3,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_ts",
+      "label": "harness-behavior.ts",
+      "norm_label": "harness-behavior.ts",
+      "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1"
     },
     {
@@ -62700,6 +62943,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "appointments_buildserviceappointment",
+      "label": "buildServiceAppointment()",
+      "norm_label": "buildserviceappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "appointments_findoverlappingappointment",
+      "label": "findOverlappingAppointment()",
+      "norm_label": "findoverlappingappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
+      "label": "appointments.ts",
+      "norm_label": "appointments.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
       "norm_label": "servicecases.test.ts",
@@ -62707,7 +62977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -62716,7 +62986,7 @@
       "source_location": "L23"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -62725,7 +62995,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -62734,7 +63004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -62743,7 +63013,7 @@
       "source_location": "L20"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -62752,7 +63022,7 @@
       "source_location": "L16"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -62761,7 +63031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -62770,7 +63040,7 @@
       "source_location": "L12"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -62779,7 +63049,7 @@
       "source_location": "L7"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -62788,7 +63058,7 @@
       "source_location": "L25"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -62797,7 +63067,7 @@
       "source_location": "L21"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -62806,7 +63076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -62815,7 +63085,7 @@
       "source_location": "L7"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -62824,7 +63094,7 @@
       "source_location": "L14"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -62833,7 +63103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -62842,7 +63112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -62851,7 +63121,7 @@
       "source_location": "L45"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -62860,7 +63130,7 @@
       "source_location": "L37"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -62869,7 +63139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -62878,7 +63148,7 @@
       "source_location": "L10"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -62887,7 +63157,7 @@
       "source_location": "L44"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -62896,7 +63166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -62905,7 +63175,7 @@
       "source_location": "L84"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -62914,7 +63184,7 @@
       "source_location": "L100"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -62923,7 +63193,7 @@
       "source_location": "L5"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -62932,40 +63202,13 @@
       "source_location": "L25"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
       "norm_label": "currencyformatter.ts",
       "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_workflowtrace_ts",
-      "label": "workflowTrace.ts",
-      "norm_label": "workflowtrace.ts",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "workflowtrace_createworkflowtraceid",
-      "label": "createWorkflowTraceId()",
-      "norm_label": "createworkflowtraceid()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
-      "label": "normalizeWorkflowTraceLookupValue()",
-      "norm_label": "normalizeworkflowtracelookupvalue()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L25"
     },
     {
       "community": 31,
@@ -63105,6 +63348,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "workflowtrace_createworkflowtraceid",
+      "label": "createWorkflowTraceId()",
+      "norm_label": "createworkflowtraceid()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "label": "normalizeWorkflowTraceLookupValue()",
+      "norm_label": "normalizeworkflowtracelookupvalue()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
       "norm_label": "view.tsx",
@@ -63112,7 +63382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -63121,7 +63391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -63130,7 +63400,7 @@
       "source_location": "L4"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -63139,7 +63409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -63148,7 +63418,7 @@
       "source_location": "L19"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -63157,7 +63427,7 @@
       "source_location": "L5"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -63166,7 +63436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -63175,7 +63445,7 @@
       "source_location": "L19"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -63184,7 +63454,7 @@
       "source_location": "L11"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -63193,7 +63463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -63202,7 +63472,7 @@
       "source_location": "L22"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -63211,7 +63481,7 @@
       "source_location": "L8"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -63220,7 +63490,7 @@
       "source_location": "L21"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -63229,7 +63499,7 @@
       "source_location": "L13"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -63238,7 +63508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -63247,7 +63517,7 @@
       "source_location": "L100"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -63256,7 +63526,7 @@
       "source_location": "L10"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -63265,7 +63535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -63274,7 +63544,7 @@
       "source_location": "L100"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -63283,7 +63553,7 @@
       "source_location": "L10"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -63292,7 +63562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -63301,7 +63571,7 @@
       "source_location": "L15"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -63310,7 +63580,7 @@
       "source_location": "L39"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -63319,7 +63589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -63328,7 +63598,7 @@
       "source_location": "L3"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -63337,39 +63607,12 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
       "norm_label": "fadein.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "bestsellers_handleremovebestseller",
-      "label": "handleRemoveBestSeller()",
-      "norm_label": "handleremovebestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "bestsellers_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "label": "BestSellers.tsx",
-      "norm_label": "bestsellers.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1"
     },
     {
@@ -63510,6 +63753,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "bestsellers_handleremovebestseller",
+      "label": "handleRemoveBestSeller()",
+      "norm_label": "handleremovebestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "bestsellers_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
+      "label": "BestSellers.tsx",
+      "norm_label": "bestsellers.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
       "norm_label": "handlehighlighteditem()",
@@ -63517,7 +63787,7 @@
       "source_location": "L47"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -63526,7 +63796,7 @@
       "source_location": "L53"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -63535,7 +63805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -63544,7 +63814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -63553,7 +63823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -63562,7 +63832,7 @@
       "source_location": "L9"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -63571,7 +63841,7 @@
       "source_location": "L70"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -63580,7 +63850,7 @@
       "source_location": "L227"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -63589,7 +63859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -63598,7 +63868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -63607,7 +63877,7 @@
       "source_location": "L71"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -63616,7 +63886,7 @@
       "source_location": "L9"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -63625,7 +63895,7 @@
       "source_location": "L100"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -63634,7 +63904,7 @@
       "source_location": "L95"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -63643,7 +63913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
@@ -63652,7 +63922,7 @@
       "source_location": "L33"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -63661,7 +63931,7 @@
       "source_location": "L24"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -63670,7 +63940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -63679,7 +63949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -63688,7 +63958,7 @@
       "source_location": "L115"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -63697,7 +63967,7 @@
       "source_location": "L82"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -63706,7 +63976,7 @@
       "source_location": "L28"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -63715,7 +63985,7 @@
       "source_location": "L34"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -63724,7 +63994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -63733,7 +64003,7 @@
       "source_location": "L36"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -63742,40 +64012,13 @@
       "source_location": "L32"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
       "norm_label": "heldsessionslist.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "label": "POSSettingsView.tsx",
-      "norm_label": "possettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "possettingsview_fingerprintregistrationcard",
-      "label": "FingerprintRegistrationCard()",
-      "norm_label": "fingerprintregistrationcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "possettingsview_possettingsview",
-      "label": "POSSettingsView()",
-      "norm_label": "possettingsview()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L180"
     },
     {
       "community": 33,
@@ -63915,6 +64158,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
+      "label": "POSSettingsView.tsx",
+      "norm_label": "possettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "possettingsview_fingerprintregistrationcard",
+      "label": "FingerprintRegistrationCard()",
+      "norm_label": "fingerprintregistrationcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "possettingsview_possettingsview",
+      "label": "POSSettingsView()",
+      "norm_label": "possettingsview()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
       "norm_label": "transactionview.test.tsx",
@@ -63922,7 +64192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -63931,7 +64201,7 @@
       "source_location": "L151"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -63940,7 +64210,7 @@
       "source_location": "L338"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
@@ -63949,7 +64219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -63958,7 +64228,7 @@
       "source_location": "L8"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -63967,7 +64237,7 @@
       "source_location": "L18"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -63976,7 +64246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -63985,7 +64255,7 @@
       "source_location": "L65"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -63994,7 +64264,7 @@
       "source_location": "L20"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -64003,7 +64273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -64012,7 +64282,7 @@
       "source_location": "L16"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -64021,7 +64291,7 @@
       "source_location": "L60"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -64030,7 +64300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -64039,7 +64309,7 @@
       "source_location": "L45"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -64048,7 +64318,7 @@
       "source_location": "L19"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -64057,7 +64327,7 @@
       "source_location": "L128"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -64066,7 +64336,7 @@
       "source_location": "L40"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -64075,7 +64345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -64084,7 +64354,7 @@
       "source_location": "L24"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -64093,7 +64363,7 @@
       "source_location": "L20"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -64102,7 +64372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -64111,7 +64381,7 @@
       "source_location": "L25"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -64120,7 +64390,7 @@
       "source_location": "L17"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -64129,7 +64399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -64138,7 +64408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -64147,40 +64417,13 @@
       "source_location": "L59"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
       "source_location": "L50"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
-      "label": "ServiceIntakeView.tsx",
-      "norm_label": "serviceintakeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "serviceintakeview_serviceintakeview",
-      "label": "ServiceIntakeView()",
-      "norm_label": "serviceintakeview()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L225"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "serviceintakeview_serviceintakeviewcontent",
-      "label": "ServiceIntakeViewContent()",
-      "norm_label": "serviceintakeviewcontent()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L80"
     },
     {
       "community": 34,
@@ -64311,6 +64554,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
+      "label": "ServiceIntakeView.tsx",
+      "norm_label": "serviceintakeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "serviceintakeview_serviceintakeview",
+      "label": "ServiceIntakeView()",
+      "norm_label": "serviceintakeview()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L225"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "serviceintakeview_serviceintakeviewcontent",
+      "label": "ServiceIntakeViewContent()",
+      "norm_label": "serviceintakeviewcontent()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
       "norm_label": "staffmanagement.test.tsx",
@@ -64318,7 +64588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -64327,7 +64597,7 @@
       "source_location": "L163"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -64336,7 +64606,7 @@
       "source_location": "L107"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
@@ -64345,7 +64615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -64354,7 +64624,7 @@
       "source_location": "L162"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -64363,7 +64633,7 @@
       "source_location": "L109"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -64372,7 +64642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -64381,7 +64651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -64390,7 +64660,7 @@
       "source_location": "L3"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -64399,7 +64669,7 @@
       "source_location": "L9"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -64408,7 +64678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -64417,7 +64687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -64426,7 +64696,7 @@
       "source_location": "L3"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -64435,7 +64705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -64444,7 +64714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -64453,7 +64723,7 @@
       "source_location": "L3"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -64462,7 +64732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -64471,7 +64741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -64480,7 +64750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -64489,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -64498,7 +64768,7 @@
       "source_location": "L3"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -64507,7 +64777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -64516,7 +64786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -64525,7 +64795,7 @@
       "source_location": "L3"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -64534,7 +64804,7 @@
       "source_location": "L4"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -64543,39 +64813,12 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
       "norm_label": "notfound.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "feesview_handletoggleallfees",
-      "label": "handleToggleAllFees()",
-      "norm_label": "handletoggleallfees()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "feesview_handleupdatefees",
-      "label": "handleUpdateFees()",
-      "norm_label": "handleupdatefees()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
-      "label": "FeesView.tsx",
-      "norm_label": "feesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1"
     },
     {
@@ -64707,6 +64950,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "feesview_handletoggleallfees",
+      "label": "handleToggleAllFees()",
+      "norm_label": "handletoggleallfees()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "feesview_handleupdatefees",
+      "label": "handleUpdateFees()",
+      "norm_label": "handleupdatefees()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
+      "label": "FeesView.tsx",
+      "norm_label": "feesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
       "norm_label": "workflowtraceroutelink.tsx",
@@ -64714,7 +64984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -64723,7 +64993,7 @@
       "source_location": "L23"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -64732,7 +65002,7 @@
       "source_location": "L41"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -64741,7 +65011,7 @@
       "source_location": "L20"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -64750,7 +65020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -64759,7 +65029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -64768,7 +65038,7 @@
       "source_location": "L30"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -64777,7 +65047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -64786,7 +65056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -64795,7 +65065,7 @@
       "source_location": "L9"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -64804,7 +65074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -64813,7 +65083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -64822,7 +65092,7 @@
       "source_location": "L38"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -64831,7 +65101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -64840,7 +65110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -64849,7 +65119,7 @@
       "source_location": "L20"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -64858,7 +65128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -64867,7 +65137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -64876,7 +65146,7 @@
       "source_location": "L12"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -64885,7 +65155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -64894,7 +65164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -64903,7 +65173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -64912,7 +65182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -64921,7 +65191,7 @@
       "source_location": "L3"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -64930,7 +65200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -64939,40 +65209,13 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
       "norm_label": "toaster()",
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "spinner_spinner",
-      "label": "Spinner()",
-      "norm_label": "spinner()",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L3"
     },
     {
       "community": 36,
@@ -65103,6 +65346,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "spinner_spinner",
+      "label": "Spinner()",
+      "norm_label": "spinner()",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
       "norm_label": "activitysummarycards()",
@@ -65110,7 +65380,7 @@
       "source_location": "L44"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -65119,7 +65389,7 @@
       "source_location": "L19"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -65128,7 +65398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -65137,7 +65407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -65146,7 +65416,7 @@
       "source_location": "L159"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -65155,7 +65425,7 @@
       "source_location": "L195"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -65164,7 +65434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -65173,7 +65443,7 @@
       "source_location": "L22"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -65182,7 +65452,7 @@
       "source_location": "L45"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -65191,7 +65461,7 @@
       "source_location": "L24"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -65200,7 +65470,7 @@
       "source_location": "L38"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -65209,7 +65479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -65218,7 +65488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -65227,7 +65497,7 @@
       "source_location": "L23"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -65236,7 +65506,7 @@
       "source_location": "L51"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -65245,7 +65515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -65254,7 +65524,7 @@
       "source_location": "L54"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -65263,7 +65533,7 @@
       "source_location": "L282"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -65272,7 +65542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -65281,7 +65551,7 @@
       "source_location": "L12"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -65290,7 +65560,7 @@
       "source_location": "L37"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -65299,7 +65569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -65308,7 +65578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -65317,7 +65587,7 @@
       "source_location": "L4"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -65326,7 +65596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -65335,40 +65605,13 @@
       "source_location": "L9"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
       "norm_label": "usegetstores()",
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "label": "useGetOrganizations.ts",
-      "norm_label": "usegetorganizations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetactiveorganization",
-      "label": "useGetActiveOrganization()",
-      "norm_label": "usegetactiveorganization()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetorganizations",
-      "label": "useGetOrganizations()",
-      "norm_label": "usegetorganizations()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L31"
     },
     {
       "community": 37,
@@ -65499,6 +65742,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
+      "label": "useGetOrganizations.ts",
+      "norm_label": "usegetorganizations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetactiveorganization",
+      "label": "useGetActiveOrganization()",
+      "norm_label": "usegetactiveorganization()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetorganizations",
+      "label": "useGetOrganizations()",
+      "norm_label": "usegetorganizations()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
       "norm_label": "usegetproducts.ts",
@@ -65506,7 +65776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -65515,7 +65785,7 @@
       "source_location": "L5"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -65524,7 +65794,7 @@
       "source_location": "L31"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -65533,7 +65803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -65542,7 +65812,7 @@
       "source_location": "L19"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -65551,7 +65821,7 @@
       "source_location": "L33"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -65560,7 +65830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "presentcommandtoast_getapprovalguidance",
       "label": "getApprovalGuidance()",
@@ -65569,7 +65839,7 @@
       "source_location": "L9"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -65578,7 +65848,7 @@
       "source_location": "L16"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -65587,7 +65857,7 @@
       "source_location": "L7"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -65596,7 +65866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -65605,7 +65875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "bootstrapregister_test_drawer",
       "label": "drawer()",
@@ -65614,7 +65884,7 @@
       "source_location": "L9"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "bootstrapregister_test_state",
       "label": "state()",
@@ -65623,7 +65893,7 @@
       "source_location": "L23"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -65632,7 +65902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -65641,7 +65911,7 @@
       "source_location": "L3"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -65650,7 +65920,7 @@
       "source_location": "L10"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -65659,7 +65929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -65668,7 +65938,7 @@
       "source_location": "L18"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -65677,7 +65947,7 @@
       "source_location": "L60"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -65686,7 +65956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -65695,7 +65965,7 @@
       "source_location": "L31"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -65704,7 +65974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -65713,7 +65983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -65722,7 +65992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -65731,40 +66001,13 @@
       "source_location": "L28"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
       "norm_label": "findillegalconveximports()",
       "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
       "source_location": "L46"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "authed_authedcomponent",
-      "label": "AuthedComponent()",
-      "norm_label": "authedcomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "authed_layout",
-      "label": "Layout()",
-      "norm_label": "layout()",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "label": "_authed.tsx",
-      "norm_label": "_authed.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -65895,6 +66138,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "authed_authedcomponent",
+      "label": "AuthedComponent()",
+      "norm_label": "authedcomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "authed_layout",
+      "label": "Layout()",
+      "norm_label": "layout()",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_tsx",
+      "label": "_authed.tsx",
+      "norm_label": "_authed.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "actioncolorreview_stories_swatch",
       "label": "Swatch()",
       "norm_label": "swatch()",
@@ -65902,7 +66172,7 @@
       "source_location": "L179"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "actioncolorreview_stories_tokenscope",
       "label": "TokenScope()",
@@ -65911,7 +66181,7 @@
       "source_location": "L168"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
       "label": "ActionColorReview.stories.tsx",
@@ -65920,7 +66190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -65929,7 +66199,7 @@
       "source_location": "L127"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -65938,7 +66208,7 @@
       "source_location": "L106"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -65947,7 +66217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -65956,7 +66226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -65965,7 +66235,7 @@
       "source_location": "L49"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -65974,7 +66244,7 @@
       "source_location": "L62"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -65983,7 +66253,7 @@
       "source_location": "L66"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -65992,7 +66262,7 @@
       "source_location": "L20"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -66001,7 +66271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -66010,7 +66280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -66019,7 +66289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -66028,7 +66298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -66037,7 +66307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -66046,7 +66316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -66055,7 +66325,7 @@
       "source_location": "L16"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -66064,7 +66334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -66073,7 +66343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -66082,7 +66352,7 @@
       "source_location": "L23"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -66091,7 +66361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -66100,7 +66370,7 @@
       "source_location": "L23"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -66109,7 +66379,7 @@
       "source_location": "L24"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -66118,7 +66388,7 @@
       "source_location": "L32"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -66127,39 +66397,12 @@
       "source_location": "L3"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "color_getallcolors",
-      "label": "getAllColors()",
-      "norm_label": "getallcolors()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "color_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1"
     },
     {
@@ -66282,6 +66525,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "color_getallcolors",
+      "label": "getAllColors()",
+      "norm_label": "getallcolors()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "color_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
       "norm_label": "getallorganizations()",
@@ -66289,7 +66559,7 @@
       "source_location": "L6"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -66298,7 +66568,7 @@
       "source_location": "L18"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -66307,7 +66577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -66316,7 +66586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -66325,7 +66595,7 @@
       "source_location": "L60"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "postransaction_getpostransaction",
       "label": "getPosTransaction()",
@@ -66334,7 +66604,7 @@
       "source_location": "L62"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -66343,7 +66613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -66352,7 +66622,7 @@
       "source_location": "L3"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -66361,7 +66631,7 @@
       "source_location": "L5"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -66370,7 +66640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -66379,7 +66649,7 @@
       "source_location": "L18"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -66388,7 +66658,7 @@
       "source_location": "L23"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -66397,7 +66667,7 @@
       "source_location": "L22"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -66406,7 +66676,7 @@
       "source_location": "L55"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -66415,7 +66685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -66424,7 +66694,7 @@
       "source_location": "L77"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -66433,7 +66703,7 @@
       "source_location": "L11"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -66442,7 +66712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -66451,7 +66721,7 @@
       "source_location": "L11"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -66460,7 +66730,7 @@
       "source_location": "L22"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -66469,7 +66739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -66478,7 +66748,7 @@
       "source_location": "L110"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -66487,7 +66757,7 @@
       "source_location": "L89"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -66496,7 +66766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -66505,7 +66775,7 @@
       "source_location": "L4"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -66514,7 +66784,7 @@
       "source_location": "L24"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -66523,283 +66793,283 @@
       "source_location": "L1"
     },
     {
-      "community": 399,
+      "community": 4,
       "file_type": "code",
-      "id": "footer_enablecategories",
-      "label": "enableCategories()",
-      "norm_label": "enablecategories()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "footer_linkgroup",
-      "label": "LinkGroup()",
-      "norm_label": "linkgroup()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "label": "Footer.tsx",
-      "norm_label": "footer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L1"
+      "id": "harness_generate_builddiscoveryindex",
+      "label": "buildDiscoveryIndex()",
+      "norm_label": "builddiscoveryindex()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L386"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
-      "label": "storeConfigV2.ts",
-      "norm_label": "storeconfigv2.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L1"
+      "id": "harness_generate_buildgenerateddoc",
+      "label": "buildGeneratedDoc()",
+      "norm_label": "buildgenerateddoc()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L376"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_asarray",
-      "label": "asArray()",
-      "norm_label": "asarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_assignordelete",
-      "label": "assignOrDelete()",
-      "norm_label": "assignordelete()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L507"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "storeconfigv2_deepmerge",
-      "label": "deepMerge()",
-      "norm_label": "deepmerge()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "id": "harness_generate_buildkeyfolderindex",
+      "label": "buildKeyFolderIndex()",
+      "norm_label": "buildkeyfolderindex()",
+      "source_file": "scripts/harness-generate.ts",
       "source_location": "L478"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L101"
+      "id": "harness_generate_buildtestindex",
+      "label": "buildTestIndex()",
+      "norm_label": "buildtestindex()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L421"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "label": "getUnknownStoreConfigRootKeys()",
-      "norm_label": "getunknownstoreconfigrootkeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L591"
+      "id": "harness_generate_buildvalidationguide",
+      "label": "buildValidationGuide()",
+      "norm_label": "buildvalidationguide()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L511"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L178"
+      "id": "harness_generate_buildvalidationmap",
+      "label": "buildValidationMap()",
+      "norm_label": "buildvalidationmap()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L553"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_islegacyrootkey",
-      "label": "isLegacyRootKey()",
-      "norm_label": "islegacyrootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L623"
+      "id": "harness_generate_collectfolderfacts",
+      "label": "collectFolderFacts()",
+      "norm_label": "collectfolderfacts()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L272"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_isplainobject",
-      "label": "isPlainObject()",
-      "norm_label": "isplainobject()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L53"
+      "id": "harness_generate_collectroutegroups",
+      "label": "collectRouteGroups()",
+      "norm_label": "collectroutegroups()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L126"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_isstorecheckoutdisabled",
-      "label": "isStoreCheckoutDisabled()",
-      "norm_label": "isstorecheckoutdisabled()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L597"
+      "id": "harness_generate_collectservicedocumentedentries",
+      "label": "collectServiceDocumentedEntries()",
+      "norm_label": "collectservicedocumentedentries()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L152"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_isv2rootkey",
-      "label": "isV2RootKey()",
-      "norm_label": "isv2rootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L627"
+      "id": "harness_generate_collectserviceentrygroups",
+      "label": "collectServiceEntryGroups()",
+      "norm_label": "collectserviceentrygroups()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L177"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L191"
+      "id": "harness_generate_collecttestfiles",
+      "label": "collectTestFiles()",
+      "norm_label": "collecttestfiles()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L196"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L111"
+      "id": "harness_generate_collecttestsurfaceroots",
+      "label": "collectTestSurfaceRoots()",
+      "norm_label": "collecttestsurfaceroots()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L226"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L115"
+      "id": "harness_generate_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L32"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_mirrorlegacykeys",
-      "label": "mirrorLegacyKeys()",
-      "norm_label": "mirrorlegacykeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L520"
+      "id": "harness_generate_formatmarkdownlink",
+      "label": "formatMarkdownLink()",
+      "norm_label": "formatmarkdownlink()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L85"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L214"
+      "id": "harness_generate_formatscriptcommand",
+      "label": "formatScriptCommand()",
+      "norm_label": "formatscriptcommand()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L316"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_normalizestoreconfig",
-      "label": "normalizeStoreConfig()",
-      "norm_label": "normalizestoreconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L474"
+      "id": "harness_generate_formatvalidationcommandfordoc",
+      "label": "formatValidationCommandForDoc()",
+      "norm_label": "formatvalidationcommandfordoc()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L338"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L135"
+      "id": "harness_generate_generateharnessdocs",
+      "label": "generateHarnessDocs()",
+      "norm_label": "generateharnessdocs()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L560"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_patchv2config",
-      "label": "patchV2Config()",
-      "norm_label": "patchv2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L498"
+      "id": "harness_generate_headingfromsegment",
+      "label": "headingFromSegment()",
+      "norm_label": "headingfromsegment()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L89"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "label": "removeLegacyRootKeysFromConfig()",
-      "norm_label": "removelegacyrootkeysfromconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L606"
+      "id": "harness_generate_iswithinfolder",
+      "label": "isWithinFolder()",
+      "norm_label": "iswithinfolder()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L105"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "storeconfigv2_tov2config",
-      "label": "toV2Config()",
-      "norm_label": "tov2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L231"
+      "id": "harness_generate_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_readpackageconfig",
+      "label": "readPackageConfig()",
+      "norm_label": "readpackageconfig()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_shouldskipgeneratedentry",
+      "label": "shouldSkipGeneratedEntry()",
+      "norm_label": "shouldskipgeneratedentry()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_slugifytitle",
+      "label": "slugifyTitle()",
+      "norm_label": "slugifytitle()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L331"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_summarizechildren",
+      "label": "summarizeChildren()",
+      "norm_label": "summarizechildren()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_todocpath",
+      "label": "toDocPath()",
+      "norm_label": "todocpath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_togeneratedvalidationmap",
+      "label": "toGeneratedValidationMap()",
+      "norm_label": "togeneratedvalidationmap()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_topackagerelativegenerateddocpaths",
+      "label": "toPackageRelativeGeneratedDocPaths()",
+      "norm_label": "topackagerelativegenerateddocpaths()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_torepovalidationpath",
+      "label": "toRepoValidationPath()",
+      "norm_label": "torepovalidationpath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_walkfiles",
+      "label": "walkFiles()",
+      "norm_label": "walkfiles()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_generate_writegeneratedharnessdocs",
+      "label": "writeGeneratedHarnessDocs()",
+      "norm_label": "writegeneratedharnessdocs()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L590"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "scripts_harness_generate_ts",
+      "label": "harness-generate.ts",
+      "norm_label": "harness-generate.ts",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L1"
     },
     {
       "community": 40,
@@ -66921,6 +67191,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "footer_enablecategories",
+      "label": "enableCategories()",
+      "norm_label": "enablecategories()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "footer_linkgroup",
+      "label": "LinkGroup()",
+      "norm_label": "linkgroup()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
+      "label": "Footer.tsx",
+      "norm_label": "footer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
       "norm_label": "featuredproductssection()",
@@ -66928,7 +67225,7 @@
       "source_location": "L20"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -66937,7 +67234,7 @@
       "source_location": "L46"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -66946,7 +67243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -66955,7 +67252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -66964,7 +67261,7 @@
       "source_location": "L20"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -66973,7 +67270,7 @@
       "source_location": "L59"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -66982,7 +67279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -66991,7 +67288,7 @@
       "source_location": "L25"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -67000,7 +67297,7 @@
       "source_location": "L20"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -67009,7 +67306,7 @@
       "source_location": "L30"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -67018,7 +67315,7 @@
       "source_location": "L95"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -67027,7 +67324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -67036,7 +67333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -67045,7 +67342,7 @@
       "source_location": "L150"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -67054,7 +67351,7 @@
       "source_location": "L157"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -67063,7 +67360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -67072,7 +67369,7 @@
       "source_location": "L63"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -67081,7 +67378,7 @@
       "source_location": "L48"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -67090,7 +67387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -67099,7 +67396,7 @@
       "source_location": "L63"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -67108,7 +67405,7 @@
       "source_location": "L76"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -67117,7 +67414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -67126,7 +67423,7 @@
       "source_location": "L51"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -67135,7 +67432,7 @@
       "source_location": "L36"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -67144,7 +67441,7 @@
       "source_location": "L16"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -67153,40 +67450,13 @@
       "source_location": "L39"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
       "norm_label": "navigationbarprovider.tsx",
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L55"
     },
     {
       "community": 41,
@@ -67308,6 +67578,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
       "norm_label": "useproductdiscount.ts",
@@ -67315,7 +67612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -67324,7 +67621,7 @@
       "source_location": "L107"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -67333,7 +67630,7 @@
       "source_location": "L25"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -67342,7 +67639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -67351,7 +67648,7 @@
       "source_location": "L556"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -67360,7 +67657,7 @@
       "source_location": "L52"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -67369,7 +67666,7 @@
       "source_location": "L429"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -67378,7 +67675,7 @@
       "source_location": "L102"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -67387,7 +67684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -67396,7 +67693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -67405,7 +67702,7 @@
       "source_location": "L250"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -67414,7 +67711,7 @@
       "source_location": "L46"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -67423,7 +67720,7 @@
       "source_location": "L17"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -67432,7 +67729,7 @@
       "source_location": "L63"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -67441,7 +67738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -67450,7 +67747,7 @@
       "source_location": "L47"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -67459,7 +67756,7 @@
       "source_location": "L141"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -67468,7 +67765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -67477,7 +67774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -67486,7 +67783,7 @@
       "source_location": "L21"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -67495,7 +67792,7 @@
       "source_location": "L107"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "index_money",
       "label": "money()",
@@ -67504,7 +67801,7 @@
       "source_location": "L51"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "index_paymentlabel",
       "label": "paymentLabel()",
@@ -67513,7 +67810,7 @@
       "source_location": "L14"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
       "label": "index.tsx",
@@ -67522,7 +67819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -67531,7 +67828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -67540,40 +67837,13 @@
       "source_location": "L161"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
       "norm_label": "signupbeforeload()",
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "env_optionalnumberenv",
-      "label": "optionalNumberEnv()",
-      "norm_label": "optionalnumberenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "env_requireenv",
-      "label": "requireEnv()",
-      "norm_label": "requireenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -67695,6 +67965,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "env_optionalnumberenv",
+      "label": "optionalNumberEnv()",
+      "norm_label": "optionalnumberenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "env_requireenv",
+      "label": "requireEnv()",
+      "norm_label": "requireenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -67702,7 +67999,7 @@
       "source_location": "L16"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -67711,7 +68008,7 @@
       "source_location": "L10"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -67720,7 +68017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -67729,7 +68026,7 @@
       "source_location": "L17"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -67738,39 +68035,12 @@
       "source_location": "L11"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
       "norm_label": "harness-audit.test.ts",
       "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 422,
-      "file_type": "code",
-      "id": "harness_behavior_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 422,
-      "file_type": "code",
-      "id": "harness_behavior_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 422,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_test_ts",
-      "label": "harness-behavior.test.ts",
-      "norm_label": "harness-behavior.test.ts",
-      "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L1"
     },
     {
@@ -68847,101 +69117,101 @@
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L116"
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L283"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L318"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "gettransactions_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L55"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L46"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L16"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 460,
@@ -69126,100 +69396,100 @@
     {
       "community": 47,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L116"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L46"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L16"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
     },
     {
@@ -69405,101 +69675,101 @@
     {
       "community": 48,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 480,
@@ -69684,101 +69954,101 @@
     {
       "community": 49,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 490,
@@ -69963,353 +70233,353 @@
     {
       "community": 5,
       "file_type": "code",
-      "id": "harness_scorecard_builddocumentationstatus",
-      "label": "buildDocumentationStatus()",
-      "norm_label": "builddocumentationstatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_buildemptyhistorymetric",
-      "label": "buildEmptyHistoryMetric()",
-      "norm_label": "buildemptyhistorymetric()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_buildgraphifystatus",
-      "label": "buildGraphifyStatus()",
-      "norm_label": "buildgraphifystatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_buildinferentialsummarynote",
-      "label": "buildInferentialSummaryNote()",
-      "norm_label": "buildinferentialsummarynote()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L315"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L327"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_collectharnessscorecard",
-      "label": "collectHarnessScorecard()",
-      "norm_label": "collectharnessscorecard()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L752"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_countmissingsnippets",
-      "label": "countMissingSnippets()",
-      "norm_label": "countmissingsnippets()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_createfilesystem",
-      "label": "createFileSystem()",
-      "norm_label": "createfilesystem()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_extractscenarionames",
-      "label": "extractScenarioNames()",
-      "norm_label": "extractscenarionames()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_extractscenariosection",
-      "label": "extractScenarioSection()",
-      "norm_label": "extractscenariosection()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_getdocumentedscenarioexpectations",
-      "label": "getDocumentedScenarioExpectations()",
-      "norm_label": "getdocumentedscenarioexpectations()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L470"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L389"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectappdocumentation",
-      "label": "inspectAppDocumentation()",
-      "norm_label": "inspectappdocumentation()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L406"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectgraphifyartifacts",
-      "label": "inspectGraphifyArtifacts()",
-      "norm_label": "inspectgraphifyartifacts()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L724"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectinferentialartifact",
-      "label": "inspectInferentialArtifact()",
-      "norm_label": "inspectinferentialartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L483"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectinferentialhistory",
-      "label": "inspectInferentialHistory()",
-      "norm_label": "inspectinferentialhistory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L579"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectruntimetrendartifact",
-      "label": "inspectRuntimeTrendArtifact()",
-      "norm_label": "inspectruntimetrendartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L631"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectruntimetrendhistory",
-      "label": "inspectRuntimeTrendHistory()",
-      "norm_label": "inspectruntimetrendhistory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L674"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_ishealthyinferentialstatus",
-      "label": "isHealthyInferentialStatus()",
-      "norm_label": "ishealthyinferentialstatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_isruntimescenarioname",
-      "label": "isRuntimeScenarioName()",
-      "norm_label": "isruntimescenarioname()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_listdirectory",
-      "label": "listDirectory()",
-      "norm_label": "listdirectory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_readtextfile",
-      "label": "readTextFile()",
-      "norm_label": "readtextfile()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L220"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_runharnessscorecard",
-      "label": "runHarnessScorecard()",
-      "norm_label": "runharnessscorecard()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L842"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "harness_scorecard_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "scripts_harness_scorecard_ts",
-      "label": "harness-scorecard.ts",
-      "norm_label": "harness-scorecard.ts",
-      "source_file": "scripts/harness-scorecard.ts",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
+      "label": "storeConfigV2.ts",
+      "norm_label": "storeconfigv2.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1"
     },
     {
-      "community": 50,
+      "community": 5,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
+      "id": "storeconfigv2_asarray",
+      "label": "asArray()",
+      "norm_label": "asarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L77"
     },
     {
-      "community": 50,
+      "community": 5,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "storeconfigv2_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L69"
     },
     {
-      "community": 50,
+      "community": 5,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "storeconfigv2_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L165"
     },
     {
-      "community": 50,
+      "community": 5,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "storeconfigv2_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61"
     },
     {
-      "community": 50,
+      "community": 5,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "storeconfigv2_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_assignordelete",
+      "label": "assignOrDelete()",
+      "norm_label": "assignordelete()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L507"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_deepmerge",
+      "label": "deepMerge()",
+      "norm_label": "deepmerge()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L478"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
+      "label": "getUnknownStoreConfigRootKeys()",
+      "norm_label": "getunknownstoreconfigrootkeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_islegacyrootkey",
+      "label": "isLegacyRootKey()",
+      "norm_label": "islegacyrootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L623"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_isplainobject",
+      "label": "isPlainObject()",
+      "norm_label": "isplainobject()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_isstorecheckoutdisabled",
+      "label": "isStoreCheckoutDisabled()",
+      "norm_label": "isstorecheckoutdisabled()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L597"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_isv2rootkey",
+      "label": "isV2RootKey()",
+      "norm_label": "isv2rootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L627"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_mirrorlegacykeys",
+      "label": "mirrorLegacyKeys()",
+      "norm_label": "mirrorlegacykeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L520"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_normalizestoreconfig",
+      "label": "normalizeStoreConfig()",
+      "norm_label": "normalizestoreconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L474"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_patchv2config",
+      "label": "patchV2Config()",
+      "norm_label": "patchv2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L498"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
+      "label": "removeLegacyRootKeysFromConfig()",
+      "norm_label": "removelegacyrootkeysfromconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L606"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "storeconfigv2_tov2config",
+      "label": "toV2Config()",
+      "norm_label": "tov2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L231"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 500,
@@ -72933,245 +73203,254 @@
     {
       "community": 6,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1"
+      "id": "harness_scorecard_builddocumentationstatus",
+      "label": "buildDocumentationStatus()",
+      "norm_label": "builddocumentationstatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L275"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_applycloseoutcommandresult",
-      "label": "applyCloseoutCommandResult()",
-      "norm_label": "applycloseoutcommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L505"
+      "id": "harness_scorecard_buildemptyhistorymetric",
+      "label": "buildEmptyHistoryMetric()",
+      "norm_label": "buildemptyhistorymetric()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L569"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L495"
+      "id": "harness_scorecard_buildgraphifystatus",
+      "label": "buildGraphifyStatus()",
+      "norm_label": "buildgraphifystatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L299"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_builddepositsubmissionkey",
-      "label": "buildDepositSubmissionKey()",
-      "norm_label": "builddepositsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L273"
+      "id": "harness_scorecard_buildinferentialsummarynote",
+      "label": "buildInferentialSummaryNote()",
+      "norm_label": "buildinferentialsummarynote()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L315"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2054"
+      "id": "harness_scorecard_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L327"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L277"
+      "id": "harness_scorecard_collectharnessscorecard",
+      "label": "collectHarnessScorecard()",
+      "norm_label": "collectharnessscorecard()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L752"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L326"
+      "id": "harness_scorecard_countmissingsnippets",
+      "label": "countMissingSnippets()",
+      "norm_label": "countmissingsnippets()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L268"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatregisterheadername",
-      "label": "formatRegisterHeaderName()",
-      "norm_label": "formatregisterheadername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L339"
+      "id": "harness_scorecard_createfilesystem",
+      "label": "createFileSystem()",
+      "norm_label": "createfilesystem()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L224"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L334"
+      "id": "harness_scorecard_extractscenarionames",
+      "label": "extractScenarioNames()",
+      "norm_label": "extractscenarionames()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L255"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatsessioncode",
-      "label": "formatSessionCode()",
-      "norm_label": "formatsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L353"
+      "id": "harness_scorecard_extractscenariosection",
+      "label": "extractScenarioSection()",
+      "norm_label": "extractscenariosection()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L233"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L296"
+      "id": "harness_scorecard_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L203"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatstoredamountforinput",
-      "label": "formatStoredAmountForInput()",
-      "norm_label": "formatstoredamountforinput()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L285"
+      "id": "harness_scorecard_getdocumentedscenarioexpectations",
+      "label": "getDocumentedScenarioExpectations()",
+      "norm_label": "getdocumentedscenarioexpectations()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L470"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L289"
+      "id": "harness_scorecard_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L389"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_getnumericeventmetadata",
-      "label": "getNumericEventMetadata()",
-      "norm_label": "getnumericeventmetadata()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "id": "harness_scorecard_inspectappdocumentation",
+      "label": "inspectAppDocumentation()",
+      "norm_label": "inspectappdocumentation()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L406"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectgraphifyartifacts",
+      "label": "inspectGraphifyArtifacts()",
+      "norm_label": "inspectgraphifyartifacts()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectinferentialartifact",
+      "label": "inspectInferentialArtifact()",
+      "norm_label": "inspectinferentialartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L483"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectinferentialhistory",
+      "label": "inspectInferentialHistory()",
+      "norm_label": "inspectinferentialhistory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L579"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectruntimetrendartifact",
+      "label": "inspectRuntimeTrendArtifact()",
+      "norm_label": "inspectruntimetrendartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L631"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectruntimetrendhistory",
+      "label": "inspectRuntimeTrendHistory()",
+      "norm_label": "inspectruntimetrendhistory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L674"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "harness_scorecard_ishealthyinferentialstatus",
+      "label": "isHealthyInferentialStatus()",
+      "norm_label": "ishealthyinferentialstatus()",
+      "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L311"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L365"
+      "id": "harness_scorecard_isruntimescenarioname",
+      "label": "isRuntimeScenarioName()",
+      "norm_label": "isruntimescenarioname()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L199"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L357"
+      "id": "harness_scorecard_listdirectory",
+      "label": "listDirectory()",
+      "norm_label": "listdirectory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L216"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handleauthenticatedcloseoutstaff",
-      "label": "handleAuthenticatedCloseoutStaff()",
-      "norm_label": "handleauthenticatedcloseoutstaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L659"
+      "id": "harness_scorecard_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L189"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handleopeningfloatapprovalapproved",
-      "label": "handleOpeningFloatApprovalApproved()",
-      "norm_label": "handleopeningfloatapprovalapproved()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L755"
+      "id": "harness_scorecard_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L212"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlerecorddeposit",
-      "label": "handleRecordDeposit()",
-      "norm_label": "handlerecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L517"
+      "id": "harness_scorecard_readtextfile",
+      "label": "readTextFile()",
+      "norm_label": "readtextfile()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L220"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlereviewcloseout",
-      "label": "handleReviewCloseout()",
-      "norm_label": "handlereviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L586"
+      "id": "harness_scorecard_runharnessscorecard",
+      "label": "runHarnessScorecard()",
+      "norm_label": "runharnessscorecard()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L842"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlesubmitcloseout",
-      "label": "handleSubmitCloseout()",
-      "norm_label": "handlesubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L560"
+      "id": "harness_scorecard_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L193"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlesubmitopeningfloatcorrection",
-      "label": "handleSubmitOpeningFloatCorrection()",
-      "norm_label": "handlesubmitopeningfloatcorrection()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L603"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "registersessionview_iscloseoutrejectionevent",
-      "label": "isCloseoutRejectionEvent()",
-      "norm_label": "iscloseoutrejectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L300"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "registersessionview_isopeningfloatcorrectionevent",
-      "label": "isOpeningFloatCorrectionEvent()",
-      "norm_label": "isopeningfloatcorrectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L304"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "registersessionview_isregistersessioncorrectionevent",
-      "label": "isRegisterSessionCorrectionEvent()",
-      "norm_label": "isregistersessioncorrectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "registersessionview_runopeningfloatcorrection",
-      "label": "runOpeningFloatCorrection()",
-      "norm_label": "runopeningfloatcorrection()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L709"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L268"
+      "id": "scripts_harness_scorecard_ts",
+      "label": "harness-scorecard.ts",
+      "norm_label": "harness-scorecard.ts",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
@@ -75795,236 +76074,245 @@
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_asregexp",
-      "label": "asRegExp()",
-      "norm_label": "asregexp()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L295"
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_collectlatencydiagnostics",
-      "label": "collectLatencyDiagnostics()",
-      "norm_label": "collectlatencydiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L753"
+      "id": "registersessionview_applycloseoutcommandresult",
+      "label": "applyCloseoutCommandResult()",
+      "norm_label": "applycloseoutcommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L505"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_collectruntimesignaldiagnostics",
-      "label": "collectRuntimeSignalDiagnostics()",
-      "norm_label": "collectruntimesignaldiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L720"
+      "id": "registersessionview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L495"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_collectruntimesignalmatches",
-      "label": "collectRuntimeSignalMatches()",
-      "norm_label": "collectruntimesignalmatches()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L663"
+      "id": "registersessionview_builddepositsubmissionkey",
+      "label": "buildDepositSubmissionKey()",
+      "norm_label": "builddepositsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L273"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_consumelines",
-      "label": "consumeLines()",
-      "norm_label": "consumelines()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L328"
+      "id": "registersessionview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L2054"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_escaperegexp",
-      "label": "escapeRegExp()",
-      "norm_label": "escaperegexp()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L303"
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L277"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_formatassertiondiagnostics",
-      "label": "formatAssertionDiagnostics()",
-      "norm_label": "formatassertiondiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L801"
+      "id": "registersessionview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L326"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L307"
+      "id": "registersessionview_formatregisterheadername",
+      "label": "formatRegisterHeaderName()",
+      "norm_label": "formatregisterheadername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L339"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_getlinesforsource",
-      "label": "getLinesForSource()",
-      "norm_label": "getlinesforsource()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L315"
+      "id": "registersessionview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L334"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_harnessbehaviorphaseerror",
-      "label": "HarnessBehaviorPhaseError",
-      "norm_label": "harnessbehaviorphaseerror",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L222"
+      "id": "registersessionview_formatsessioncode",
+      "label": "formatSessionCode()",
+      "norm_label": "formatsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L353"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L227"
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L296"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_logphase",
-      "label": "logPhase()",
-      "norm_label": "logphase()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L281"
+      "id": "registersessionview_formatstoredamountforinput",
+      "label": "formatStoredAmountForInput()",
+      "norm_label": "formatstoredamountforinput()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L285"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_parseharnessbehaviorargs",
-      "label": "parseHarnessBehaviorArgs()",
-      "norm_label": "parseharnessbehaviorargs()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1215"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_printharnessbehaviorusage",
-      "label": "printHarnessBehaviorUsage()",
-      "norm_label": "printharnessbehaviorusage()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1287"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_resolveharnessbehaviorshell",
-      "label": "resolveHarnessBehaviorShell()",
-      "norm_label": "resolveharnessbehaviorshell()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L604"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_runharnessbehaviorcli",
-      "label": "runHarnessBehaviorCli()",
-      "norm_label": "runharnessbehaviorcli()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1295"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L981"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_runhttpreadinesscheck",
-      "label": "runHttpReadinessCheck()",
-      "norm_label": "runhttpreadinesscheck()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L631"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_runphasewithduration",
-      "label": "runPhaseWithDuration()",
-      "norm_label": "runphasewithduration()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L968"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_runplaywrightflow",
-      "label": "runPlaywrightFlow()",
-      "norm_label": "runplaywrightflow()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L853"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_behavior_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "scripts/harness-behavior.ts",
+      "id": "registersessionview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
       "source_location": "L289"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_spawncommand",
-      "label": "spawnCommand()",
-      "norm_label": "spawncommand()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L550"
+      "id": "registersessionview_getnumericeventmetadata",
+      "label": "getNumericEventMetadata()",
+      "norm_label": "getnumericeventmetadata()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L311"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_startprocess",
-      "label": "startProcess()",
-      "norm_label": "startprocess()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L416"
+      "id": "registersessionview_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L365"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_stopprocess",
-      "label": "stopProcess()",
-      "norm_label": "stopprocess()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L394"
+      "id": "registersessionview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L357"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_behavior_wrapphaseerror",
-      "label": "wrapPhaseError()",
-      "norm_label": "wrapphaseerror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L957"
+      "id": "registersessionview_handleauthenticatedcloseoutstaff",
+      "label": "handleAuthenticatedCloseoutStaff()",
+      "norm_label": "handleauthenticatedcloseoutstaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L659"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "scripts_harness_behavior_ts",
-      "label": "harness-behavior.ts",
-      "norm_label": "harness-behavior.ts",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1"
+      "id": "registersessionview_handleopeningfloatapprovalapproved",
+      "label": "handleOpeningFloatApprovalApproved()",
+      "norm_label": "handleopeningfloatapprovalapproved()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L755"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_handlerecorddeposit",
+      "label": "handleRecordDeposit()",
+      "norm_label": "handlerecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L517"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_handlereviewcloseout",
+      "label": "handleReviewCloseout()",
+      "norm_label": "handlereviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L586"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_handlesubmitcloseout",
+      "label": "handleSubmitCloseout()",
+      "norm_label": "handlesubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L560"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_handlesubmitopeningfloatcorrection",
+      "label": "handleSubmitOpeningFloatCorrection()",
+      "norm_label": "handlesubmitopeningfloatcorrection()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L603"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_iscloseoutrejectionevent",
+      "label": "isCloseoutRejectionEvent()",
+      "norm_label": "iscloseoutrejectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L300"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_isopeningfloatcorrectionevent",
+      "label": "isOpeningFloatCorrectionEvent()",
+      "norm_label": "isopeningfloatcorrectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L304"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_isregistersessioncorrectionevent",
+      "label": "isRegisterSessionCorrectionEvent()",
+      "norm_label": "isregistersessioncorrectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L320"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_runopeningfloatcorrection",
+      "label": "runOpeningFloatCorrection()",
+      "norm_label": "runopeningfloatcorrection()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L709"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L268"
     },
     {
       "community": 70,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1546
-- Graph nodes: 4123
-- Graph edges: 3749
+- Graph nodes: 4131
+- Graph edges: 3767
 - Communities: 1474
 
 ## Graph Hotspots
@@ -17,10 +17,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `harness-check.ts` (32 edges, Community 2) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
-- `harness-generate.ts` (30 edges, Community 3) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
-- `harness-scorecard.ts` (27 edges, Community 5) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
-- `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `RegisterSessionView.tsx` (26 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `harness-behavior.ts` (30 edges, Community 3) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
+- `harness-generate.ts` (30 edges, Community 4) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
+- `harness-scorecard.ts` (27 edges, Community 6) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
+- `storeConfigV2.ts` (27 edges, Community 5) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `RegisterSessionView.tsx` (26 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `storeConfigV2.ts` (27 edges, Community 5) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `RegisterSessionView.tsx` (26 edges, Community 7) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `sessionCommands.ts` (20 edges, Community 11) - [`packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts)
 - `expenseSessionCommands.ts` (19 edges, Community 12) - [`packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts)
 - `ProductStock.tsx` (19 edges, Community 13) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)

--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -8,6 +8,7 @@ import {
   parseHarnessBehaviorArgs,
   resolveHarnessBehaviorShell,
   runHarnessBehaviorScenario,
+  runPlaywrightFlow,
 } from "./harness-behavior";
 
 const tempRoots: string[] = [];
@@ -31,6 +32,43 @@ afterEach(async () => {
     )
   );
 });
+
+const missingChromiumError = [
+  "browserType.launch: Executable doesn't exist at /Users/example/Library/Caches/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-mac-arm64/chrome-headless-shell",
+  "Looks like Playwright was just installed or updated.",
+  "Please run the following command to download new browsers:",
+  "",
+  "    npx playwright install",
+].join("\n");
+
+function createPlaywrightModule(launch: () => Promise<unknown>) {
+  return {
+    chromium: {
+      launch,
+    },
+  };
+}
+
+function createBrowser() {
+  const page = {
+    goto: async () => {},
+    on: () => {},
+    getByRole: () => ({
+      click: async () => {},
+    }),
+    waitForSelector: async () => {},
+    textContent: async () => null,
+    video: () => null,
+  };
+
+  return {
+    newContext: async () => ({
+      close: async () => {},
+      newPage: async () => page,
+    }),
+    close: async () => {},
+  };
+}
 
 describe("runHarnessBehaviorScenario", () => {
   it("runs boot/readiness/browser/runtime/assertion/cleanup and captures runtime signals", async () => {
@@ -386,6 +424,77 @@ describe("runHarnessBehaviorScenario", () => {
         ]),
       },
     });
+  });
+});
+
+describe("runPlaywrightFlow", () => {
+  it("installs Chromium once and retries when local Playwright browser binaries are missing", async () => {
+    let launchCount = 0;
+    let installCount = 0;
+    const browser = createBrowser();
+
+    const result = await runPlaywrightFlow({
+      url: "http://127.0.0.1:4173",
+      playwrightModule: createPlaywrightModule(async () => {
+        launchCount += 1;
+        if (launchCount === 1) {
+          throw new Error(missingChromiumError);
+        }
+        return browser;
+      }),
+      env: {},
+      installChromium: async () => {
+        installCount += 1;
+      },
+      steps: async () => ({ loaded: true }),
+    });
+
+    expect(result.stepResult).toEqual({ loaded: true });
+    expect(launchCount).toBe(2);
+    expect(installCount).toBe(1);
+  });
+
+  it("does not auto-install missing Chromium in CI", async () => {
+    let installCount = 0;
+
+    await expect(
+      runPlaywrightFlow({
+        url: "http://127.0.0.1:4173",
+        playwrightModule: createPlaywrightModule(async () => {
+          throw new Error(missingChromiumError);
+        }),
+        env: { CI: "true" },
+        installChromium: async () => {
+          installCount += 1;
+        },
+        steps: async () => ({}),
+      })
+    ).rejects.toThrow("Run `bunx playwright install chromium` and rerun the blocked validation.");
+
+    expect(installCount).toBe(0);
+  });
+
+  it("still fails genuine browser launch failures after Chromium install", async () => {
+    let launchCount = 0;
+    const launchFailure = new Error("browser process crashed after launch");
+
+    await expect(
+      runPlaywrightFlow({
+        url: "http://127.0.0.1:4173",
+        playwrightModule: createPlaywrightModule(async () => {
+          launchCount += 1;
+          if (launchCount === 1) {
+            throw new Error(missingChromiumError);
+          }
+          throw launchFailure;
+        }),
+        env: {},
+        installChromium: async () => {},
+        steps: async () => ({}),
+      })
+    ).rejects.toThrow("browser process crashed after launch");
+
+    expect(launchCount).toBe(2);
   });
 });
 

--- a/scripts/harness-behavior.ts
+++ b/scripts/harness-behavior.ts
@@ -9,6 +9,7 @@ const DEFAULT_READY_TIMEOUT_MS = 30_000;
 const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
 const DEFAULT_HTTP_INTERVAL_MS = 250;
 const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+const PLAYWRIGHT_CHROMIUM_REPAIR_COMMAND = "bunx playwright install chromium";
 
 type LineSource = "stdout" | "stderr";
 
@@ -83,6 +84,9 @@ export type HarnessBehaviorPlaywrightFlowOptions<TStepResult> = {
     width: number;
     height: number;
   };
+  env?: NodeJS.ProcessEnv;
+  playwrightModule?: HarnessBehaviorPlaywrightModule;
+  installChromium?: () => Promise<void>;
   steps: (context: { page: HarnessBehaviorPlaywrightPage }) => Promise<TStepResult>;
 };
 
@@ -601,6 +605,28 @@ function spawnCommand(
   };
 }
 
+async function runShellCommand(command: string, cwd: string) {
+  const subprocess = spawnCommand(command, cwd, undefined);
+  const outputLines: ProcessOutputLine[] = [];
+  const appendOutputLine = (source: LineSource, line: string) => {
+    outputLines.push({ source, line });
+  };
+
+  const stdoutPump = consumeLines(subprocess.stdout, "stdout", appendOutputLine);
+  const stderrPump = consumeLines(subprocess.stderr, "stderr", appendOutputLine);
+  const exitCode = await subprocess.exited;
+  await Promise.all([stdoutPump, stderrPump]);
+
+  if (exitCode !== 0) {
+    const output = outputLines.map((entry) => entry.line).join("\n").trim();
+    throw new Error(
+      output
+        ? `Command failed (${exitCode}): ${command}\n${output}`
+        : `Command failed (${exitCode}): ${command}`
+    );
+  }
+}
+
 export function resolveHarnessBehaviorShell(options: {
   env?: NodeJS.ProcessEnv;
   fileExists?: (filePath: string) => boolean;
@@ -850,6 +876,69 @@ type HarnessBehaviorPlaywrightModule = {
   };
 };
 
+function isMissingPlaywrightChromiumError(error: unknown) {
+  const message = formatError(error);
+  return (
+    message.includes("Executable doesn't exist") &&
+    message.includes("ms-playwright") &&
+    message.includes("chromium")
+  );
+}
+
+function shouldAutoInstallPlaywrightChromium(env: NodeJS.ProcessEnv) {
+  return env.CI !== "true";
+}
+
+function missingPlaywrightChromiumDiagnostic(error: unknown) {
+  return [
+    formatError(error),
+    "",
+    "Athena harness repair: Playwright Chromium is not installed for this machine.",
+    `Run \`${PLAYWRIGHT_CHROMIUM_REPAIR_COMMAND}\` and rerun the blocked validation.`,
+  ].join("\n");
+}
+
+async function installPlaywrightChromium() {
+  await runShellCommand(PLAYWRIGHT_CHROMIUM_REPAIR_COMMAND, process.cwd());
+}
+
+async function launchPlaywrightChromium(
+  playwright: HarnessBehaviorPlaywrightModule,
+  options: HarnessBehaviorPlaywrightFlowOptions<unknown>
+) {
+  const launchOptions = {
+    headless: options.headless ?? true,
+  };
+
+  try {
+    return await playwright.chromium.launch(launchOptions);
+  } catch (error) {
+    if (!isMissingPlaywrightChromiumError(error)) {
+      throw error;
+    }
+
+    const env = options.env ?? process.env;
+    if (!shouldAutoInstallPlaywrightChromium(env)) {
+      throw new Error(missingPlaywrightChromiumDiagnostic(error));
+    }
+
+    const installChromium = options.installChromium ?? installPlaywrightChromium;
+    try {
+      await installChromium();
+    } catch (installError) {
+      throw new Error(
+        [
+          missingPlaywrightChromiumDiagnostic(error),
+          "",
+          `Automatic repair failed: ${formatError(installError)}`,
+        ].join("\n")
+      );
+    }
+
+    return playwright.chromium.launch(launchOptions);
+  }
+}
+
 export async function runPlaywrightFlow<TStepResult>(
   options: HarnessBehaviorPlaywrightFlowOptions<TStepResult>
 ) {
@@ -868,9 +957,9 @@ export async function runPlaywrightFlow<TStepResult>(
   let flowError: unknown = null;
 
   try {
-    const playwright = (await import(
-      "@playwright/test"
-    )) as unknown as HarnessBehaviorPlaywrightModule;
+    const playwright =
+      options.playwrightModule ??
+      ((await import("@playwright/test")) as unknown as HarnessBehaviorPlaywrightModule);
 
     let contextRecordVideoOptions:
       | {
@@ -897,9 +986,7 @@ export async function runPlaywrightFlow<TStepResult>(
       };
     }
 
-    browser = await playwright.chromium.launch({
-      headless: options.headless ?? true,
-    });
+    browser = await launchPlaywrightChromium(playwright, options);
     browserContext = await browser.newContext({
       recordVideo: contextRecordVideoOptions,
     });


### PR DESCRIPTION
## Summary
- Auto-install Playwright Chromium once for local harness behavior runs when the browser cache is missing
- Keep CI deterministic by emitting the repo repair command instead of auto-installing under CI
- Add focused tests for local repair, CI diagnostics, and real post-repair launch failures
- Refresh graphify artifacts after harness code changes

## Why
Fresh worktrees and agent machines can have dependencies installed while the Playwright browser cache is empty. That made `bun run pr:athena` fail with Playwright generic guidance instead of following the repo-approved recovery path.

## Validation
- `bun test scripts/harness-behavior.test.ts --test-name-pattern "runPlaywrightFlow"`
- `bun run harness:behavior --scenario athena-admin-shell-boot`
- `bun run harness:test`
- `bun run graphify:rebuild`
- `bun run harness:review --base origin/main`
- `bun run graphify:check`
- `git diff --check`
- `bun run pr:athena`
- pre-push hook passed while pushing branch

Linear: https://linear.app/v26-labs/issue/V26-433/explore-harness-auto-install-for-missing-playwright-browser-binaries