### PR TITLE
Add manager approval fast path

### DIFF
--- a/docs/plans/2026-05-02-002-feat-manager-approval-fast-path-plan.md
+++ b/docs/plans/2026-05-02-002-feat-manager-approval-fast-path-plan.md
@@ -1,0 +1,264 @@
+---
+title: "feat: Add manager approval fast path"
+type: feature
+status: active
+date: 2026-05-02
+---
+
+# feat: Add manager approval fast path
+
+## Summary
+
+Add a shared one-modal manager approval fast path on top of the first-class command approval foundation. Transaction payment-method correction, POS register closeout, and cash-controls register-session closeout should all run the command first, let the server return the approval requirement, and then use the same fresh staff credential submission to mint an inline manager proof and retry when the returned requirement supports `inline_manager_proof`.
+
+---
+
+## Problem Frame
+
+The approval foundation now gives Athena the right boundary: domain commands decide whether an action requires approval, return a shared `approval_required` result, and consume server-validated approval proofs on retry. The remaining UX gap is that workflows with an initial staff-auth modal can still ask a manager to authenticate twice: once to begin the action, and again in `CommandApprovalDialog` after the command returns `approval_required`.
+
+The register-session detail page already demonstrates the desired one-modal experience, but its fast path is screen-local. This work moves that behavior into the shared operations approval path so all three target workflows use the same pattern without leaking approval policy into screens.
+
+---
+
+## Requirements
+
+- R1. A manager who begins an eligible workflow can complete inline approval in the same staff-auth modal submission when the command returns an `approval_required` result that includes `inline_manager_proof`.
+- R2. The command response remains the source of truth for approval action, subject, required role, reason, resolution modes, requester binding, and async request state.
+- R3. The client must not trust `staffProfileId` as approval proof. It may use the authenticated staff role only to decide whether to attempt a same-submission proof mint; the server still validates the credential and proof.
+- R4. Cashiers and non-manager staff keep the existing approval-required fallback path instead of silently bypassing approval or receiving a fake manager path.
+- R5. Transaction payment-method correction, POS register closeout, and register-session detail closeout all consume the shared fast-path coordinator.
+- R6. Register-session detail closeout loses its bespoke manager variance fast-path logic while preserving the current one-modal behavior.
+- R7. Proof minting must use the fresh credentials submitted in the current modal only; do not store reusable PIN hashes or introduce cross-action credential reuse.
+- R8. Approved retries still call the same command with `approvalProofId`; audit events, one-use proof consumption, and register-session workflow traces remain server-owned.
+- R9. Failed proof minting or failed approved retry leaves the workflow state intact with actionable operator feedback.
+- R10. Existing async approval behavior remains available for requirements that include or require `async_request`.
+
+---
+
+## Scope Boundaries
+
+- Do not change approval thresholds, action keys, proof lifetime, one-use semantics, or manager role definitions.
+- Do not build a generic approval policy registry or async command-resume engine.
+- Do not migrate unrelated approval workflows beyond the three target workflows.
+- Do not redesign the staff-authentication dialog beyond the minimum callback shape needed to expose fresh credentials to the shared coordinator.
+- Do not replace `CommandApprovalDialog`; it remains the fallback when same-submission inline approval is unavailable or inappropriate.
+
+---
+
+## Context & Research
+
+### Current Foundation
+
+- `packages/athena-webapp/shared/approvalPolicy.ts` defines `ApprovalRequirement`, resolution modes, subject identity, role, and operator copy.
+- `packages/athena-webapp/shared/commandResult.ts` defines the shared `approval_required` result.
+- `packages/athena-webapp/convex/operations/approvalProofs.ts` creates and consumes one-use proof records bound to store, action, subject, required role, requester, and expiry.
+- `packages/athena-webapp/convex/operations/staffCredentials.ts` authenticates staff credentials and mints approval proofs.
+- `packages/athena-webapp/src/components/operations/useApprovedCommand.tsx` already renders `CommandApprovalDialog`, creates a proof, and retries the command after `approval_required`.
+
+### Target Workflows
+
+- `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx` authenticates staff before payment correction, then may open a second approval dialog.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` uses the shared approval runner for closeout, but a manager closeout with variance still goes through a second approval dialog.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` already has a one-modal manager variance closeout path, but it hand-checks manager/variance state locally before submitting.
+
+### Learnings Applied
+
+- `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md` establishes that approval UI is presentation only and approved retries must go back through the command.
+- `docs/plans/2026-05-02-001-refactor-first-class-command-approval-plan.md` established the shared command approval foundation this work builds on.
+- `docs/solutions/logic-errors/athena-pos-ledger-safe-corrections-2026-04-30.md` keeps transaction payment corrections narrow: same amount, one payment, one allocation, no ledger total mutation.
+
+---
+
+## Key Decisions
+
+- **Server-first fast path:** Run the command before minting an approval proof. Only attempt same-submission proof minting after the server returns an approval requirement that supports `inline_manager_proof`.
+- **Shared operations coordinator:** Add the fast-path behavior to the shared approval operations layer instead of duplicating manager/variance logic in each workflow.
+- **Fresh credential scope:** Pass the same modal submission credentials directly into the coordinator for one immediate proof attempt and retry. Do not persist them.
+- **Fallback stays intact:** When the authenticated staff member is not a manager, the proof mint fails, the requirement does not support inline proof, or the retry fails, preserve the existing approval dialog / async review behavior and form state.
+- **Observability stays server-owned:** Client changes should not invent workflow traces. Register closeout traces and approval audit events remain emitted by the existing Convex command/proof rails.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  actor Operator
+  participant Modal as Staff Auth Modal
+  participant Runner as Shared Approval Coordinator
+  participant Command as Domain Command
+  participant Staff as Staff Credential Approval
+  participant Proof as Approval Proof
+
+  Operator->>Modal: Submit staff credentials
+  Modal->>Runner: Run command with staff result and fresh credentials
+  Runner->>Command: Execute without approvalProofId
+  alt No approval required
+    Command-->>Runner: ok
+    Runner-->>Modal: success
+  else Inline manager proof available
+    Command-->>Runner: approval_required
+    Runner->>Staff: Mint proof with same credentials and server requirement
+    Staff->>Proof: Create one-use proof
+    Runner->>Command: Retry with approvalProofId
+    Command->>Proof: Consume proof
+    Command-->>Runner: ok
+    Runner-->>Modal: success
+  else Fallback required
+    Command-->>Runner: approval_required
+    Runner-->>Modal: approval still required
+    Runner->>Runner: Open existing approval dialog or show async state
+  end
+```
+
+---
+
+## Implementation Units
+
+- U1. **Add shared manager approval fast-path coordinator**
+
+**Goal:** Extend the operations approval layer so a caller with fresh staff credentials can run an approval-aware command, resolve a returned inline manager requirement with those same credentials, and retry through the same command.
+
+**Requirements:** R1, R2, R3, R4, R7, R9, R10
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/operations/useApprovedCommand.tsx`
+- Modify or create: `packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx`
+- Modify if needed: `packages/athena-webapp/src/components/operations/StaffAuthenticationDialog.tsx`
+- Modify if needed: `packages/athena-webapp/src/components/operations/StaffAuthenticationDialog.test.tsx`
+
+**Approach:**
+- Add a method or helper on `useApprovedCommand` that accepts a command executor, fresh `username` / `pinHash`, requester staff profile id, and a caller-supplied `canAttemptInlineManagerProof` boolean from the just-authenticated staff result.
+- If the initial command returns `approval_required` and the requirement supports `inline_manager_proof`, call the existing `onAuthenticateForApproval` adapter with the server-returned requirement and same credentials.
+- On proof success, retry the same executor with `approvalProofId`.
+- On cashier/non-manager staff, unsupported resolution mode, async-only requirement, proof auth failure, or retry failure, preserve current `useApprovedCommand` fallback behavior and error propagation.
+
+**Test scenarios:**
+- No-approval command succeeds without proof minting.
+- Manager-initiated approval-required command mints proof and retries without rendering the approval dialog.
+- Cashier-initiated approval-required command returns/presents the existing approval-required fallback.
+- Failed proof minting does not retry and surfaces the credential error.
+- Approved retry failure leaves the pending workflow recoverable.
+
+---
+
+- U2. **Migrate transaction payment-method correction**
+
+**Goal:** Make the transaction payment update workflow use the shared one-modal fast path when a manager begins the correction.
+
+**Requirements:** R1, R2, R3, R4, R5, R7, R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+- Verify: `packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts`
+
+**Approach:**
+- Keep the existing staff authentication entry point for payment corrections.
+- Pass the fresh credentials and authenticated staff identity into the shared fast-path coordinator.
+- Remove per-screen second-step assumptions from the payment update path while preserving the `CommandApprovalDialog` fallback for cashier or async approval paths.
+
+**Test scenarios:**
+- Manager updates payment method in one modal submission and no second approval dialog appears.
+- Cashier-initiated update still reaches approval-required fallback.
+- Unsupported payment correction cases remain blocked by the server.
+- Failed approved retry keeps the correction modal state.
+
+---
+
+- U3. **Migrate POS register closeout**
+
+**Goal:** Make closeout from the POS register page use the shared fast path when the active operator is a manager and variance approval is required.
+
+**Requirements:** R1, R2, R3, R4, R5, R8, R9, R10
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify if needed: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify if needed: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Verify: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+
+**Approach:**
+- Keep notes-required validation as a local ergonomics check.
+- Submit closeout through the shared coordinator with current staff credentials when the closeout modal has them available.
+- Preserve async approval request behavior and closeout-blocked UI for cashier or review-required paths.
+
+**Test scenarios:**
+- Manager closes a variance session through one closeout modal flow.
+- Cashier variance closeout creates/presents review-required state without inline bypass.
+- No-variance closeout does not mint an approval proof.
+- Failed proof or retry preserves counted cash and notes.
+
+---
+
+- U4. **Converge register-session detail closeout on the shared path**
+
+**Goal:** Remove the bespoke manager variance fast path from `RegisterSessionView` and preserve the same one-modal behavior through the shared coordinator.
+
+**Requirements:** R1, R2, R3, R5, R6, R7, R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx`
+- Verify: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+
+**Approach:**
+- Stop hand-checking manager + variance before submit.
+- Let submit receive `approval_required`, then have the shared coordinator decide whether the same credential submission can mint an inline proof.
+- Keep existing success/error copy and register-session trace behavior.
+
+**Test scenarios:**
+- Current manager variance one-modal behavior still passes.
+- Manager no-variance closeout does not mint a proof.
+- Cashier variance closeout falls back to review-required behavior.
+- Proof mint or approved retry failure keeps form state.
+
+---
+
+- U5. **Refresh docs, graph, and validation**
+
+**Goal:** Keep repository sensors and implementation knowledge current after approval fast-path migration.
+
+**Requirements:** R5, R8, R10
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Modify or create: `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md`
+- Regenerate: `graphify-out/*`
+- Regenerate only if signatures drift: `packages/athena-webapp/convex/_generated/api.d.ts`
+
+**Approach:**
+- Document the server-first one-modal approval pattern as a reusable solution.
+- Run graph rebuild after code changes.
+- Run targeted approval/POS/cash-controls tests before broad repo validation.
+
+**Expected sensors:**
+- `bun run --filter '@athena/webapp' test -- src/components/operations/useApprovedCommand.test.tsx src/components/pos/transactions/TransactionView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/cash-controls/RegisterSessionView.test.tsx src/components/cash-controls/RegisterSessionView.auth.test.tsx`
+- `bun run --filter '@athena/webapp' test -- convex/cashControls/closeouts.test.ts convex/pos/application/correctTransactionPaymentMethod.test.ts convex/operations/staffCredentials.test.ts convex/operations/approvalProofs.test.ts`
+- `bun run audit:convex`
+- `bun run graphify:rebuild`
+- `bun run typecheck`
+- `bun run build`
+- `bun run pre-push:review`
+
+---
+
+## Ticket Breakdown
+
+- Ticket 1: Add shared manager approval fast-path coordinator.
+- Ticket 2: Migrate transaction payment-method correction to the shared fast path.
+- Ticket 3: Migrate POS register closeout to the shared fast path.
+- Ticket 4: Converge register-session detail closeout on the shared fast path.
+- Ticket 5: Refresh approval fast-path docs, graph, and validation.
+
+This is a coordinated integration batch. Ticket 1 is the shared dependency; tickets 2, 3, and 4 can be implemented in parallel once the coordinator contract is stable; ticket 5 closes the batch after behavior is migrated.

--- a/docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md
+++ b/docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md
@@ -1,0 +1,35 @@
+---
+title: "Athena command approval manager fast path"
+date: 2026-05-02
+tags:
+  - athena-webapp
+  - command-approval
+  - manager-approval
+  - staff-auth
+---
+
+# Athena command approval manager fast path
+
+## Problem
+
+Approval-aware workflows can accidentally ask a manager to authenticate twice: once to begin a workflow-specific action, and again after the command returns `approval_required`. The tempting fix is to let the screen pre-check manager status and mint a proof before submit, but that moves approval policy back into the UI.
+
+## Pattern
+
+Keep the command first. The screen may pass the fresh staff-auth credentials from the current modal submission into the shared approval runner. The runner executes the command without a proof, inspects the server-returned `ApprovalRequirement`, and only then attempts an inline manager proof when the requirement supports `inline_manager_proof`.
+
+If proof minting succeeds, the runner retries the same command with `approvalProofId`. If the staff member is not manager-eligible, the requirement is async-only, proof minting fails, or the approved retry fails, the existing approval-required fallback and user-safe error handling remain in place.
+
+## Rules
+
+- Do not trust `staffProfileId` as approval. It is only the requester identity.
+- Do not precompute approval policy in React. The command response owns action, subject, role, reason, and resolution modes.
+- Do not store or reuse PIN hashes. Pass the current modal submission credentials directly into one immediate proof attempt.
+- Do not replace `CommandApprovalDialog`. It remains the fallback when the same-submission fast path is unavailable.
+- Keep audit and trace behavior server-owned through approval proof creation/consumption and the domain command.
+
+## Current Consumers
+
+- Transaction payment-method correction uses the same staff-auth submission to resolve the returned payment correction approval requirement.
+- Cash-controls register-session closeout uses the shared runner instead of bespoke manager variance logic.
+- POS register closeout routes through the same coordinator contract and can fast-path only when fresh closeout credentials are available.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4138 nodes · 3769 edges · 1477 communities detected
+- 4139 nodes · 3772 edges · 1477 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1540,7 +1540,7 @@ Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOption
 
 ### Community 6 - "Community 6"
 Cohesion: 0.1
-Nodes (16): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), handleAuthenticatedCloseoutStaff(), handleOpeningFloatApprovalApproved(), handleRecordDeposit() (+8 more)
+Nodes (17): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), handleAuthenticatedCloseoutStaff(), handleOpeningFloatApprovalApproved(), handleRecordDeposit() (+9 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.15
@@ -1639,28 +1639,28 @@ Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
 ### Community 31 - "Community 31"
+Cohesion: 0.18
+Nodes (9): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff(), runCustomerCorrection() (+1 more)
+
+### Community 32 - "Community 32"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.28
 Nodes (12): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix() (+4 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.18
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.35
 Nodes (13): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+5 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.19
-Nodes (7): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), runCustomerCorrection()
 
 ### Community 37 - "Community 37"
 Cohesion: 0.18
@@ -2039,16 +2039,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 131 - "Community 131"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 132 - "Community 132"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 133 - "Community 133"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 134 - "Community 134"
 Cohesion: 0.33
@@ -2063,16 +2063,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 137 - "Community 137"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 138 - "Community 138"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 139 - "Community 139"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
@@ -2083,36 +2083,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 142 - "Community 142"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 143 - "Community 143"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 144 - "Community 144"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 149 - "Community 149"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 150 - "Community 150"
 Cohesion: 0.53

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19607,7 +19607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L505",
+      "source_location": "L519",
       "target": "registersessionview_applycloseoutcommandresult",
       "weight": 1
     },
@@ -19619,7 +19619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L495",
+      "source_location": "L509",
       "target": "registersessionview_applycommandresult",
       "weight": 1
     },
@@ -19631,7 +19631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L273",
+      "source_location": "L274",
       "target": "registersessionview_builddepositsubmissionkey",
       "weight": 1
     },
@@ -19643,7 +19643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2135",
+      "source_location": "L2124",
       "target": "registersessionview_errormessage",
       "weight": 1
     },
@@ -19655,7 +19655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L277",
+      "source_location": "L278",
       "target": "registersessionview_formatcurrency",
       "weight": 1
     },
@@ -19667,7 +19667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L326",
+      "source_location": "L327",
       "target": "registersessionview_formatpaymentmethod",
       "weight": 1
     },
@@ -19679,7 +19679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L339",
+      "source_location": "L340",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -19691,7 +19691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L334",
+      "source_location": "L335",
       "target": "registersessionview_formatregistername",
       "weight": 1
     },
@@ -19703,7 +19703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L353",
+      "source_location": "L354",
       "target": "registersessionview_formatsessioncode",
       "weight": 1
     },
@@ -19715,7 +19715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L296",
+      "source_location": "L297",
       "target": "registersessionview_formatstatuslabel",
       "weight": 1
     },
@@ -19727,7 +19727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L285",
+      "source_location": "L286",
       "target": "registersessionview_formatstoredamountforinput",
       "weight": 1
     },
@@ -19739,7 +19739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L289",
+      "source_location": "L290",
       "target": "registersessionview_formattimestamp",
       "weight": 1
     },
@@ -19751,7 +19751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L311",
+      "source_location": "L312",
       "target": "registersessionview_getnumericeventmetadata",
       "weight": 1
     },
@@ -19763,7 +19763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L365",
+      "source_location": "L366",
       "target": "registersessionview_getpaymentmethodicon",
       "weight": 1
     },
@@ -19775,7 +19775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L357",
+      "source_location": "L358",
       "target": "registersessionview_getvariancetone",
       "weight": 1
     },
@@ -19787,7 +19787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L675",
+      "source_location": "L689",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
       "weight": 1
     },
@@ -19799,7 +19799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L772",
+      "source_location": "L803",
       "target": "registersessionview_handleopeningfloatapprovalapproved",
       "weight": 1
     },
@@ -19811,7 +19811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L522",
+      "source_location": "L536",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -19823,7 +19823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L602",
+      "source_location": "L616",
       "target": "registersessionview_handlereviewcloseout",
       "weight": 1
     },
@@ -19835,7 +19835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L565",
+      "source_location": "L579",
       "target": "registersessionview_handlesubmitcloseout",
       "weight": 1
     },
@@ -19847,7 +19847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L619",
+      "source_location": "L633",
       "target": "registersessionview_handlesubmitopeningfloatcorrection",
       "weight": 1
     },
@@ -19859,7 +19859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L300",
+      "source_location": "L301",
       "target": "registersessionview_iscloseoutrejectionevent",
       "weight": 1
     },
@@ -19871,7 +19871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L269",
+      "source_location": "L270",
       "target": "registersessionview_ismanagerstaff",
       "weight": 1
     },
@@ -19883,7 +19883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L304",
+      "source_location": "L305",
       "target": "registersessionview_isopeningfloatcorrectionevent",
       "weight": 1
     },
@@ -19895,7 +19895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L320",
+      "source_location": "L321",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -19907,7 +19907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L726",
+      "source_location": "L757",
       "target": "registersessionview_runopeningfloatcorrection",
       "weight": 1
     },
@@ -19919,7 +19919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L264",
+      "source_location": "L265",
       "target": "registersessionview_trimoptional",
       "weight": 1
     },
@@ -20759,7 +20759,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L53",
+      "source_location": "L61",
       "target": "useapprovedcommand_hasinlinemanagerproof",
       "weight": 1
     },
@@ -20771,7 +20771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L59",
+      "source_location": "L67",
       "target": "useapprovedcommand_useapprovedcommand",
       "weight": 1
     },
@@ -22619,7 +22619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L151",
+      "source_location": "L155",
       "target": "transactionview_test_async",
       "weight": 1
     },
@@ -22631,7 +22631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L370",
+      "source_location": "L377",
       "target": "transactionview_test_mocktransactionmutations",
       "weight": 1
     },
@@ -22643,7 +22643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L331",
+      "source_location": "L338",
       "target": "transactionview_test_paymentapprovalrequirement",
       "weight": 1
     },
@@ -22655,7 +22655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L371",
+      "source_location": "L375",
       "target": "transactionview_authenticatecorrectionstaff",
       "weight": 1
     },
@@ -22667,7 +22667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L396",
+      "source_location": "L400",
       "target": "transactionview_exitcorrectionworkflow",
       "weight": 1
     },
@@ -22691,7 +22691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L128",
+      "source_location": "L132",
       "target": "transactionview_formatcorrectionhistorychange",
       "weight": 1
     },
@@ -22739,7 +22739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L149",
+      "source_location": "L153",
       "target": "transactionview_getcorrectionhistorychangeparts",
       "weight": 1
     },
@@ -22751,8 +22751,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L169",
+      "source_location": "L173",
       "target": "transactionview_gettransactioncorrectionhistory",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "_tgt": "transactionview_ismanagerstaff",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L128",
+      "target": "transactionview_ismanagerstaff",
       "weight": 1
     },
     {
@@ -22763,7 +22775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L511",
+      "source_location": "L530",
       "target": "transactionview_requestcorrectionsubmit",
       "weight": 1
     },
@@ -22787,7 +22799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L403",
+      "source_location": "L407",
       "target": "transactionview_runcustomercorrection",
       "weight": 1
     },
@@ -22799,7 +22811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L441",
+      "source_location": "L445",
       "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
@@ -24047,7 +24059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L162",
+      "source_location": "L168",
       "target": "staffauthenticationdialog_handlekeydown",
       "weight": 1
     },
@@ -24059,7 +24071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L109",
+      "source_location": "L110",
       "target": "staffauthenticationdialog_handlesubmit",
       "weight": 1
     },
@@ -36947,7 +36959,7 @@
       "relation": "calls",
       "source": "registersessionview_formatregistername",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L340",
+      "source_location": "L341",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -36958,6 +36970,18 @@
       "confidence_score": 1,
       "relation": "calls",
       "source": "registersessionview_applycloseoutcommandresult",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L743",
+      "target": "registersessionview_handleauthenticatedcloseoutstaff",
+      "weight": 1
+    },
+    {
+      "_src": "registersessionview_handleauthenticatedcloseoutstaff",
+      "_tgt": "registersessionview_ismanagerstaff",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionview_ismanagerstaff",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
       "source_location": "L712",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
@@ -36971,7 +36995,7 @@
       "relation": "calls",
       "source": "registersessionview_runopeningfloatcorrection",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L785",
+      "source_location": "L816",
       "target": "registersessionview_handleopeningfloatapprovalapproved",
       "weight": 1
     },
@@ -36983,7 +37007,7 @@
       "relation": "calls",
       "source": "registersessionview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L552",
+      "source_location": "L566",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -36995,7 +37019,7 @@
       "relation": "calls",
       "source": "registersessionview_builddepositsubmissionkey",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L559",
+      "source_location": "L573",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -37007,7 +37031,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L545",
+      "source_location": "L559",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -37019,7 +37043,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L614",
+      "source_location": "L628",
       "target": "registersessionview_handlereviewcloseout",
       "weight": 1
     },
@@ -37031,7 +37055,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L582",
+      "source_location": "L596",
       "target": "registersessionview_handlesubmitcloseout",
       "weight": 1
     },
@@ -37043,7 +37067,7 @@
       "relation": "calls",
       "source": "registersessionview_handlesubmitopeningfloatcorrection",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L672",
+      "source_location": "L686",
       "target": "registersessionview_runopeningfloatcorrection",
       "weight": 1
     },
@@ -37055,7 +37079,7 @@
       "relation": "calls",
       "source": "registersessionview_iscloseoutrejectionevent",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L322",
+      "source_location": "L323",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -37067,7 +37091,7 @@
       "relation": "calls",
       "source": "registersessionview_isopeningfloatcorrectionevent",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L322",
+      "source_location": "L323",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -42623,7 +42647,7 @@
       "relation": "calls",
       "source": "staffauthenticationdialog_handlesubmit",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L164",
+      "source_location": "L170",
       "target": "staffauthenticationdialog_handlekeydown",
       "weight": 1
     },
@@ -44939,7 +44963,7 @@
       "relation": "calls",
       "source": "transactionview_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L133",
+      "source_location": "L137",
       "target": "transactionview_formatcorrectionhistorychange",
       "weight": 1
     },
@@ -44963,7 +44987,7 @@
       "relation": "calls",
       "source": "transactionview_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L154",
+      "source_location": "L158",
       "target": "transactionview_getcorrectionhistorychangeparts",
       "weight": 1
     },
@@ -44975,8 +44999,20 @@
       "relation": "calls",
       "source": "transactionview_exitcorrectionworkflow",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L433",
+      "source_location": "L437",
       "target": "transactionview_runcustomercorrection",
+      "weight": 1
+    },
+    {
+      "_src": "transactionview_runpaymentmethodcorrection",
+      "_tgt": "transactionview_ismanagerstaff",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "transactionview_ismanagerstaff",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L495",
+      "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
     {
@@ -51438,56 +51474,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1310,
@@ -51582,56 +51618,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1320,
@@ -51726,56 +51762,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1330,
@@ -51870,56 +51906,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1340,
@@ -52014,56 +52050,56 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
     },
     {
       "community": 1350,
@@ -52158,56 +52194,56 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L102"
     },
     {
       "community": 1360,
@@ -52302,56 +52338,56 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L122"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L68"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L85"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L51"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L102"
     },
     {
       "community": 1370,
@@ -52446,56 +52482,56 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
     },
     {
       "community": 1380,
@@ -52590,56 +52626,56 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L49"
     },
     {
       "community": 1390,
@@ -52914,56 +52950,56 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L28"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L37"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L12"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L6"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L49"
     },
     {
       "community": 1400,
@@ -53058,56 +53094,56 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1410,
@@ -53202,56 +53238,56 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1420,
@@ -53346,56 +53382,56 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
+      "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1430,
@@ -53490,56 +53526,56 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L83"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 1440,
@@ -53634,56 +53670,56 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1450,
@@ -53778,56 +53814,56 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1460,
@@ -53922,55 +53958,55 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -54039,6 +54075,60 @@
     {
       "community": 148,
       "file_type": "code",
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
       "norm_label": "checkoutexpired()",
@@ -54046,7 +54136,7 @@
       "source_location": "L9"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -54055,7 +54145,7 @@
       "source_location": "L73"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -54064,7 +54154,7 @@
       "source_location": "L54"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -54073,7 +54163,7 @@
       "source_location": "L98"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -54082,66 +54172,12 @@
       "source_location": "L33"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -60001,7 +60037,7 @@
       "label": "async()",
       "norm_label": "async()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L151"
+      "source_location": "L155"
     },
     {
       "community": 244,
@@ -60010,7 +60046,7 @@
       "label": "mockTransactionMutations()",
       "norm_label": "mocktransactionmutations()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L370"
+      "source_location": "L377"
     },
     {
       "community": 244,
@@ -60019,7 +60055,7 @@
       "label": "paymentApprovalRequirement()",
       "norm_label": "paymentapprovalrequirement()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L331"
+      "source_location": "L338"
     },
     {
       "community": 245,
@@ -63273,137 +63309,137 @@
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_attachredislogging",
-      "label": "attachRedisLogging()",
-      "norm_label": "attachredislogging()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L53"
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_createapp",
-      "label": "createApp()",
-      "norm_label": "createapp()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L321"
+      "id": "transactionview_authenticatecorrectionstaff",
+      "label": "authenticateCorrectionStaff()",
+      "norm_label": "authenticatecorrectionstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L375"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_createhandlers",
-      "label": "createHandlers()",
-      "norm_label": "createhandlers()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L213"
+      "id": "transactionview_exitcorrectionworkflow",
+      "label": "exitCorrectionWorkflow()",
+      "norm_label": "exitcorrectionworkflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L400"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_createredisclient",
-      "label": "createRedisClient()",
-      "norm_label": "createredisclient()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L41"
+      "id": "transactionview_formatcorrectioneventtype",
+      "label": "formatCorrectionEventType()",
+      "norm_label": "formatcorrectioneventtype()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L85"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_createrediscluster",
-      "label": "createRedisCluster()",
-      "norm_label": "createrediscluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L32"
+      "id": "transactionview_formatcorrectionhistorychange",
+      "label": "formatCorrectionHistoryChange()",
+      "norm_label": "formatcorrectionhistorychange()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L132"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_deletekeysindividually",
-      "label": "deleteKeysIndividually()",
-      "norm_label": "deletekeysindividually()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L96"
+      "id": "transactionview_formatcorrectionhistorymeta",
+      "label": "formatCorrectionHistoryMeta()",
+      "norm_label": "formatcorrectionhistorymeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L103"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_invalidateacrosscluster",
-      "label": "invalidateAcrossCluster()",
-      "norm_label": "invalidateacrosscluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
+      "id": "transactionview_formatcorrectionhistorytitle",
+      "label": "formatCorrectionHistoryTitle()",
+      "norm_label": "formatcorrectionhistorytitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "transactionview_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L112"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_invalidateacrossclusterwithpipeline",
-      "label": "invalidateAcrossClusterWithPipeline()",
-      "norm_label": "invalidateacrossclusterwithpipeline()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L135"
+      "id": "transactionview_getcorrectionhistorychangeparts",
+      "label": "getCorrectionHistoryChangeParts()",
+      "norm_label": "getcorrectionhistorychangeparts()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_runconnectionprobe",
-      "label": "runConnectionProbe()",
-      "norm_label": "runconnectionprobe()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L176"
+      "id": "transactionview_gettransactioncorrectionhistory",
+      "label": "getTransactionCorrectionHistory()",
+      "norm_label": "gettransactioncorrectionhistory()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L173"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_scannodeforpattern",
-      "label": "scanNodeForPattern()",
-      "norm_label": "scannodeforpattern()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L72"
+      "id": "transactionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L128"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_serializeredisvalue",
-      "label": "serializeRedisValue()",
-      "norm_label": "serializeredisvalue()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L68"
+      "id": "transactionview_requestcorrectionsubmit",
+      "label": "requestCorrectionSubmit()",
+      "norm_label": "requestcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L530"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_shouldusecluster",
-      "label": "shouldUseCluster()",
-      "norm_label": "shouldusecluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L26"
+      "id": "transactionview_requiresinlinemanagerproof",
+      "label": "requiresInlineManagerProof()",
+      "norm_label": "requiresinlinemanagerproof()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L122"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_startserver",
-      "label": "startServer()",
-      "norm_label": "startserver()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L340"
+      "id": "transactionview_runcustomercorrection",
+      "label": "runCustomerCorrection()",
+      "norm_label": "runcustomercorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L407"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "app_valkeyendpointfromenv",
-      "label": "valkeyEndpointFromEnv()",
-      "norm_label": "valkeyendpointfromenv()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L19"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_js",
-      "label": "app.js",
-      "norm_label": "app.js",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L1"
+      "id": "transactionview_runpaymentmethodcorrection",
+      "label": "runPaymentMethodCorrection()",
+      "norm_label": "runpaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L445"
     },
     {
       "community": 310,
@@ -63678,136 +63714,136 @@
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_addgroupederror",
-      "label": "addGroupedError()",
-      "norm_label": "addgroupederror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L102"
+      "id": "app_attachredislogging",
+      "label": "attachRedisLogging()",
+      "norm_label": "attachredislogging()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L53"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_collectlivesurfaceentries",
-      "label": "collectLiveSurfaceEntries()",
-      "norm_label": "collectlivesurfaceentries()",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "app_createapp",
+      "label": "createApp()",
+      "norm_label": "createapp()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L321"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "app_createhandlers",
+      "label": "createHandlers()",
+      "norm_label": "createhandlers()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L213"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "app_createredisclient",
+      "label": "createRedisClient()",
+      "norm_label": "createredisclient()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L41"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "app_createrediscluster",
+      "label": "createRedisCluster()",
+      "norm_label": "createrediscluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L32"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "app_deletekeysindividually",
+      "label": "deleteKeysIndividually()",
+      "norm_label": "deletekeysindividually()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L96"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "app_invalidateacrosscluster",
+      "label": "invalidateAcrossCluster()",
+      "norm_label": "invalidateacrosscluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L112"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "app_invalidateacrossclusterwithpipeline",
+      "label": "invalidateAcrossClusterWithPipeline()",
+      "norm_label": "invalidateacrossclusterwithpipeline()",
+      "source_file": "packages/valkey-proxy-server/app.js",
       "source_location": "L135"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L57"
+      "id": "app_runconnectionprobe",
+      "label": "runConnectionProbe()",
+      "norm_label": "runconnectionprobe()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L176"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_formatgroupederrors",
-      "label": "formatGroupedErrors()",
-      "norm_label": "formatgroupederrors()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L341"
+      "id": "app_scannodeforpattern",
+      "label": "scanNodeForPattern()",
+      "norm_label": "scannodeforpattern()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L72"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66"
+      "id": "app_serializeredisvalue",
+      "label": "serializeRedisValue()",
+      "norm_label": "serializeredisvalue()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L68"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_infergroupfromerror",
-      "label": "inferGroupFromError()",
-      "norm_label": "infergroupfromerror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L116"
+      "id": "app_shouldusecluster",
+      "label": "shouldUseCluster()",
+      "norm_label": "shouldusecluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L26"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_loadaudittarget",
-      "label": "loadAuditTarget()",
-      "norm_label": "loadaudittarget()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L164"
+      "id": "app_startserver",
+      "label": "startServer()",
+      "norm_label": "startserver()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L340"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L43"
+      "id": "app_valkeyendpointfromenv",
+      "label": "valkeyEndpointFromEnv()",
+      "norm_label": "valkeyendpointfromenv()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L19"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_runharnessaudit",
-      "label": "runHarnessAudit()",
-      "norm_label": "runharnessaudit()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L356"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_shouldskipsurfaceentry",
-      "label": "shouldSkipSurfaceEntry()",
-      "norm_label": "shouldskipsurfaceentry()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "scripts_harness_audit_ts",
-      "label": "harness-audit.ts",
-      "norm_label": "harness-audit.ts",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "packages_valkey_proxy_server_app_js",
+      "label": "app.js",
+      "norm_label": "app.js",
+      "source_file": "packages/valkey-proxy-server/app.js",
       "source_location": "L1"
     },
     {
@@ -63934,7 +63970,7 @@
       "label": "hasInlineManagerProof()",
       "norm_label": "hasinlinemanagerproof()",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L53"
+      "source_location": "L61"
     },
     {
       "community": 324,
@@ -63943,7 +63979,7 @@
       "label": "useApprovedCommand()",
       "norm_label": "useapprovedcommand()",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L59"
+      "source_location": "L67"
     },
     {
       "community": 325,
@@ -64083,127 +64119,136 @@
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L253"
+      "id": "harness_audit_addgroupederror",
+      "label": "addGroupedError()",
+      "norm_label": "addgroupederror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L102"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L257"
+      "id": "harness_audit_collectlivesurfaceentries",
+      "label": "collectLiveSurfaceEntries()",
+      "norm_label": "collectlivesurfaceentries()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L135"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L245"
+      "id": "harness_audit_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L57"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
-      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
-      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L141"
+      "id": "harness_audit_formatgroupederrors",
+      "label": "formatGroupedErrors()",
+      "norm_label": "formatgroupederrors()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L341"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_buildregistersessioncloseoutreview",
-      "label": "buildRegisterSessionCloseoutReview()",
-      "norm_label": "buildregistersessioncloseoutreview()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L307"
+      "id": "harness_audit_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
-      "label": "buildRegisterSessionVarianceApprovalRequirement()",
-      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L361"
+      "id": "harness_audit_infergroupfromerror",
+      "label": "inferGroupFromError()",
+      "norm_label": "infergroupfromerror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L116"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_cancelpendingapprovalifneeded",
-      "label": "cancelPendingApprovalIfNeeded()",
-      "norm_label": "cancelpendingapprovalifneeded()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L488"
+      "id": "harness_audit_loadaudittarget",
+      "label": "loadAuditTarget()",
+      "norm_label": "loadaudittarget()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L164"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_getcashcontrolsconfig",
-      "label": "getCashControlsConfig()",
-      "norm_label": "getcashcontrolsconfig()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L288"
+      "id": "harness_audit_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L43"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_listregistersessionsforcloseout",
-      "label": "listRegisterSessionsForCloseout()",
-      "norm_label": "listregistersessionsforcloseout()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L406"
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L98"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L436"
+      "id": "harness_audit_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L39"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L266"
+      "id": "harness_audit_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L90"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
-      "label": "staffProfileCanReviewCloseoutVariance()",
-      "norm_label": "staffprofilecanreviewcloseoutvariance()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L453"
+      "id": "harness_audit_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L86"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "closeouts_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L261"
+      "id": "harness_audit_runharnessaudit",
+      "label": "runHarnessAudit()",
+      "norm_label": "runharnessaudit()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L356"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
-      "label": "closeouts.ts",
-      "norm_label": "closeouts.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "label": "shouldSkipSurfaceEntry()",
+      "norm_label": "shouldskipsurfaceentry()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "scripts_harness_audit_ts",
+      "label": "harness-audit.ts",
+      "norm_label": "harness-audit.ts",
+      "source_file": "scripts/harness-audit.ts",
       "source_location": "L1"
     },
     {
@@ -64479,128 +64524,128 @@
     {
       "community": 34,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "closeouts_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L257"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
+      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
+      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_buildregistersessioncloseoutreview",
+      "label": "buildRegisterSessionCloseoutReview()",
+      "norm_label": "buildregistersessioncloseoutreview()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
+      "label": "buildRegisterSessionVarianceApprovalRequirement()",
+      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L361"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_cancelpendingapprovalifneeded",
+      "label": "cancelPendingApprovalIfNeeded()",
+      "norm_label": "cancelpendingapprovalifneeded()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L488"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_getcashcontrolsconfig",
+      "label": "getCashControlsConfig()",
+      "norm_label": "getcashcontrolsconfig()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_listregistersessionsforcloseout",
+      "label": "listRegisterSessionsForCloseout()",
+      "norm_label": "listregistersessionsforcloseout()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L406"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
+      "label": "staffProfileCanReviewCloseoutVariance()",
+      "norm_label": "staffprofilecanreviewcloseoutvariance()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L453"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "closeouts_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L261"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
+      "label": "closeouts.ts",
+      "norm_label": "closeouts.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L292"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L367"
     },
     {
       "community": 340,
@@ -64699,7 +64744,7 @@
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L162"
+      "source_location": "L168"
     },
     {
       "community": 343,
@@ -64708,7 +64753,7 @@
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L109"
+      "source_location": "L110"
     },
     {
       "community": 344,
@@ -64875,128 +64920,128 @@
     {
       "community": 35,
       "file_type": "code",
-      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
-      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
-      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_applypaymentmethodcorrection",
-      "label": "applyPaymentMethodCorrection()",
-      "norm_label": "applypaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
-      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
-      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
-      "label": "consumePaymentMethodCorrectionApprovalProof()",
-      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_correcttransactioncustomer",
-      "label": "correctTransactionCustomer()",
-      "norm_label": "correcttransactioncustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_correcttransactionpaymentmethod",
-      "label": "correctTransactionPaymentMethod()",
-      "norm_label": "correcttransactionpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
-      "label": "createPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_getpaymentmethodcashcontribution",
-      "label": "getPaymentMethodCashContribution()",
-      "norm_label": "getpaymentmethodcashcontribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L539"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
-      "label": "requireRegisterSessionAllowsPaymentCorrection()",
-      "norm_label": "requireregistersessionallowspaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L180"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
-      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
-      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L547"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "correcttransaction_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
-      "label": "correctTransaction.ts",
-      "norm_label": "correcttransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L292"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L367"
     },
     {
       "community": 350,
@@ -65271,128 +65316,128 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
+      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_applypaymentmethodcorrection",
+      "label": "applyPaymentMethodCorrection()",
+      "norm_label": "applypaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L282"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
+      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
+      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
+      "label": "consumePaymentMethodCorrectionApprovalProof()",
+      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactioncustomer",
+      "label": "correctTransactionCustomer()",
+      "norm_label": "correcttransactioncustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactionpaymentmethod",
+      "label": "correctTransactionPaymentMethod()",
+      "norm_label": "correcttransactionpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "label": "createPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_getpaymentmethodcashcontribution",
+      "label": "getPaymentMethodCashContribution()",
+      "norm_label": "getpaymentmethodcashcontribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L539"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "label": "requireRegisterSessionAllowsPaymentCorrection()",
+      "norm_label": "requireregistersessionallowspaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L180"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
+      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L547"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "correcttransaction_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "label": "correctTransaction.ts",
+      "norm_label": "correcttransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_authenticatecorrectionstaff",
-      "label": "authenticateCorrectionStaff()",
-      "norm_label": "authenticatecorrectionstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L371"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_exitcorrectionworkflow",
-      "label": "exitCorrectionWorkflow()",
-      "norm_label": "exitcorrectionworkflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L396"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectioneventtype",
-      "label": "formatCorrectionEventType()",
-      "norm_label": "formatcorrectioneventtype()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorychange",
-      "label": "formatCorrectionHistoryChange()",
-      "norm_label": "formatcorrectionhistorychange()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorymeta",
-      "label": "formatCorrectionHistoryMeta()",
-      "norm_label": "formatcorrectionhistorymeta()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L103"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorytitle",
-      "label": "formatCorrectionHistoryTitle()",
-      "norm_label": "formatcorrectionhistorytitle()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L112"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_getcorrectionhistorychangeparts",
-      "label": "getCorrectionHistoryChangeParts()",
-      "norm_label": "getcorrectionhistorychangeparts()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_gettransactioncorrectionhistory",
-      "label": "getTransactionCorrectionHistory()",
-      "norm_label": "gettransactioncorrectionhistory()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_requestcorrectionsubmit",
-      "label": "requestCorrectionSubmit()",
-      "norm_label": "requestcorrectionsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L511"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_requiresinlinemanagerproof",
-      "label": "requiresInlineManagerProof()",
-      "norm_label": "requiresinlinemanagerproof()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_runcustomercorrection",
-      "label": "runCustomerCorrection()",
-      "norm_label": "runcustomercorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L403"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "transactionview_runpaymentmethodcorrection",
-      "label": "runPaymentMethodCorrection()",
-      "norm_label": "runpaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L441"
     },
     {
       "community": 360,
@@ -73276,7 +73321,7 @@
       "label": "applyCloseoutCommandResult()",
       "norm_label": "applycloseoutcommandresult()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L505"
+      "source_location": "L519"
     },
     {
       "community": 6,
@@ -73285,7 +73330,7 @@
       "label": "applyCommandResult()",
       "norm_label": "applycommandresult()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L495"
+      "source_location": "L509"
     },
     {
       "community": 6,
@@ -73294,7 +73339,7 @@
       "label": "buildDepositSubmissionKey()",
       "norm_label": "builddepositsubmissionkey()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L273"
+      "source_location": "L274"
     },
     {
       "community": 6,
@@ -73303,7 +73348,7 @@
       "label": "errorMessage()",
       "norm_label": "errormessage()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2135"
+      "source_location": "L2124"
     },
     {
       "community": 6,
@@ -73312,7 +73357,7 @@
       "label": "formatCurrency()",
       "norm_label": "formatcurrency()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L277"
+      "source_location": "L278"
     },
     {
       "community": 6,
@@ -73321,7 +73366,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L326"
+      "source_location": "L327"
     },
     {
       "community": 6,
@@ -73330,7 +73375,7 @@
       "label": "formatRegisterHeaderName()",
       "norm_label": "formatregisterheadername()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L339"
+      "source_location": "L340"
     },
     {
       "community": 6,
@@ -73339,7 +73384,7 @@
       "label": "formatRegisterName()",
       "norm_label": "formatregistername()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L334"
+      "source_location": "L335"
     },
     {
       "community": 6,
@@ -73348,7 +73393,7 @@
       "label": "formatSessionCode()",
       "norm_label": "formatsessioncode()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L353"
+      "source_location": "L354"
     },
     {
       "community": 6,
@@ -73357,7 +73402,7 @@
       "label": "formatStatusLabel()",
       "norm_label": "formatstatuslabel()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L296"
+      "source_location": "L297"
     },
     {
       "community": 6,
@@ -73366,7 +73411,7 @@
       "label": "formatStoredAmountForInput()",
       "norm_label": "formatstoredamountforinput()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L285"
+      "source_location": "L286"
     },
     {
       "community": 6,
@@ -73375,7 +73420,7 @@
       "label": "formatTimestamp()",
       "norm_label": "formattimestamp()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L289"
+      "source_location": "L290"
     },
     {
       "community": 6,
@@ -73384,7 +73429,7 @@
       "label": "getNumericEventMetadata()",
       "norm_label": "getnumericeventmetadata()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L311"
+      "source_location": "L312"
     },
     {
       "community": 6,
@@ -73393,7 +73438,7 @@
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L365"
+      "source_location": "L366"
     },
     {
       "community": 6,
@@ -73402,7 +73447,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L357"
+      "source_location": "L358"
     },
     {
       "community": 6,
@@ -73411,7 +73456,7 @@
       "label": "handleAuthenticatedCloseoutStaff()",
       "norm_label": "handleauthenticatedcloseoutstaff()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L675"
+      "source_location": "L689"
     },
     {
       "community": 6,
@@ -73420,7 +73465,7 @@
       "label": "handleOpeningFloatApprovalApproved()",
       "norm_label": "handleopeningfloatapprovalapproved()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L772"
+      "source_location": "L803"
     },
     {
       "community": 6,
@@ -73429,7 +73474,7 @@
       "label": "handleRecordDeposit()",
       "norm_label": "handlerecorddeposit()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L522"
+      "source_location": "L536"
     },
     {
       "community": 6,
@@ -73438,7 +73483,7 @@
       "label": "handleReviewCloseout()",
       "norm_label": "handlereviewcloseout()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L602"
+      "source_location": "L616"
     },
     {
       "community": 6,
@@ -73447,7 +73492,7 @@
       "label": "handleSubmitCloseout()",
       "norm_label": "handlesubmitcloseout()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L565"
+      "source_location": "L579"
     },
     {
       "community": 6,
@@ -73456,7 +73501,7 @@
       "label": "handleSubmitOpeningFloatCorrection()",
       "norm_label": "handlesubmitopeningfloatcorrection()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L619"
+      "source_location": "L633"
     },
     {
       "community": 6,
@@ -73465,7 +73510,7 @@
       "label": "isCloseoutRejectionEvent()",
       "norm_label": "iscloseoutrejectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L300"
+      "source_location": "L301"
     },
     {
       "community": 6,
@@ -73474,7 +73519,7 @@
       "label": "isManagerStaff()",
       "norm_label": "ismanagerstaff()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L269"
+      "source_location": "L270"
     },
     {
       "community": 6,
@@ -73483,7 +73528,7 @@
       "label": "isOpeningFloatCorrectionEvent()",
       "norm_label": "isopeningfloatcorrectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L304"
+      "source_location": "L305"
     },
     {
       "community": 6,
@@ -73492,7 +73537,7 @@
       "label": "isRegisterSessionCorrectionEvent()",
       "norm_label": "isregistersessioncorrectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L320"
+      "source_location": "L321"
     },
     {
       "community": 6,
@@ -73501,7 +73546,7 @@
       "label": "runOpeningFloatCorrection()",
       "norm_label": "runopeningfloatcorrection()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L726"
+      "source_location": "L757"
     },
     {
       "community": 6,
@@ -73510,7 +73555,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L264"
+      "source_location": "L265"
     },
     {
       "community": 60,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1549
-- Graph nodes: 4138
-- Graph edges: 3769
+- Graph nodes: 4139
+- Graph edges: 3772
 - Communities: 1477
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 31) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 70) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 31) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 31) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 31) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -65,11 +65,16 @@ vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
       pinHash: string;
       username: string;
     }) => Promise<unknown>;
-    onAuthenticated: (result: {
-      approvalProofId?: string;
-      staffProfile: { fullName: string };
-      staffProfileId: string;
-    }) => void;
+    onAuthenticated: (
+      result: {
+        activeRoles?: string[];
+        approvalProofId?: string;
+        staffProfile: { fullName: string };
+        staffProfileId: string;
+      },
+      mode: "authenticate",
+      credentials: { pinHash: string; username: string },
+    ) => void;
     open: boolean;
   }) =>
     open ? (
@@ -88,6 +93,7 @@ vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
             result.kind === "ok" &&
             "data" in result
               ? (result.data as {
+                  activeRoles?: string[];
                   approvalProofId?: string;
                   staffProfile: { fullName: string };
                   staffProfileId: string;
@@ -96,7 +102,10 @@ vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
                   staffProfile: { fullName: "Ato Kofi" },
                   staffProfileId: "staff-1",
                 };
-          onAuthenticated(authenticatedResult);
+          onAuthenticated(authenticatedResult, "authenticate", {
+            pinHash: "hashed-pin",
+            username: "ato",
+          });
         }}
       >
         Confirm staff for {copy.submitLabel}
@@ -591,15 +600,37 @@ describe("RegisterSessionViewContent", () => {
         staffProfileId: "staff-1",
       }),
     );
-    const onAuthenticateCloseoutReviewApproval = vi.fn().mockResolvedValue(
+    const onAuthenticateForApproval = vi.fn().mockResolvedValue(
       ok({
         approvalProofId: "approval-proof-1",
-        staffProfile: { fullName: "Ato Kofi" },
-        staffProfileId: "staff-1",
+        approvedByStaffProfileId: "staff-1",
+        expiresAt: Date.now() + 60_000,
       }),
     );
     const onSubmitCloseout = vi
       .fn()
+      .mockResolvedValueOnce({
+        kind: "approval_required",
+        approval: {
+          action: {
+            key: "cash_controls.register_session.review_variance",
+            label: "Review register closeout variance",
+          },
+          copy: {
+            title: "Manager approval required",
+            message: "Manager approval is required.",
+            primaryActionLabel: "Approve",
+          },
+          reason: "Manager counted the overage.",
+          requiredRole: "manager",
+          resolutionModes: [{ kind: "inline_manager_proof" }],
+          subject: {
+            id: "session-1",
+            label: "Register 3",
+            type: "register_session",
+          },
+        },
+      })
       .mockResolvedValue(ok({ action: "closed" }));
 
     render(
@@ -607,9 +638,7 @@ describe("RegisterSessionViewContent", () => {
         actorUserId="user-1"
         currency="GHS"
         isLoading={false}
-        onAuthenticateCloseoutReviewApproval={
-          onAuthenticateCloseoutReviewApproval
-        }
+        onAuthenticateForApproval={onAuthenticateForApproval}
         onAuthenticateStaff={onAuthenticateStaff}
         onRecordDeposit={vi.fn()}
         onReviewCloseout={vi.fn()}
@@ -635,15 +664,22 @@ describe("RegisterSessionViewContent", () => {
       pinHash: "hashed-pin",
       username: "ato",
     });
-    expect(onAuthenticateCloseoutReviewApproval).toHaveBeenCalledWith({
+    expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+      actionKey: "cash_controls.register_session.review_variance",
       pinHash: "hashed-pin",
       reason: "Manager counted the overage.",
-      registerSessionId: "session-1",
+      requiredRole: "manager",
       requestedByStaffProfileId: "staff-1",
+      storeId: "store-1",
+      subject: {
+        id: "session-1",
+        label: "Register 3",
+        type: "register_session",
+      },
       username: "ato",
     });
     await waitFor(() =>
-      expect(onSubmitCloseout).toHaveBeenCalledWith({
+      expect(onSubmitCloseout).toHaveBeenLastCalledWith({
         actorStaffProfileId: "staff-1",
         approvalProofId: "approval-proof-1",
         countedCash: 18000,

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -24,6 +24,7 @@ import {
   CommandApprovalApprovedResult,
   CommandApprovalProofResult,
 } from "@/components/operations/CommandApprovalDialog";
+import { useApprovedCommand } from "@/components/operations/useApprovedCommand";
 import {
   isApprovalRequiredResult,
   type NormalizedCommandResult,
@@ -435,6 +436,19 @@ export function RegisterSessionViewContent({
     useState<ApprovalRequirement | null>(null);
   const [isCorrectingOpeningFloat, setIsCorrectingOpeningFloat] =
     useState(false);
+  const closeoutApprovalRunner = useApprovedCommand({
+    storeId: storeId as Id<"store"> | undefined,
+    onAuthenticateForApproval:
+      onAuthenticateForApproval ??
+      (() =>
+        Promise.resolve(
+          userError({
+            code: "unavailable",
+            message:
+              "Manager approval is not available yet. Try again after the register tools refresh.",
+          }),
+        )),
+  });
   const [submissionKey, setSubmissionKey] = useState(() =>
     buildDepositSubmissionKey(registerSession?._id ?? "session"),
   );
@@ -674,6 +688,7 @@ export function RegisterSessionViewContent({
 
   async function handleAuthenticatedCloseoutStaff(
     result: CloseoutApprovalAuthenticationResult,
+    credentials?: { pinHash: string; username: string },
   ) {
     if (!closeoutStaffAuthIntent) {
       return;
@@ -689,12 +704,28 @@ export function RegisterSessionViewContent({
     try {
       const commandResult =
         intent.kind === "submit"
-          ? await onSubmitCloseout({
-              actorStaffProfileId: result.staffProfileId,
-              approvalProofId: result.approvalProofId,
-              countedCash: intent.countedCash,
-              notes: intent.notes,
-              registerSessionId: intent.registerSessionId,
+          ? await closeoutApprovalRunner.run({
+              requestedByStaffProfileId:
+                result.staffProfileId as Id<"staffProfile">,
+              sameSubmissionApproval: credentials
+                ? {
+                    canAttemptInlineManagerProof: isManagerStaff(result),
+                    pinHash: credentials.pinHash,
+                    requestedByStaffProfileId:
+                      result.staffProfileId as Id<"staffProfile">,
+                    username: credentials.username,
+                  }
+                : undefined,
+              execute: (approvalArgs) =>
+                onSubmitCloseout({
+                  actorStaffProfileId: result.staffProfileId,
+                  approvalProofId:
+                    approvalArgs.approvalProofId ?? result.approvalProofId,
+                  countedCash: intent.countedCash,
+                  notes: intent.notes,
+                  registerSessionId: intent.registerSessionId,
+                }),
+              onResult: () => undefined,
             })
           : result.approvalProofId
             ? await onReviewCloseout({
@@ -1100,57 +1131,15 @@ export function RegisterSessionViewContent({
               pinHash: args.pinHash,
               username: args.username,
             }),
-          ).then(async (staffResult) => {
-            if (
-              !staffResult ||
-              closeoutStaffAuthIntent?.kind !== "submit" ||
-              staffResult.kind !== "ok" ||
-              !isManagerStaff(staffResult.data) ||
-              !onAuthenticateCloseoutReviewApproval
-            ) {
-              return staffResult;
-            }
-
-            const expectedCloseoutCash =
-              registerSession?.netExpectedCash ?? registerSession?.expectedCash;
-
-            if (
-              expectedCloseoutCash === undefined ||
-              closeoutStaffAuthIntent.countedCash === expectedCloseoutCash
-            ) {
-              return staffResult;
-            }
-
-            const approvalResult = await onAuthenticateCloseoutReviewApproval({
-              pinHash: args.pinHash,
-              reason: closeoutStaffAuthIntent.notes,
-              registerSessionId: closeoutStaffAuthIntent.registerSessionId,
-              requestedByStaffProfileId: staffResult.data.staffProfileId,
-              username: args.username,
-            });
-
-            if (approvalResult.kind !== "ok") {
-              return approvalResult;
-            }
-
-            return {
-              kind: "ok" as const,
-              data: {
-                ...staffResult.data,
-                approvalProofId: approvalResult.data.approvalProofId,
-                approvedByStaffProfileId:
-                  approvalResult.data.approvedByStaffProfileId,
-                expiresAt: approvalResult.data.expiresAt,
-              },
-            };
-          });
+          );
         }}
-        onAuthenticated={(result) => {
-          void handleAuthenticatedCloseoutStaff(result);
+        onAuthenticated={(result, _mode, credentials) => {
+          void handleAuthenticatedCloseoutStaff(result, credentials);
         }}
         onDismiss={() => setCloseoutStaffAuthIntent(null)}
         open={Boolean(closeoutStaffAuthIntent)}
       />
+      {closeoutApprovalRunner.dialog}
       <CommandApprovalDialog
         approval={pendingOpeningFloatApproval}
         onAuthenticateForApproval={

--- a/packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx
+++ b/packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx
@@ -96,6 +96,128 @@ describe("useApprovedCommand", () => {
     expect(result.current.pendingApproval).toBeNull();
   });
 
+  it("uses a same-submission manager proof before opening approval UI", async () => {
+    const onResult = vi.fn();
+    const onAuthenticateForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        expiresAt: 123,
+      }),
+    );
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ kind: "approval_required", approval })
+      .mockResolvedValueOnce(ok({ action: "closed" }));
+    const { result } = renderHook(() =>
+      useApprovedCommand({
+        storeId,
+        onAuthenticateForApproval,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run({
+        execute,
+        onResult,
+        requestedByStaffProfileId: requesterId,
+        sameSubmissionApproval: {
+          canAttemptInlineManagerProof: true,
+          pinHash: "pin-hash",
+          requestedByStaffProfileId: requesterId,
+          username: "manager",
+        },
+      });
+    });
+
+    expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+      actionKey: approval.action.key,
+      pinHash: "pin-hash",
+      reason: approval.reason,
+      requiredRole: approval.requiredRole,
+      requestedByStaffProfileId: requesterId,
+      storeId,
+      subject: approval.subject,
+      username: "manager",
+    });
+    expect(execute).toHaveBeenLastCalledWith({
+      approvalProofId: "proof-1",
+    });
+    expect(onResult).toHaveBeenCalledWith(ok({ action: "closed" }));
+    expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.approvalDialog).toBeNull();
+  });
+
+  it("falls back to approval UI when same-submission staff cannot approve", async () => {
+    const onResult = vi.fn();
+    const onAuthenticateForApproval = vi.fn();
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ kind: "approval_required", approval });
+    const { result } = renderHook(() =>
+      useApprovedCommand({
+        storeId,
+        onAuthenticateForApproval,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run({
+        execute,
+        onResult,
+        requestedByStaffProfileId: requesterId,
+        sameSubmissionApproval: {
+          canAttemptInlineManagerProof: false,
+          pinHash: "pin-hash",
+          requestedByStaffProfileId: requesterId,
+          username: "cashier",
+        },
+      });
+    });
+
+    expect(onAuthenticateForApproval).not.toHaveBeenCalled();
+    expect(result.current.approvalDialog).toMatchObject({
+      approval,
+      requestedByStaffProfileId: requesterId,
+      storeId,
+    });
+  });
+
+  it("surfaces same-submission proof failures without retrying", async () => {
+    const proofError = userError({
+      code: "authentication_failed",
+      message: "Manager credentials required.",
+    });
+    const onResult = vi.fn();
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ kind: "approval_required", approval });
+    const { result } = renderHook(() =>
+      useApprovedCommand({
+        storeId,
+        onAuthenticateForApproval: vi.fn().mockResolvedValue(proofError),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run({
+        execute,
+        onResult,
+        requestedByStaffProfileId: requesterId,
+        sameSubmissionApproval: {
+          canAttemptInlineManagerProof: true,
+          pinHash: "pin-hash",
+          requestedByStaffProfileId: requesterId,
+          username: "cashier",
+        },
+      });
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(proofError);
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
   it("reports async approval requirements without authenticating inline", async () => {
     const asyncApproval = {
       ...approval,

--- a/packages/athena-webapp/src/components/operations/useApprovedCommand.tsx
+++ b/packages/athena-webapp/src/components/operations/useApprovedCommand.tsx
@@ -17,6 +17,13 @@ type ApprovalRetryArgs = {
   approvalProofId?: Id<"approvalProof">;
 };
 
+type SameSubmissionApprovalArgs = {
+  canAttemptInlineManagerProof: boolean;
+  pinHash: string;
+  requestedByStaffProfileId?: Id<"staffProfile">;
+  username: string;
+};
+
 type PendingApproval<T> = {
   approval: ApprovalRequirement;
   execute: (args: ApprovalRetryArgs) => Promise<NormalizedApprovalCommandResult<T>>;
@@ -34,6 +41,7 @@ type RunApprovedCommandArgs<T> = {
   onApprovalRequired?: (approval: ApprovalRequirement) => void;
   onResult: (result: NormalizedApprovalCommandResult<T>) => void | Promise<void>;
   requestedByStaffProfileId?: Id<"staffProfile">;
+  sameSubmissionApproval?: SameSubmissionApprovalArgs;
 };
 
 type UseApprovedCommandArgs = {
@@ -88,9 +96,41 @@ export function useApprovedCommand({ onAuthenticateForApproval, storeId }: UseAp
   const run = useCallback(
     async <T,>(args: RunApprovedCommandArgs<T>) => {
       const result = await args.execute({});
+      if (
+        isApprovalRequiredResult(result) &&
+        storeId &&
+        args.sameSubmissionApproval?.canAttemptInlineManagerProof &&
+        hasInlineManagerProof(result.approval)
+      ) {
+        const approvalResult = await onAuthenticateForApproval({
+          actionKey: result.approval.action.key,
+          pinHash: args.sameSubmissionApproval.pinHash,
+          reason: result.approval.reason,
+          requiredRole: result.approval.requiredRole,
+          requestedByStaffProfileId:
+            args.sameSubmissionApproval.requestedByStaffProfileId ??
+            args.requestedByStaffProfileId,
+          storeId,
+          subject: result.approval.subject,
+          username: args.sameSubmissionApproval.username,
+        });
+
+        if (approvalResult.kind !== "ok") {
+          await args.onResult(
+            approvalResult as NormalizedApprovalCommandResult<T>,
+          );
+          return approvalResult as NormalizedApprovalCommandResult<T>;
+        }
+
+        const retryResult = await args.execute({
+          approvalProofId: approvalResult.data.approvalProofId,
+        });
+        return handleResult(retryResult, args);
+      }
+
       return handleResult(result, args);
     },
-    [handleResult],
+    [handleResult, onAuthenticateForApproval, storeId],
   );
 
   const approvalDialog = useMemo(() => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -133,14 +133,18 @@ vi.mock("../../staff-auth/StaffAuthenticationDialog", () => ({
       pinHash: string;
       username: string;
     }) => Promise<unknown>;
-    onAuthenticated: (result: {
-      activeRoles?: string[];
-      approvalProofId?: string;
-      approvedByStaffProfileId?: string;
-      expiresAt?: number;
-      staffProfile: { firstName: string; lastName: string };
-      staffProfileId: string;
-    }) => void;
+    onAuthenticated: (
+      result: {
+        activeRoles?: string[];
+        approvalProofId?: string;
+        approvedByStaffProfileId?: string;
+        expiresAt?: number;
+        staffProfile: { firstName: string; lastName: string };
+        staffProfileId: string;
+      },
+      mode: "authenticate",
+      credentials: { pinHash: string; username: string },
+    ) => void;
     open: boolean;
   }) =>
     open ? (
@@ -160,7 +164,10 @@ vi.mock("../../staff-auth/StaffAuthenticationDialog", () => ({
               result.kind === "ok" &&
               "data" in result
             ) {
-              onAuthenticated(result.data as never);
+              onAuthenticated(result.data as never, "authenticate", {
+                pinHash: "123456",
+                username: "manager",
+              });
             }
           }}
           type="button"
@@ -880,7 +887,6 @@ describe("TransactionView", () => {
       screen.getByRole("button", { name: "Submit payment update" }),
     );
     await user.click(screen.getByRole("button", { name: "Confirm" }));
-    await user.click(await screen.findByRole("button", { name: "Approve update" }));
 
     await waitFor(() => {
       expect(approvalMutation).toHaveBeenCalledWith({

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -125,6 +125,10 @@ function requiresInlineManagerProof(approval: ApprovalRequirement) {
   );
 }
 
+function isManagerStaff(staff: StaffAuthenticationResult) {
+  return staff.activeRoles?.includes("manager") ?? false;
+}
+
 function formatCorrectionHistoryChange(event: CorrectionEvent) {
   if (event.eventType !== "pos_transaction_payment_method_corrected") {
     return null;
@@ -440,6 +444,11 @@ export function TransactionView() {
 
   async function runPaymentMethodCorrection(args?: {
     approvalProofId?: Id<"approvalProof">;
+    sameSubmissionApproval?: {
+      pinHash: string;
+      username: string;
+    };
+    staff?: StaffAuthenticationResult;
     staffProfileId?: Id<"staffProfile">;
   }) {
     if (!isAuthenticated) {
@@ -480,6 +489,16 @@ export function TransactionView() {
         setCorrectionSubmitting(false);
         return result;
       },
+      sameSubmissionApproval:
+        args?.sameSubmissionApproval && args.staff
+          ? {
+              canAttemptInlineManagerProof: isManagerStaff(args.staff),
+              pinHash: args.sameSubmissionApproval.pinHash,
+              requestedByStaffProfileId:
+                args.staffProfileId ?? args.staff.staffProfileId,
+              username: args.sameSubmissionApproval.username,
+            }
+          : undefined,
       onApprovalRequired: (approval) => {
         if (!requiresInlineManagerProof(approval)) {
           setPaymentCorrectionReason("");
@@ -576,7 +595,7 @@ export function TransactionView() {
             username: args.username,
           })
         }
-        onAuthenticated={(result) => {
+        onAuthenticated={(result, _mode, credentials) => {
           const correction = pendingCorrection;
           setPendingCorrection(null);
           if (correction === "customer") {
@@ -584,6 +603,8 @@ export function TransactionView() {
           }
           if (correction === "payment_method") {
             void runPaymentMethodCorrection({
+              sameSubmissionApproval: credentials,
+              staff: result,
               staffProfileId: result.staffProfileId,
             });
           }

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -57,6 +57,7 @@ export type StaffAuthenticationDialogProps = {
   onAuthenticated: (
     result: StaffAuthenticationResult,
     mode: StaffAuthMode,
+    credentials: { pinHash: string; username: string },
   ) => void;
   onDismiss: () => void;
   open: boolean;
@@ -120,14 +121,16 @@ export function StaffAuthenticationDialog({
     setIsAuthenticating(true);
 
     let result: NormalizedCommandResult<StaffAuthenticationResult>;
+    let submittedPinHash = "";
+    let submittedUsername = username.trim();
 
     try {
-      const pinHash = await hashPin(pin);
+      submittedPinHash = await hashPin(pin);
 
       result = await onAuthenticate({
         mode,
-        pinHash,
-        username: username.trim(),
+        pinHash: submittedPinHash,
+        username: submittedUsername,
       });
     } catch (error) {
       console.error(error);
@@ -153,7 +156,10 @@ export function StaffAuthenticationDialog({
       toast.success(successMessage);
     }
 
-    onAuthenticated(result.data, mode);
+    onAuthenticated(result.data, mode, {
+      pinHash: submittedPinHash,
+      username: submittedUsername,
+    });
     setUsername("");
     setPin("");
     setMode("authenticate");

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1036,6 +1036,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       countedCash: number;
       notes?: string;
       registerSessionId: Id<"registerSession">;
+      sameSubmissionApproval?: {
+        pinHash: string;
+        username: string;
+      };
     }) => {
       if (!activeStore?._id || !user?._id || !staffProfileId) {
         setDrawerErrorMessage(
@@ -1047,6 +1051,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       setDrawerErrorMessage(null);
       await closeoutApprovalRunner.run({
         requestedByStaffProfileId: staffProfileId,
+        sameSubmissionApproval: args.sameSubmissionApproval
+          ? {
+              canAttemptInlineManagerProof: isCashierManager,
+              pinHash: args.sameSubmissionApproval.pinHash,
+              requestedByStaffProfileId: staffProfileId,
+              username: args.sameSubmissionApproval.username,
+            }
+          : undefined,
         execute: async (approvalArgs) => {
           setIsSubmittingCloseout(true);
           const result = await runCommand(() =>
@@ -1090,6 +1102,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     [
       activeStore?._id,
       closeoutApprovalRunner,
+      isCashierManager,
       requestBootstrap,
       staffProfileId,
       submitRegisterSessionCloseout,


### PR DESCRIPTION
## Summary
- add a shared same-submission manager approval fast path to the command approval runner
- route transaction payment correction and register-session closeout through the shared path
- add planning/solution docs and refresh graphify outputs

## Validation
- bun run --filter '@athena/webapp' test
- bun run --filter '@athena/webapp' build
- bun run --filter '@athena/webapp' audit:convex
- bun run pre-push:review

Linear: V26-441, V26-442, V26-443, V26-444, V26-445