### PR TITLE
Polish manager approval flows

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4139 nodes · 3772 edges · 1477 communities detected
+- 4138 nodes · 3771 edges · 1477 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1808,35 +1808,35 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 73 - "Community 73"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 74 - "Community 74"
+Cohesion: 0.43
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+
+### Community 75 - "Community 75"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 78 - "Community 78"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 79 - "Community 79"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 80 - "Community 80"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 81 - "Community 81"
 Cohesion: 0.36
@@ -1943,20 +1943,20 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 107 - "Community 107"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 108 - "Community 108"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 109 - "Community 109"
+### Community 108 - "Community 108"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 110 - "Community 110"
+### Community 109 - "Community 109"
 Cohesion: 0.29
 Nodes (0):
+
+### Community 110 - "Community 110"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 111 - "Community 111"
 Cohesion: 0.29
@@ -1967,64 +1967,64 @@ Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 113 - "Community 113"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 114 - "Community 114"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+
+### Community 119 - "Community 119"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 120 - "Community 120"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 121 - "Community 121"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 122 - "Community 122"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.4
 Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 127 - "Community 127"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 128 - "Community 128"
 Cohesion: 0.33
@@ -2035,20 +2035,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 131 - "Community 131"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 133 - "Community 133"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 134 - "Community 134"
 Cohesion: 0.33
@@ -2063,16 +2063,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 137 - "Community 137"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 138 - "Community 138"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
+
+### Community 139 - "Community 139"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
@@ -2083,56 +2083,56 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 142 - "Community 142"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 143 - "Community 143"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 144 - "Community 144"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
+
+### Community 154 - "Community 154"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 155 - "Community 155"
 Cohesion: 0.4
@@ -2143,48 +2143,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 157 - "Community 157"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 158 - "Community 158"
 Cohesion: 0.7
 Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
+
+### Community 160 - "Community 160"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 162 - "Community 162"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 163 - "Community 163"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 165 - "Community 165"
+### Community 164 - "Community 164"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 166 - "Community 166"
+### Community 165 - "Community 165"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 167 - "Community 167"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 168 - "Community 168"
 Cohesion: 0.4
@@ -2207,12 +2207,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 173 - "Community 173"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 174 - "Community 174"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 174 - "Community 174"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.4
@@ -2224,23 +2224,23 @@ Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 0.4
-Nodes (0):
-
-### Community 178 - "Community 178"
-Cohesion: 0.4
 Nodes (1): Header()
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
+
+### Community 181 - "Community 181"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 182 - "Community 182"
 Cohesion: 0.4
@@ -2483,12 +2483,12 @@ Cohesion: 0.67
 Nodes (2): getApprovalRequestCopy(), handleDecideApprovalRequest()
 
 ### Community 242 - "Community 242"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 243 - "Community 243"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 244 - "Community 244"
 Cohesion: 0.5
@@ -2515,68 +2515,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 251 - "Community 251"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 251 - "Community 251"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 253 - "Community 253"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 254 - "Community 254"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 255 - "Community 255"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 256 - "Community 256"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 258 - "Community 258"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 259 - "Community 259"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 265 - "Community 265"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 266 - "Community 266"
 Cohesion: 0.5
@@ -2603,51 +2603,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 274 - "Community 274"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 277 - "Community 277"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 280 - "Community 280"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 281 - "Community 281"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 282 - "Community 282"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 283 - "Community 283"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 284 - "Community 284"
@@ -2700,35 +2700,35 @@ Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 299 - "Community 299"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 300 - "Community 300"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 300 - "Community 300"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 303 - "Community 303"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 303 - "Community 303"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.67
@@ -2739,36 +2739,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 306 - "Community 306"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 311 - "Community 311"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 312 - "Community 312"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 312 - "Community 312"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
@@ -2783,24 +2783,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 317 - "Community 317"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
@@ -2808,11 +2808,11 @@ Nodes (0):
 
 ### Community 323 - "Community 323"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 325 - "Community 325"
 Cohesion: 1.0

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1259,7 +1259,7 @@
       "relation": "calls",
       "source": "closeouts_asboolean",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L295",
+      "source_location": "L296",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -1271,7 +1271,7 @@
       "relation": "calls",
       "source": "closeouts_asnumber",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L291",
+      "source_location": "L292",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -1283,7 +1283,7 @@
       "relation": "calls",
       "source": "closeouts_asrecord",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L289",
+      "source_location": "L290",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -2075,7 +2075,7 @@
       "relation": "calls",
       "source": "deposits_sumdepositsbysession",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L232",
+      "source_location": "L233",
       "target": "deposits_buildcashcontrolsdashboardsnapshot",
       "weight": 1
     },
@@ -7859,7 +7859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L253",
+      "source_location": "L254",
       "target": "closeouts_asboolean",
       "weight": 1
     },
@@ -7871,7 +7871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L257",
+      "source_location": "L258",
       "target": "closeouts_asnumber",
       "weight": 1
     },
@@ -7883,7 +7883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L245",
+      "source_location": "L246",
       "target": "closeouts_asrecord",
       "weight": 1
     },
@@ -7895,7 +7895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L141",
+      "source_location": "L142",
       "target": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
       "weight": 1
     },
@@ -7907,7 +7907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L307",
+      "source_location": "L308",
       "target": "closeouts_buildregistersessioncloseoutreview",
       "weight": 1
     },
@@ -7919,7 +7919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L361",
+      "source_location": "L362",
       "target": "closeouts_buildregistersessionvarianceapprovalrequirement",
       "weight": 1
     },
@@ -7931,7 +7931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L488",
+      "source_location": "L489",
       "target": "closeouts_cancelpendingapprovalifneeded",
       "weight": 1
     },
@@ -7943,7 +7943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L288",
+      "source_location": "L289",
       "target": "closeouts_getcashcontrolsconfig",
       "weight": 1
     },
@@ -7955,7 +7955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L406",
+      "source_location": "L407",
       "target": "closeouts_listregistersessionsforcloseout",
       "weight": 1
     },
@@ -7967,7 +7967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L436",
+      "source_location": "L437",
       "target": "closeouts_liststaffnames",
       "weight": 1
     },
@@ -7979,7 +7979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L266",
+      "source_location": "L267",
       "target": "closeouts_persistregistersessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -7991,7 +7991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L453",
+      "source_location": "L454",
       "target": "closeouts_staffprofilecanreviewcloseoutvariance",
       "weight": 1
     },
@@ -8003,7 +8003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L261",
+      "source_location": "L262",
       "target": "closeouts_trimoptional",
       "weight": 1
     },
@@ -8027,7 +8027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L225",
+      "source_location": "L226",
       "target": "deposits_buildcashcontrolsdashboardsnapshot",
       "weight": 1
     },
@@ -8063,7 +8063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L371",
+      "source_location": "L372",
       "target": "deposits_collectstaffprofileids",
       "weight": 1
     },
@@ -8087,7 +8087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L289",
+      "source_location": "L290",
       "target": "deposits_listregistersessionsfordashboard",
       "weight": 1
     },
@@ -8099,7 +8099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L345",
+      "source_location": "L346",
       "target": "deposits_listregistersessiontimeline",
       "weight": 1
     },
@@ -8111,7 +8111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L358",
+      "source_location": "L359",
       "target": "deposits_listregistersessiontransactions",
       "weight": 1
     },
@@ -8123,7 +8123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L331",
+      "source_location": "L332",
       "target": "deposits_listsessiondeposits",
       "weight": 1
     },
@@ -8147,7 +8147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L317",
+      "source_location": "L318",
       "target": "deposits_liststoredeposits",
       "weight": 1
     },
@@ -8159,7 +8159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L300",
+      "source_location": "L301",
       "target": "deposits_listterminalnames",
       "weight": 1
     },
@@ -19607,7 +19607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L519",
+      "source_location": "L521",
       "target": "registersessionview_applycloseoutcommandresult",
       "weight": 1
     },
@@ -19619,7 +19619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L509",
+      "source_location": "L511",
       "target": "registersessionview_applycommandresult",
       "weight": 1
     },
@@ -19631,7 +19631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L274",
+      "source_location": "L276",
       "target": "registersessionview_builddepositsubmissionkey",
       "weight": 1
     },
@@ -19643,7 +19643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2124",
+      "source_location": "L2140",
       "target": "registersessionview_errormessage",
       "weight": 1
     },
@@ -19655,7 +19655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L278",
+      "source_location": "L280",
       "target": "registersessionview_formatcurrency",
       "weight": 1
     },
@@ -19667,7 +19667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L327",
+      "source_location": "L329",
       "target": "registersessionview_formatpaymentmethod",
       "weight": 1
     },
@@ -19679,7 +19679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L340",
+      "source_location": "L342",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -19691,7 +19691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L335",
+      "source_location": "L337",
       "target": "registersessionview_formatregistername",
       "weight": 1
     },
@@ -19703,7 +19703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L354",
+      "source_location": "L356",
       "target": "registersessionview_formatsessioncode",
       "weight": 1
     },
@@ -19715,7 +19715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L297",
+      "source_location": "L299",
       "target": "registersessionview_formatstatuslabel",
       "weight": 1
     },
@@ -19727,7 +19727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L286",
+      "source_location": "L288",
       "target": "registersessionview_formatstoredamountforinput",
       "weight": 1
     },
@@ -19739,7 +19739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L290",
+      "source_location": "L292",
       "target": "registersessionview_formattimestamp",
       "weight": 1
     },
@@ -19751,7 +19751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L312",
+      "source_location": "L314",
       "target": "registersessionview_getnumericeventmetadata",
       "weight": 1
     },
@@ -19763,7 +19763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L366",
+      "source_location": "L368",
       "target": "registersessionview_getpaymentmethodicon",
       "weight": 1
     },
@@ -19775,7 +19775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L358",
+      "source_location": "L360",
       "target": "registersessionview_getvariancetone",
       "weight": 1
     },
@@ -19787,7 +19787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L689",
+      "source_location": "L691",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
       "weight": 1
     },
@@ -19799,7 +19799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L803",
+      "source_location": "L805",
       "target": "registersessionview_handleopeningfloatapprovalapproved",
       "weight": 1
     },
@@ -19811,7 +19811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L536",
+      "source_location": "L538",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -19823,7 +19823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L616",
+      "source_location": "L618",
       "target": "registersessionview_handlereviewcloseout",
       "weight": 1
     },
@@ -19835,7 +19835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L579",
+      "source_location": "L581",
       "target": "registersessionview_handlesubmitcloseout",
       "weight": 1
     },
@@ -19847,7 +19847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L633",
+      "source_location": "L635",
       "target": "registersessionview_handlesubmitopeningfloatcorrection",
       "weight": 1
     },
@@ -19859,7 +19859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L301",
+      "source_location": "L303",
       "target": "registersessionview_iscloseoutrejectionevent",
       "weight": 1
     },
@@ -19871,7 +19871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L270",
+      "source_location": "L272",
       "target": "registersessionview_ismanagerstaff",
       "weight": 1
     },
@@ -19883,7 +19883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L305",
+      "source_location": "L307",
       "target": "registersessionview_isopeningfloatcorrectionevent",
       "weight": 1
     },
@@ -19895,7 +19895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L321",
+      "source_location": "L323",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -19907,7 +19907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L757",
+      "source_location": "L759",
       "target": "registersessionview_runopeningfloatcorrection",
       "weight": 1
     },
@@ -19919,7 +19919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L265",
+      "source_location": "L267",
       "target": "registersessionview_trimoptional",
       "weight": 1
     },
@@ -20615,7 +20615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L76",
+      "source_location": "L78",
       "target": "commandapprovaldialog_getasyncresolution",
       "weight": 1
     },
@@ -20627,7 +20627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L65",
+      "source_location": "L67",
       "target": "commandapprovaldialog_getinlinemanagerresolution",
       "weight": 1
     },
@@ -20639,7 +20639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L83",
+      "source_location": "L85",
       "target": "commandapprovaldialog_tostaffauthenticationresult",
       "weight": 1
     },
@@ -20753,6 +20753,18 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
+      "_tgt": "useapprovedcommand_hasasyncapprovalrequest",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
+      "source_location": "L67",
+      "target": "useapprovedcommand_hasasyncapprovalrequest",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "_tgt": "useapprovedcommand_hasinlinemanagerproof",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -20771,7 +20783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L67",
+      "source_location": "L73",
       "target": "useapprovedcommand_useapprovedcommand",
       "weight": 1
     },
@@ -22373,49 +22385,13 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "_tgt": "registerdrawergate_cashcontrolsbutton",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L17",
-      "target": "registerdrawergate_cashcontrolsbutton",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "_tgt": "registerdrawergate_formatcurrency",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L45",
-      "target": "registerdrawergate_formatcurrency",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "_tgt": "registerdrawergate_getvariancetone",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L53",
-      "target": "registerdrawergate_getvariancetone",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "_tgt": "registerdrawergate_handlecloseoutsubmit",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L73",
+      "source_location": "L80",
       "target": "registerdrawergate_handlecloseoutsubmit",
       "weight": 1
     },
@@ -22427,7 +22403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L77",
+      "source_location": "L84",
       "target": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "weight": 1
     },
@@ -22439,8 +22415,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L66",
+      "source_location": "L73",
       "target": "registerdrawergate_handlesubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "_tgt": "registerdrawergate_if",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L61",
+      "target": "registerdrawergate_if",
       "weight": 1
     },
     {
@@ -22655,7 +22643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L375",
+      "source_location": "L379",
       "target": "transactionview_authenticatecorrectionstaff",
       "weight": 1
     },
@@ -22667,7 +22655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L400",
+      "source_location": "L404",
       "target": "transactionview_exitcorrectionworkflow",
       "weight": 1
     },
@@ -22691,7 +22679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L132",
+      "source_location": "L136",
       "target": "transactionview_formatcorrectionhistorychange",
       "weight": 1
     },
@@ -22739,7 +22727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L153",
+      "source_location": "L157",
       "target": "transactionview_getcorrectionhistorychangeparts",
       "weight": 1
     },
@@ -22751,7 +22739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L173",
+      "source_location": "L177",
       "target": "transactionview_gettransactioncorrectionhistory",
       "weight": 1
     },
@@ -22763,7 +22751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L128",
+      "source_location": "L132",
       "target": "transactionview_ismanagerstaff",
       "weight": 1
     },
@@ -22775,7 +22763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L530",
+      "source_location": "L534",
       "target": "transactionview_requestcorrectionsubmit",
       "weight": 1
     },
@@ -22799,7 +22787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L407",
+      "source_location": "L411",
       "target": "transactionview_runcustomercorrection",
       "weight": 1
     },
@@ -22811,7 +22799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L445",
+      "source_location": "L449",
       "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
@@ -27731,7 +27719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L148",
+      "source_location": "L160",
       "target": "useregisterviewmodel_canoperateregister",
       "weight": 1
     },
@@ -27815,7 +27803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L157",
+      "source_location": "L169",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -36959,7 +36947,7 @@
       "relation": "calls",
       "source": "registersessionview_formatregistername",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L341",
+      "source_location": "L343",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -36971,7 +36959,7 @@
       "relation": "calls",
       "source": "registersessionview_applycloseoutcommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L743",
+      "source_location": "L745",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
       "weight": 1
     },
@@ -36983,7 +36971,7 @@
       "relation": "calls",
       "source": "registersessionview_ismanagerstaff",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L712",
+      "source_location": "L714",
       "target": "registersessionview_handleauthenticatedcloseoutstaff",
       "weight": 1
     },
@@ -36995,7 +36983,7 @@
       "relation": "calls",
       "source": "registersessionview_runopeningfloatcorrection",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L816",
+      "source_location": "L818",
       "target": "registersessionview_handleopeningfloatapprovalapproved",
       "weight": 1
     },
@@ -37007,7 +36995,7 @@
       "relation": "calls",
       "source": "registersessionview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L566",
+      "source_location": "L568",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -37019,7 +37007,7 @@
       "relation": "calls",
       "source": "registersessionview_builddepositsubmissionkey",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L573",
+      "source_location": "L575",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -37031,7 +37019,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L559",
+      "source_location": "L561",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -37043,7 +37031,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L628",
+      "source_location": "L630",
       "target": "registersessionview_handlereviewcloseout",
       "weight": 1
     },
@@ -37055,7 +37043,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L596",
+      "source_location": "L598",
       "target": "registersessionview_handlesubmitcloseout",
       "weight": 1
     },
@@ -37067,7 +37055,7 @@
       "relation": "calls",
       "source": "registersessionview_handlesubmitopeningfloatcorrection",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L686",
+      "source_location": "L688",
       "target": "registersessionview_runopeningfloatcorrection",
       "weight": 1
     },
@@ -37079,7 +37067,7 @@
       "relation": "calls",
       "source": "registersessionview_iscloseoutrejectionevent",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L323",
+      "source_location": "L325",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -37091,7 +37079,7 @@
       "relation": "calls",
       "source": "registersessionview_isopeningfloatcorrectionevent",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L323",
+      "source_location": "L325",
       "target": "registersessionview_isregistersessioncorrectionevent",
       "weight": 1
     },
@@ -44963,7 +44951,7 @@
       "relation": "calls",
       "source": "transactionview_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L137",
+      "source_location": "L141",
       "target": "transactionview_formatcorrectionhistorychange",
       "weight": 1
     },
@@ -44987,7 +44975,7 @@
       "relation": "calls",
       "source": "transactionview_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L158",
+      "source_location": "L162",
       "target": "transactionview_getcorrectionhistorychangeparts",
       "weight": 1
     },
@@ -44999,7 +44987,7 @@
       "relation": "calls",
       "source": "transactionview_exitcorrectionworkflow",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L437",
+      "source_location": "L441",
       "target": "transactionview_runcustomercorrection",
       "weight": 1
     },
@@ -45011,7 +44999,7 @@
       "relation": "calls",
       "source": "transactionview_ismanagerstaff",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L495",
+      "source_location": "L499",
       "target": "transactionview_runpaymentmethodcorrection",
       "weight": 1
     },
@@ -45059,7 +45047,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L341",
+      "source_location": "L368",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -45071,7 +45059,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_trimoptional",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L165",
+      "source_location": "L177",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -47379,65 +47367,65 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "label": "RegisterDrawerGate.tsx",
-      "norm_label": "registerdrawergate.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "registerdrawergate_cashcontrolsbutton",
-      "label": "CashControlsButton()",
-      "norm_label": "cashcontrolsbutton()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L17"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "registerdrawergate_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "registerdrawergate_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L53"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "registerdrawergate_handlecloseoutsubmit",
-      "label": "handleCloseoutSubmit()",
-      "norm_label": "handlecloseoutsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
-      "label": "handleOpeningFloatCorrectionSubmit()",
-      "norm_label": "handleopeningfloatcorrectionsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "registerdrawergate_handlesubmit",
+      "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L66"
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 1070,
@@ -47532,65 +47520,65 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1080,
@@ -47685,65 +47673,65 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
     },
     {
       "community": 1090,
@@ -48027,65 +48015,65 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1100,
@@ -48486,65 +48474,65 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171"
     },
     {
       "community": 1130,
@@ -48639,65 +48627,65 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L394"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L171"
     },
     {
       "community": 1140,
@@ -48792,64 +48780,64 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L23"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -48945,64 +48933,55 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L23"
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
     },
     {
@@ -49098,56 +49077,56 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1170,
@@ -49242,56 +49221,56 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L1"
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L1"
     },
     {
       "community": 1180,
@@ -49386,56 +49365,56 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
     },
     {
       "community": 1190,
@@ -49710,56 +49689,56 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
     },
     {
       "community": 1200,
@@ -49854,55 +49833,55 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -49998,55 +49977,55 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L1"
     },
     {
@@ -50142,56 +50121,56 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1230,
@@ -50286,56 +50265,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1240,
@@ -50430,56 +50409,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1250,
@@ -50574,56 +50553,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1260,
@@ -50718,56 +50697,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1270,
@@ -50862,55 +50841,55 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L418"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L285"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
+      "id": "ordersummary_handleeditingpaymentidchange",
+      "label": "handleEditingPaymentIdChange()",
+      "norm_label": "handleeditingpaymentidchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L318"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
+      "id": "ordersummary_handleselectedpaymentmethodchange",
+      "label": "handleSelectedPaymentMethodChange()",
+      "norm_label": "handleselectedpaymentmethodchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L308"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
+      "id": "ordersummary_handlestartnewtransaction",
+      "label": "handleStartNewTransaction()",
+      "norm_label": "handlestartnewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L302"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -51006,56 +50985,56 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "ordersummary_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L418"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L285"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "ordersummary_handleeditingpaymentidchange",
-      "label": "handleEditingPaymentIdChange()",
-      "norm_label": "handleeditingpaymentidchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L318"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "ordersummary_handleselectedpaymentmethodchange",
-      "label": "handleSelectedPaymentMethodChange()",
-      "norm_label": "handleselectedpaymentmethodchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L308"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "ordersummary_handlestartnewtransaction",
-      "label": "handleStartNewTransaction()",
-      "norm_label": "handlestartnewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L302"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
     },
     {
       "community": 1290,
@@ -51330,56 +51309,56 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1300,
@@ -51474,56 +51453,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1310,
@@ -51618,56 +51597,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1320,
@@ -51762,56 +51741,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L101"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
     },
     {
       "community": 1330,
@@ -51906,56 +51885,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
     },
     {
       "community": 1340,
@@ -52050,56 +52029,56 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1350,
@@ -52194,56 +52173,56 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L102"
     },
     {
       "community": 1360,
@@ -52338,56 +52317,56 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L122"
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L68"
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L85"
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L51"
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L102"
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
     },
     {
       "community": 1370,
@@ -52482,56 +52461,56 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
     },
     {
       "community": 1380,
@@ -52626,56 +52605,56 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L49"
     },
     {
       "community": 1390,
@@ -52950,56 +52929,56 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L28"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L37"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L12"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L6"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L49"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1400,
@@ -53094,56 +53073,56 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1410,
@@ -53238,56 +53217,56 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
     },
     {
       "community": 1420,
@@ -53382,56 +53361,56 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
+      "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
+      "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 1430,
@@ -53526,56 +53505,56 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L83"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1440,
@@ -53670,56 +53649,56 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1450,
@@ -53814,56 +53793,56 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
     },
     {
       "community": 1460,
@@ -53958,55 +53937,55 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -54075,60 +54054,6 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
       "norm_label": "checkoutexpired()",
@@ -54136,7 +54061,7 @@
       "source_location": "L9"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -54145,7 +54070,7 @@
       "source_location": "L73"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -54154,7 +54079,7 @@
       "source_location": "L54"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -54163,7 +54088,7 @@
       "source_location": "L98"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -54172,12 +54097,66 @@
       "source_location": "L33"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1"
     },
     {
@@ -54354,60 +54333,6 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
       "norm_label": "formattime()",
@@ -54415,7 +54340,7 @@
       "source_location": "L149"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -54424,7 +54349,7 @@
       "source_location": "L156"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -54433,7 +54358,7 @@
       "source_location": "L201"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -54442,7 +54367,7 @@
       "source_location": "L93"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -54451,7 +54376,7 @@
       "source_location": "L282"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -54460,7 +54385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -54469,7 +54394,7 @@
       "source_location": "L72"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -54478,7 +54403,7 @@
       "source_location": "L124"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -54487,7 +54412,7 @@
       "source_location": "L106"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -54496,7 +54421,7 @@
       "source_location": "L63"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -54505,7 +54430,7 @@
       "source_location": "L151"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -54514,7 +54439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "harness_behavior_scenarios_buildathenaruntimeurl",
       "label": "buildAthenaRuntimeUrl()",
@@ -54523,7 +54448,7 @@
       "source_location": "L129"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
       "label": "buildValkeyRuntimeUrl()",
@@ -54532,7 +54457,7 @@
       "source_location": "L145"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "harness_behavior_scenarios_createathenaruntimeprocess",
       "label": "createAthenaRuntimeProcess()",
@@ -54541,7 +54466,7 @@
       "source_location": "L117"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
       "label": "createStorefrontRuntimeProcesses()",
@@ -54550,7 +54475,7 @@
       "source_location": "L149"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
       "label": "createValkeyRuntimeProcess()",
@@ -54559,7 +54484,7 @@
       "source_location": "L133"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_ts",
       "label": "harness-behavior-scenarios.ts",
@@ -54568,7 +54493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -54577,7 +54502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -54586,7 +54511,7 @@
       "source_location": "L46"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -54595,7 +54520,7 @@
       "source_location": "L22"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -54604,7 +54529,7 @@
       "source_location": "L118"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -54613,7 +54538,7 @@
       "source_location": "L81"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -54622,7 +54547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -54631,7 +54556,7 @@
       "source_location": "L292"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -54640,7 +54565,7 @@
       "source_location": "L94"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -54649,7 +54574,7 @@
       "source_location": "L110"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -54658,7 +54583,7 @@
       "source_location": "L311"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -54667,7 +54592,7 @@
       "source_location": "L135"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -54676,7 +54601,7 @@
       "source_location": "L39"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -54685,7 +54610,7 @@
       "source_location": "L19"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -54694,7 +54619,7 @@
       "source_location": "L92"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -54703,7 +54628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
       "label": "products.ts",
@@ -54712,7 +54637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "products_calculatetotalavailablecount",
       "label": "calculateTotalAvailableCount()",
@@ -54721,7 +54646,7 @@
       "source_location": "L70"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "products_calculatetotalinventorycount",
       "label": "calculateTotalInventoryCount()",
@@ -54730,7 +54655,7 @@
       "source_location": "L65"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "products_generatebarcode",
       "label": "generateBarcode()",
@@ -54739,7 +54664,7 @@
       "source_location": "L42"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "products_generatesku",
       "label": "generateSKU()",
@@ -54748,7 +54673,7 @@
       "source_location": "L18"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -54757,7 +54682,7 @@
       "source_location": "L85"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestascommandwithctx",
       "label": "decideApprovalRequestAsCommandWithCtx()",
@@ -54766,7 +54691,7 @@
       "source_location": "L173"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -54775,7 +54700,7 @@
       "source_location": "L28"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "approvalrequests_mapdecideapprovalrequesterror",
       "label": "mapDecideApprovalRequestError()",
@@ -54784,7 +54709,7 @@
       "source_location": "L114"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -54793,7 +54718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -54802,7 +54727,7 @@
       "source_location": "L24"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -54811,7 +54736,7 @@
       "source_location": "L207"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -54820,7 +54745,7 @@
       "source_location": "L45"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -54829,12 +54754,57 @@
       "source_location": "L30"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
       "norm_label": "customerprofiles.ts",
       "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -55011,51 +54981,6 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
       "norm_label": "serviceintake.test.ts",
@@ -55063,7 +54988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -55072,7 +54997,7 @@
       "source_location": "L16"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -55081,7 +55006,7 @@
       "source_location": "L29"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -55090,7 +55015,7 @@
       "source_location": "L12"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -55099,7 +55024,7 @@
       "source_location": "L8"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -55108,7 +55033,7 @@
       "source_location": "L255"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -55117,7 +55042,7 @@
       "source_location": "L282"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -55126,7 +55051,7 @@
       "source_location": "L239"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -55135,7 +55060,7 @@
       "source_location": "L269"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -55144,7 +55069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -55153,7 +55078,7 @@
       "source_location": "L100"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -55162,7 +55087,7 @@
       "source_location": "L110"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -55171,7 +55096,7 @@
       "source_location": "L84"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -55180,7 +55105,7 @@
       "source_location": "L92"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -55189,7 +55114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -55198,7 +55123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -55207,7 +55132,7 @@
       "source_location": "L11"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -55216,7 +55141,7 @@
       "source_location": "L21"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -55225,7 +55150,7 @@
       "source_location": "L87"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -55234,7 +55159,7 @@
       "source_location": "L65"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -55243,7 +55168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -55252,7 +55177,7 @@
       "source_location": "L115"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -55261,7 +55186,7 @@
       "source_location": "L90"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -55270,7 +55195,7 @@
       "source_location": "L74"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -55279,7 +55204,7 @@
       "source_location": "L70"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -55288,7 +55213,7 @@
       "source_location": "L89"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -55297,7 +55222,7 @@
       "source_location": "L765"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -55306,7 +55231,7 @@
       "source_location": "L37"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -55315,7 +55240,7 @@
       "source_location": "L60"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -55324,7 +55249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -55333,7 +55258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -55342,7 +55267,7 @@
       "source_location": "L124"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -55351,7 +55276,7 @@
       "source_location": "L67"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -55360,7 +55285,7 @@
       "source_location": "L106"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -55369,7 +55294,7 @@
       "source_location": "L73"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -55378,7 +55303,7 @@
       "source_location": "L61"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -55387,7 +55312,7 @@
       "source_location": "L75"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -55396,7 +55321,7 @@
       "source_location": "L116"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -55405,7 +55330,7 @@
       "source_location": "L20"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -55414,7 +55339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -55423,7 +55348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -55432,7 +55357,7 @@
       "source_location": "L287"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -55441,7 +55366,7 @@
       "source_location": "L203"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -55450,13 +55375,58 @@
       "source_location": "L243"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
       "norm_label": "setinitialselectedoption()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L1"
     },
     {
       "community": 17,
@@ -55632,51 +55602,6 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L84"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
       "norm_label": "pageheader.tsx",
@@ -55684,7 +55609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -55693,7 +55618,7 @@
       "source_location": "L30"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -55702,7 +55627,7 @@
       "source_location": "L8"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -55711,7 +55636,7 @@
       "source_location": "L49"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -55720,7 +55645,7 @@
       "source_location": "L66"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -55729,7 +55654,7 @@
       "source_location": "L20"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -55738,7 +55663,7 @@
       "source_location": "L50"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -55747,7 +55672,7 @@
       "source_location": "L342"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -55756,7 +55681,7 @@
       "source_location": "L322"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -55765,7 +55690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -55774,7 +55699,7 @@
       "source_location": "L61"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -55783,7 +55708,7 @@
       "source_location": "L57"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -55792,7 +55717,7 @@
       "source_location": "L98"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -55801,7 +55726,7 @@
       "source_location": "L134"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -55810,7 +55735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -55819,7 +55744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -55828,7 +55753,7 @@
       "source_location": "L38"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -55837,7 +55762,7 @@
       "source_location": "L64"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -55846,7 +55771,7 @@
       "source_location": "L135"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -55855,7 +55780,7 @@
       "source_location": "L43"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -55864,7 +55789,7 @@
       "source_location": "L58"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -55873,7 +55798,7 @@
       "source_location": "L63"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -55882,7 +55807,7 @@
       "source_location": "L50"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -55891,7 +55816,7 @@
       "source_location": "L53"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -55900,7 +55825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -55909,7 +55834,7 @@
       "source_location": "L140"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -55918,7 +55843,7 @@
       "source_location": "L177"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -55927,7 +55852,7 @@
       "source_location": "L195"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -55936,7 +55861,7 @@
       "source_location": "L45"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -55945,7 +55870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -55954,7 +55879,7 @@
       "source_location": "L92"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -55963,7 +55888,7 @@
       "source_location": "L307"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -55972,7 +55897,7 @@
       "source_location": "L70"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -55981,7 +55906,7 @@
       "source_location": "L50"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -55990,7 +55915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
@@ -55999,7 +55924,7 @@
       "source_location": "L30"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -56008,7 +55933,7 @@
       "source_location": "L43"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -56017,7 +55942,7 @@
       "source_location": "L106"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -56026,7 +55951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -56035,7 +55960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -56044,7 +55969,7 @@
       "source_location": "L36"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -56053,7 +55978,7 @@
       "source_location": "L53"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -56062,7 +55987,7 @@
       "source_location": "L62"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -56071,13 +55996,58 @@
       "source_location": "L32"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
       "norm_label": "ordersummary.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
+      "label": "PaymentsAddedList.test.tsx",
+      "norm_label": "paymentsaddedlist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummaryamount",
+      "label": "getSummaryAmount()",
+      "norm_label": "getsummaryamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarylabel",
+      "label": "getSummaryLabel()",
+      "norm_label": "getsummarylabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarypanel",
+      "label": "getSummaryPanel()",
+      "norm_label": "getsummarypanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L14"
     },
     {
       "community": 18,
@@ -56253,51 +56223,6 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
-      "label": "PaymentsAddedList.test.tsx",
-      "norm_label": "paymentsaddedlist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummaryamount",
-      "label": "getSummaryAmount()",
-      "norm_label": "getsummaryamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarylabel",
-      "label": "getSummaryLabel()",
-      "norm_label": "getsummarylabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarypanel",
-      "label": "getSummaryPanel()",
-      "norm_label": "getsummarypanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
       "norm_label": "productentry.tsx",
@@ -56305,7 +56230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -56314,7 +56239,7 @@
       "source_location": "L270"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -56323,7 +56248,7 @@
       "source_location": "L275"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -56332,13 +56257,58 @@
       "source_location": "L304"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
       "norm_label": "resetquickaddform()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L295"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "label": "RegisterDrawerGate.tsx",
+      "norm_label": "registerdrawergate.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "registerdrawergate_handlecloseoutsubmit",
+      "label": "handleCloseoutSubmit()",
+      "norm_label": "handlecloseoutsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
+      "label": "handleOpeningFloatCorrectionSubmit()",
+      "norm_label": "handleopeningfloatcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "registerdrawergate_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "registerdrawergate_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L61"
     },
     {
       "community": 182,
@@ -59884,7 +59854,7 @@
       "label": "getAsyncResolution()",
       "norm_label": "getasyncresolution()",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L76"
+      "source_location": "L78"
     },
     {
       "community": 240,
@@ -59893,7 +59863,7 @@
       "label": "getInlineManagerResolution()",
       "norm_label": "getinlinemanagerresolution()",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L65"
+      "source_location": "L67"
     },
     {
       "community": 240,
@@ -59902,7 +59872,7 @@
       "label": "toStaffAuthenticationResult()",
       "norm_label": "tostaffauthenticationresult()",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L83"
+      "source_location": "L85"
     },
     {
       "community": 240,
@@ -59952,6 +59922,42 @@
     {
       "community": 242,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
+      "label": "useApprovedCommand.tsx",
+      "norm_label": "useapprovedcommand.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "useapprovedcommand_hasasyncapprovalrequest",
+      "label": "hasAsyncApprovalRequest()",
+      "norm_label": "hasasyncapprovalrequest()",
+      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "useapprovedcommand_hasinlinemanagerproof",
+      "label": "hasInlineManagerProof()",
+      "norm_label": "hasinlinemanagerproof()",
+      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "useapprovedcommand_useapprovedcommand",
+      "label": "useApprovedCommand()",
+      "norm_label": "useapprovedcommand()",
+      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
       "norm_label": "returnexchangeview.tsx",
@@ -59959,7 +59965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -59968,7 +59974,7 @@
       "source_location": "L105"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -59977,7 +59983,7 @@
       "source_location": "L97"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -59986,7 +59992,7 @@
       "source_location": "L83"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -59995,7 +60001,7 @@
       "source_location": "L91"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -60004,7 +60010,7 @@
       "source_location": "L68"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -60013,7 +60019,7 @@
       "source_location": "L22"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -60022,7 +60028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -60031,7 +60037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -60040,7 +60046,7 @@
       "source_location": "L155"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -60049,7 +60055,7 @@
       "source_location": "L377"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -60058,7 +60064,7 @@
       "source_location": "L338"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -60067,7 +60073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -60076,7 +60082,7 @@
       "source_location": "L22"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -60085,7 +60091,7 @@
       "source_location": "L27"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -60094,7 +60100,7 @@
       "source_location": "L40"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -60103,7 +60109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -60112,7 +60118,7 @@
       "source_location": "L78"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -60121,7 +60127,7 @@
       "source_location": "L118"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -60130,7 +60136,7 @@
       "source_location": "L89"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -60139,7 +60145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -60148,7 +60154,7 @@
       "source_location": "L63"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -60157,7 +60163,7 @@
       "source_location": "L54"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -60166,7 +60172,7 @@
       "source_location": "L11"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -60175,7 +60181,7 @@
       "source_location": "L16"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -60184,7 +60190,7 @@
       "source_location": "L35"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -60193,49 +60199,13 @@
       "source_location": "L6"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
       "norm_label": "complimentaryproductsview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
-      "label": "promoCodeMoney.ts",
-      "norm_label": "promocodemoney.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "promocodemoney_parsepromodiscountinput",
-      "label": "parsePromoDiscountInput()",
-      "norm_label": "parsepromodiscountinput()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountdisplaytext",
-      "label": "promoDiscountDisplayText()",
-      "norm_label": "promodiscountdisplaytext()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountinputvalue",
-      "label": "promoDiscountInputValue()",
-      "norm_label": "promodiscountinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L21"
     },
     {
       "community": 25,
@@ -60393,6 +60363,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
+      "label": "promoCodeMoney.ts",
+      "norm_label": "promocodemoney.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "promocodemoney_parsepromodiscountinput",
+      "label": "parsePromoDiscountInput()",
+      "norm_label": "parsepromodiscountinput()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountdisplaytext",
+      "label": "promoDiscountDisplayText()",
+      "norm_label": "promodiscountdisplaytext()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountinputvalue",
+      "label": "promoDiscountInputValue()",
+      "norm_label": "promodiscountinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
       "norm_label": "servicecasesview.tsx",
@@ -60400,7 +60406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -60409,7 +60415,7 @@
       "source_location": "L178"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -60418,7 +60424,7 @@
       "source_location": "L205"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -60427,7 +60433,7 @@
       "source_location": "L806"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -60436,7 +60442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -60445,7 +60451,7 @@
       "source_location": "L41"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -60454,7 +60460,7 @@
       "source_location": "L45"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -60463,7 +60469,7 @@
       "source_location": "L65"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -60472,7 +60478,7 @@
       "source_location": "L75"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -60481,7 +60487,7 @@
       "source_location": "L82"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -60490,7 +60496,7 @@
       "source_location": "L93"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -60499,7 +60505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -60508,7 +60514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -60517,7 +60523,7 @@
       "source_location": "L15"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -60526,7 +60532,7 @@
       "source_location": "L28"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -60535,7 +60541,7 @@
       "source_location": "L54"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -60544,7 +60550,7 @@
       "source_location": "L66"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -60553,7 +60559,7 @@
       "source_location": "L121"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -60562,7 +60568,7 @@
       "source_location": "L74"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -60571,7 +60577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -60580,7 +60586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -60589,7 +60595,7 @@
       "source_location": "L34"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -60598,7 +60604,7 @@
       "source_location": "L28"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -60607,7 +60613,7 @@
       "source_location": "L48"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -60616,7 +60622,7 @@
       "source_location": "L51"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -60625,7 +60631,7 @@
       "source_location": "L92"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -60634,7 +60640,7 @@
       "source_location": "L16"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -60643,7 +60649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -60652,7 +60658,7 @@
       "source_location": "L22"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -60661,7 +60667,7 @@
       "source_location": "L10"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -60670,7 +60676,7 @@
       "source_location": "L57"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -60679,7 +60685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -60688,7 +60694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -60697,7 +60703,7 @@
       "source_location": "L83"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -60706,7 +60712,7 @@
       "source_location": "L100"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -60715,49 +60721,13 @@
       "source_location": "L79"
     },
     {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
-      "label": "sessionGateway.ts",
-      "norm_label": "sessiongateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexactivesession",
-      "label": "useConvexActiveSession()",
-      "norm_label": "useconvexactivesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexheldsessions",
-      "label": "useConvexHeldSessions()",
-      "norm_label": "useconvexheldsessions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexsessionactions",
-      "label": "useConvexSessionActions()",
-      "norm_label": "useconvexsessionactions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L91"
-    },
-    {
       "community": 26,
       "file_type": "code",
       "id": "deposits_buildcashcontrolsdashboardsnapshot",
       "label": "buildCashControlsDashboardSnapshot()",
       "norm_label": "buildcashcontrolsdashboardsnapshot()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L225"
+      "source_location": "L226"
     },
     {
       "community": 26,
@@ -60784,7 +60754,7 @@
       "label": "collectStaffProfileIds()",
       "norm_label": "collectstaffprofileids()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L371"
+      "source_location": "L372"
     },
     {
       "community": 26,
@@ -60802,7 +60772,7 @@
       "label": "listRegisterSessionsForDashboard()",
       "norm_label": "listregistersessionsfordashboard()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L289"
+      "source_location": "L290"
     },
     {
       "community": 26,
@@ -60811,7 +60781,7 @@
       "label": "listRegisterSessionTimeline()",
       "norm_label": "listregistersessiontimeline()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L345"
+      "source_location": "L346"
     },
     {
       "community": 26,
@@ -60820,7 +60790,7 @@
       "label": "listRegisterSessionTransactions()",
       "norm_label": "listregistersessiontransactions()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L358"
+      "source_location": "L359"
     },
     {
       "community": 26,
@@ -60829,7 +60799,7 @@
       "label": "listSessionDeposits()",
       "norm_label": "listsessiondeposits()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L331"
+      "source_location": "L332"
     },
     {
       "community": 26,
@@ -60847,7 +60817,7 @@
       "label": "listStoreDeposits()",
       "norm_label": "liststoredeposits()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L317"
+      "source_location": "L318"
     },
     {
       "community": 26,
@@ -60856,7 +60826,7 @@
       "label": "listTerminalNames()",
       "norm_label": "listterminalnames()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L300"
+      "source_location": "L301"
     },
     {
       "community": 26,
@@ -60897,6 +60867,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
+      "label": "sessionGateway.ts",
+      "norm_label": "sessiongateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexactivesession",
+      "label": "useConvexActiveSession()",
+      "norm_label": "useconvexactivesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexheldsessions",
+      "label": "useConvexHeldSessions()",
+      "norm_label": "useconvexheldsessions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexsessionactions",
+      "label": "useConvexSessionActions()",
+      "norm_label": "useconvexsessionactions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
       "norm_label": "isbrowserfingerprintresult()",
@@ -60904,7 +60910,7 @@
       "source_location": "L4"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -60913,7 +60919,7 @@
       "source_location": "L20"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -60922,7 +60928,7 @@
       "source_location": "L42"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -60931,7 +60937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -60940,7 +60946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -60949,7 +60955,7 @@
       "source_location": "L36"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -60958,7 +60964,7 @@
       "source_location": "L48"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -60967,7 +60973,7 @@
       "source_location": "L64"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -60976,7 +60982,7 @@
       "source_location": "L13"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -60985,7 +60991,7 @@
       "source_location": "L46"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -60994,7 +61000,7 @@
       "source_location": "L21"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -61003,7 +61009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -61012,7 +61018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -61021,7 +61027,7 @@
       "source_location": "L8"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -61030,7 +61036,7 @@
       "source_location": "L5"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -61039,7 +61045,7 @@
       "source_location": "L20"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -61048,7 +61054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -61057,7 +61063,7 @@
       "source_location": "L11"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -61066,7 +61072,7 @@
       "source_location": "L9"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -61075,7 +61081,7 @@
       "source_location": "L25"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -61084,7 +61090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -61093,7 +61099,7 @@
       "source_location": "L50"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -61102,7 +61108,7 @@
       "source_location": "L92"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -61111,7 +61117,7 @@
       "source_location": "L74"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -61120,7 +61126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -61129,7 +61135,7 @@
       "source_location": "L62"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -61138,7 +61144,7 @@
       "source_location": "L109"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -61147,7 +61153,7 @@
       "source_location": "L177"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -61156,7 +61162,7 @@
       "source_location": "L18"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -61165,7 +61171,7 @@
       "source_location": "L52"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -61174,7 +61180,7 @@
       "source_location": "L68"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -61183,7 +61189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -61192,7 +61198,7 @@
       "source_location": "L68"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -61201,7 +61207,7 @@
       "source_location": "L26"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -61210,49 +61216,13 @@
       "source_location": "L7"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "productattribute_optionclassname",
-      "label": "optionClassName()",
-      "norm_label": "optionclassname()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L27"
     },
     {
       "community": 27,
@@ -61401,6 +61371,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "productattribute_optionclassname",
+      "label": "optionClassName()",
+      "norm_label": "optionclassname()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -61408,7 +61414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -61417,7 +61423,7 @@
       "source_location": "L43"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -61426,7 +61432,7 @@
       "source_location": "L13"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -61435,7 +61441,7 @@
       "source_location": "L88"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -61444,7 +61450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -61453,7 +61459,7 @@
       "source_location": "L111"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -61462,7 +61468,7 @@
       "source_location": "L66"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -61471,7 +61477,7 @@
       "source_location": "L127"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -61480,7 +61486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -61489,7 +61495,7 @@
       "source_location": "L25"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -61498,7 +61504,7 @@
       "source_location": "L90"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -61507,7 +61513,7 @@
       "source_location": "L82"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -61516,7 +61522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -61525,7 +61531,7 @@
       "source_location": "L115"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -61534,7 +61540,7 @@
       "source_location": "L105"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -61543,7 +61549,7 @@
       "source_location": "L110"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -61552,7 +61558,7 @@
       "source_location": "L121"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -61561,7 +61567,7 @@
       "source_location": "L26"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -61570,7 +61576,7 @@
       "source_location": "L71"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -61579,7 +61585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -61588,7 +61594,7 @@
       "source_location": "L46"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -61597,7 +61603,7 @@
       "source_location": "L24"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -61606,7 +61612,7 @@
       "source_location": "L20"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -61615,7 +61621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61624,7 +61630,7 @@
       "source_location": "L17"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -61633,7 +61639,7 @@
       "source_location": "L11"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -61642,7 +61648,7 @@
       "source_location": "L24"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -61651,7 +61657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61660,7 +61666,7 @@
       "source_location": "L20"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -61669,7 +61675,7 @@
       "source_location": "L65"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -61678,7 +61684,7 @@
       "source_location": "L14"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -61687,7 +61693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -61696,7 +61702,7 @@
       "source_location": "L126"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -61705,7 +61711,7 @@
       "source_location": "L130"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -61714,49 +61720,13 @@
       "source_location": "L876"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
       "norm_label": "harness-app-registry.ts",
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
-      "label": "valkey-runtime-app.ts",
-      "norm_label": "valkey-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "valkey_runtime_app_createvalkeyruntimeserver",
-      "label": "createValkeyRuntimeServer()",
-      "norm_label": "createvalkeyruntimeserver()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "valkey_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "valkey_runtime_app_stopvalkeyruntimeserver",
-      "label": "stopValkeyRuntimeServer()",
-      "norm_label": "stopvalkeyruntimeserver()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L61"
     },
     {
       "community": 28,
@@ -61905,6 +61875,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
+      "label": "valkey-runtime-app.ts",
+      "norm_label": "valkey-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "valkey_runtime_app_createvalkeyruntimeserver",
+      "label": "createValkeyRuntimeServer()",
+      "norm_label": "createvalkeyruntimeserver()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "valkey_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "valkey_runtime_app_stopvalkeyruntimeserver",
+      "label": "stopValkeyRuntimeServer()",
+      "norm_label": "stopvalkeyruntimeserver()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -61912,7 +61918,7 @@
       "source_location": "L49"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -61921,7 +61927,7 @@
       "source_location": "L17"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -61930,7 +61936,7 @@
       "source_location": "L11"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -61939,7 +61945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -61948,7 +61954,7 @@
       "source_location": "L26"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -61957,7 +61963,7 @@
       "source_location": "L72"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -61966,7 +61972,7 @@
       "source_location": "L36"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -61975,7 +61981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -61984,7 +61990,7 @@
       "source_location": "L96"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -61993,7 +61999,7 @@
       "source_location": "L94"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -62002,7 +62008,7 @@
       "source_location": "L95"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -62011,7 +62017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -62020,7 +62026,7 @@
       "source_location": "L15"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -62029,7 +62035,7 @@
       "source_location": "L11"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -62038,7 +62044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -62047,7 +62053,7 @@
       "source_location": "L98"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -62056,7 +62062,7 @@
       "source_location": "L33"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -62065,7 +62071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -62074,7 +62080,7 @@
       "source_location": "L85"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -62083,7 +62089,7 @@
       "source_location": "L31"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -62092,7 +62098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -62101,7 +62107,7 @@
       "source_location": "L12"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -62110,7 +62116,7 @@
       "source_location": "L21"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -62119,7 +62125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -62128,7 +62134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -62137,7 +62143,7 @@
       "source_location": "L5"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -62146,7 +62152,7 @@
       "source_location": "L12"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -62155,7 +62161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -62164,40 +62170,13 @@
       "source_location": "L14"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "label": "sessionQueryIndexes.test.ts",
-      "norm_label": "sessionqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readsourceslice",
-      "label": "readSourceSlice()",
-      "norm_label": "readsourceslice()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 29,
@@ -62346,6 +62325,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
+      "label": "sessionQueryIndexes.test.ts",
+      "norm_label": "sessionqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readsourceslice",
+      "label": "readSourceSlice()",
+      "norm_label": "readsourceslice()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
       "norm_label": "calculateactivitytrend()",
@@ -62353,7 +62359,7 @@
       "source_location": "L43"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -62362,7 +62368,7 @@
       "source_location": "L11"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -62371,7 +62377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -62380,7 +62386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -62389,7 +62395,7 @@
       "source_location": "L26"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -62398,7 +62404,7 @@
       "source_location": "L118"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -62407,7 +62413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -62416,7 +62422,7 @@
       "source_location": "L16"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -62425,7 +62431,7 @@
       "source_location": "L92"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -62434,7 +62440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -62443,7 +62449,7 @@
       "source_location": "L21"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -62452,7 +62458,7 @@
       "source_location": "L31"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -62461,7 +62467,7 @@
       "source_location": "L7"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -62470,7 +62476,7 @@
       "source_location": "L109"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -62479,7 +62485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -62488,7 +62494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -62497,7 +62503,7 @@
       "source_location": "L18"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -62506,7 +62512,7 @@
       "source_location": "L9"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -62515,7 +62521,7 @@
       "source_location": "L8"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -62524,7 +62530,7 @@
       "source_location": "L9"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -62533,7 +62539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -62542,7 +62548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -62551,7 +62557,7 @@
       "source_location": "L7"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -62560,7 +62566,7 @@
       "source_location": "L29"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -62569,7 +62575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -62578,40 +62584,13 @@
       "source_location": "L13"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
       "norm_label": "recordretailvoidpaymentallocations()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
       "source_location": "L45"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
-      "label": "registerSessionRepository.ts",
-      "norm_label": "registersessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "registersessionrepository_getactiveregistersessionforregisterstate",
-      "label": "getActiveRegisterSessionForRegisterState()",
-      "norm_label": "getactiveregistersessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
-      "label": "mapRegisterSessionToCashDrawerSummary()",
-      "norm_label": "mapregistersessiontocashdrawersummary()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
-      "source_location": "L13"
     },
     {
       "community": 3,
@@ -63039,6 +63018,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
+      "label": "registerSessionRepository.ts",
+      "norm_label": "registersessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "registersessionrepository_getactiveregistersessionforregisterstate",
+      "label": "getActiveRegisterSessionForRegisterState()",
+      "norm_label": "getactiveregistersessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
+      "label": "mapRegisterSessionToCashDrawerSummary()",
+      "norm_label": "mapregistersessiontocashdrawersummary()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
       "norm_label": "transactions.test.ts",
@@ -63046,7 +63052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -63055,7 +63061,7 @@
       "source_location": "L14"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -63064,7 +63070,7 @@
       "source_location": "L18"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -63073,7 +63079,7 @@
       "source_location": "L17"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -63082,7 +63088,7 @@
       "source_location": "L61"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -63091,7 +63097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -63100,7 +63106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -63109,7 +63115,7 @@
       "source_location": "L23"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -63118,7 +63124,7 @@
       "source_location": "L16"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -63127,7 +63133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -63136,7 +63142,7 @@
       "source_location": "L20"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -63145,7 +63151,7 @@
       "source_location": "L16"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -63154,7 +63160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -63163,7 +63169,7 @@
       "source_location": "L12"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -63172,7 +63178,7 @@
       "source_location": "L7"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -63181,7 +63187,7 @@
       "source_location": "L25"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -63190,7 +63196,7 @@
       "source_location": "L21"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -63199,7 +63205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -63208,7 +63214,7 @@
       "source_location": "L7"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -63217,7 +63223,7 @@
       "source_location": "L14"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -63226,7 +63232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -63235,7 +63241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -63244,7 +63250,7 @@
       "source_location": "L45"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -63253,7 +63259,7 @@
       "source_location": "L37"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -63262,7 +63268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -63271,40 +63277,13 @@
       "source_location": "L10"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
       "norm_label": "getworkflowtraceviewbylookupwithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
       "source_location": "L44"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
-      "label": "queryUsage.test.ts",
-      "norm_label": "queryusage.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "queryusage_test_comparebyfields",
-      "label": "compareByFields()",
-      "norm_label": "comparebyfields()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "queryusage_test_createtestctx",
-      "label": "createTestCtx()",
-      "norm_label": "createtestctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L100"
     },
     {
       "community": 31,
@@ -63322,7 +63301,7 @@
       "label": "authenticateCorrectionStaff()",
       "norm_label": "authenticatecorrectionstaff()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L375"
+      "source_location": "L379"
     },
     {
       "community": 31,
@@ -63331,7 +63310,7 @@
       "label": "exitCorrectionWorkflow()",
       "norm_label": "exitcorrectionworkflow()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L400"
+      "source_location": "L404"
     },
     {
       "community": 31,
@@ -63349,7 +63328,7 @@
       "label": "formatCorrectionHistoryChange()",
       "norm_label": "formatcorrectionhistorychange()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L132"
+      "source_location": "L136"
     },
     {
       "community": 31,
@@ -63385,7 +63364,7 @@
       "label": "getCorrectionHistoryChangeParts()",
       "norm_label": "getcorrectionhistorychangeparts()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L153"
+      "source_location": "L157"
     },
     {
       "community": 31,
@@ -63394,7 +63373,7 @@
       "label": "getTransactionCorrectionHistory()",
       "norm_label": "gettransactioncorrectionhistory()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L173"
+      "source_location": "L177"
     },
     {
       "community": 31,
@@ -63403,7 +63382,7 @@
       "label": "isManagerStaff()",
       "norm_label": "ismanagerstaff()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L128"
+      "source_location": "L132"
     },
     {
       "community": 31,
@@ -63412,7 +63391,7 @@
       "label": "requestCorrectionSubmit()",
       "norm_label": "requestcorrectionsubmit()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L530"
+      "source_location": "L534"
     },
     {
       "community": 31,
@@ -63430,7 +63409,7 @@
       "label": "runCustomerCorrection()",
       "norm_label": "runcustomercorrection()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L407"
+      "source_location": "L411"
     },
     {
       "community": 31,
@@ -63439,10 +63418,37 @@
       "label": "runPaymentMethodCorrection()",
       "norm_label": "runpaymentmethodcorrection()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L445"
+      "source_location": "L449"
     },
     {
       "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "label": "queryUsage.test.ts",
+      "norm_label": "queryusage.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "queryusage_test_comparebyfields",
+      "label": "compareByFields()",
+      "norm_label": "comparebyfields()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "queryusage_test_createtestctx",
+      "label": "createTestCtx()",
+      "norm_label": "createtestctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 311,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -63451,7 +63457,7 @@
       "source_location": "L5"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -63460,7 +63466,7 @@
       "source_location": "L25"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -63469,7 +63475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -63478,7 +63484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -63487,7 +63493,7 @@
       "source_location": "L35"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -63496,7 +63502,7 @@
       "source_location": "L25"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -63505,7 +63511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -63514,7 +63520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -63523,7 +63529,7 @@
       "source_location": "L4"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -63532,7 +63538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -63541,7 +63547,7 @@
       "source_location": "L19"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -63550,7 +63556,7 @@
       "source_location": "L5"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -63559,7 +63565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -63568,7 +63574,7 @@
       "source_location": "L19"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -63577,7 +63583,7 @@
       "source_location": "L11"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -63586,7 +63592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -63595,7 +63601,7 @@
       "source_location": "L22"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -63604,7 +63610,7 @@
       "source_location": "L8"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -63613,7 +63619,7 @@
       "source_location": "L21"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -63622,7 +63628,7 @@
       "source_location": "L13"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -63631,7 +63637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -63640,7 +63646,7 @@
       "source_location": "L100"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -63649,7 +63655,7 @@
       "source_location": "L10"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -63658,7 +63664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -63667,7 +63673,7 @@
       "source_location": "L100"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -63676,39 +63682,12 @@
       "source_location": "L10"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
       "norm_label": "analyticstopusers.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "log_items_provider_logitemsprovider",
-      "label": "LogItemsProvider()",
-      "norm_label": "logitemsprovider()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "log_items_provider_uselogitems",
-      "label": "useLogItems()",
-      "norm_label": "uselogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
-      "label": "log-items-provider.tsx",
-      "norm_label": "log-items-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -63849,6 +63828,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "log_items_provider_logitemsprovider",
+      "label": "LogItemsProvider()",
+      "norm_label": "logitemsprovider()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "log_items_provider_uselogitems",
+      "label": "useLogItems()",
+      "norm_label": "uselogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
+      "label": "log-items-provider.tsx",
+      "norm_label": "log-items-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
       "norm_label": "fadein()",
@@ -63856,7 +63862,7 @@
       "source_location": "L3"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -63865,7 +63871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -63874,7 +63880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -63883,7 +63889,7 @@
       "source_location": "L53"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -63892,7 +63898,7 @@
       "source_location": "L65"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -63901,7 +63907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -63910,7 +63916,7 @@
       "source_location": "L47"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -63919,7 +63925,7 @@
       "source_location": "L53"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -63928,7 +63934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -63937,7 +63943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -63946,40 +63952,13 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
       "norm_label": "videoplayer()",
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 324,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
-      "label": "useApprovedCommand.tsx",
-      "norm_label": "useapprovedcommand.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 324,
-      "file_type": "code",
-      "id": "useapprovedcommand_hasinlinemanagerproof",
-      "label": "hasInlineManagerProof()",
-      "norm_label": "hasinlinemanagerproof()",
-      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 324,
-      "file_type": "code",
-      "id": "useapprovedcommand_useapprovedcommand",
-      "label": "useApprovedCommand()",
-      "norm_label": "useapprovedcommand()",
-      "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
-      "source_location": "L67"
     },
     {
       "community": 325,
@@ -64528,7 +64507,7 @@
       "label": "asBoolean()",
       "norm_label": "asboolean()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L253"
+      "source_location": "L254"
     },
     {
       "community": 34,
@@ -64537,7 +64516,7 @@
       "label": "asNumber()",
       "norm_label": "asnumber()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L257"
+      "source_location": "L258"
     },
     {
       "community": 34,
@@ -64546,7 +64525,7 @@
       "label": "asRecord()",
       "norm_label": "asrecord()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L245"
+      "source_location": "L246"
     },
     {
       "community": 34,
@@ -64555,7 +64534,7 @@
       "label": "buildOpeningFloatCorrectionApprovalRequirement()",
       "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L141"
+      "source_location": "L142"
     },
     {
       "community": 34,
@@ -64564,7 +64543,7 @@
       "label": "buildRegisterSessionCloseoutReview()",
       "norm_label": "buildregistersessioncloseoutreview()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L307"
+      "source_location": "L308"
     },
     {
       "community": 34,
@@ -64573,7 +64552,7 @@
       "label": "buildRegisterSessionVarianceApprovalRequirement()",
       "norm_label": "buildregistersessionvarianceapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L361"
+      "source_location": "L362"
     },
     {
       "community": 34,
@@ -64582,7 +64561,7 @@
       "label": "cancelPendingApprovalIfNeeded()",
       "norm_label": "cancelpendingapprovalifneeded()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L488"
+      "source_location": "L489"
     },
     {
       "community": 34,
@@ -64591,7 +64570,7 @@
       "label": "getCashControlsConfig()",
       "norm_label": "getcashcontrolsconfig()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L288"
+      "source_location": "L289"
     },
     {
       "community": 34,
@@ -64600,7 +64579,7 @@
       "label": "listRegisterSessionsForCloseout()",
       "norm_label": "listregistersessionsforcloseout()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L406"
+      "source_location": "L407"
     },
     {
       "community": 34,
@@ -64609,7 +64588,7 @@
       "label": "listStaffNames()",
       "norm_label": "liststaffnames()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L436"
+      "source_location": "L437"
     },
     {
       "community": 34,
@@ -64618,7 +64597,7 @@
       "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
       "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L266"
+      "source_location": "L267"
     },
     {
       "community": 34,
@@ -64627,7 +64606,7 @@
       "label": "staffProfileCanReviewCloseoutVariance()",
       "norm_label": "staffprofilecanreviewcloseoutvariance()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L453"
+      "source_location": "L454"
     },
     {
       "community": 34,
@@ -64636,7 +64615,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L261"
+      "source_location": "L262"
     },
     {
       "community": 34,
@@ -73321,7 +73300,7 @@
       "label": "applyCloseoutCommandResult()",
       "norm_label": "applycloseoutcommandresult()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L519"
+      "source_location": "L521"
     },
     {
       "community": 6,
@@ -73330,7 +73309,7 @@
       "label": "applyCommandResult()",
       "norm_label": "applycommandresult()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L509"
+      "source_location": "L511"
     },
     {
       "community": 6,
@@ -73339,7 +73318,7 @@
       "label": "buildDepositSubmissionKey()",
       "norm_label": "builddepositsubmissionkey()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L274"
+      "source_location": "L276"
     },
     {
       "community": 6,
@@ -73348,7 +73327,7 @@
       "label": "errorMessage()",
       "norm_label": "errormessage()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2124"
+      "source_location": "L2140"
     },
     {
       "community": 6,
@@ -73357,7 +73336,7 @@
       "label": "formatCurrency()",
       "norm_label": "formatcurrency()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L278"
+      "source_location": "L280"
     },
     {
       "community": 6,
@@ -73366,7 +73345,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L327"
+      "source_location": "L329"
     },
     {
       "community": 6,
@@ -73375,7 +73354,7 @@
       "label": "formatRegisterHeaderName()",
       "norm_label": "formatregisterheadername()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L340"
+      "source_location": "L342"
     },
     {
       "community": 6,
@@ -73384,7 +73363,7 @@
       "label": "formatRegisterName()",
       "norm_label": "formatregistername()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L335"
+      "source_location": "L337"
     },
     {
       "community": 6,
@@ -73393,7 +73372,7 @@
       "label": "formatSessionCode()",
       "norm_label": "formatsessioncode()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L354"
+      "source_location": "L356"
     },
     {
       "community": 6,
@@ -73402,7 +73381,7 @@
       "label": "formatStatusLabel()",
       "norm_label": "formatstatuslabel()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L297"
+      "source_location": "L299"
     },
     {
       "community": 6,
@@ -73411,7 +73390,7 @@
       "label": "formatStoredAmountForInput()",
       "norm_label": "formatstoredamountforinput()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L286"
+      "source_location": "L288"
     },
     {
       "community": 6,
@@ -73420,7 +73399,7 @@
       "label": "formatTimestamp()",
       "norm_label": "formattimestamp()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L290"
+      "source_location": "L292"
     },
     {
       "community": 6,
@@ -73429,7 +73408,7 @@
       "label": "getNumericEventMetadata()",
       "norm_label": "getnumericeventmetadata()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L312"
+      "source_location": "L314"
     },
     {
       "community": 6,
@@ -73438,7 +73417,7 @@
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L366"
+      "source_location": "L368"
     },
     {
       "community": 6,
@@ -73447,7 +73426,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L358"
+      "source_location": "L360"
     },
     {
       "community": 6,
@@ -73456,7 +73435,7 @@
       "label": "handleAuthenticatedCloseoutStaff()",
       "norm_label": "handleauthenticatedcloseoutstaff()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L689"
+      "source_location": "L691"
     },
     {
       "community": 6,
@@ -73465,7 +73444,7 @@
       "label": "handleOpeningFloatApprovalApproved()",
       "norm_label": "handleopeningfloatapprovalapproved()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L803"
+      "source_location": "L805"
     },
     {
       "community": 6,
@@ -73474,7 +73453,7 @@
       "label": "handleRecordDeposit()",
       "norm_label": "handlerecorddeposit()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L536"
+      "source_location": "L538"
     },
     {
       "community": 6,
@@ -73483,7 +73462,7 @@
       "label": "handleReviewCloseout()",
       "norm_label": "handlereviewcloseout()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L616"
+      "source_location": "L618"
     },
     {
       "community": 6,
@@ -73492,7 +73471,7 @@
       "label": "handleSubmitCloseout()",
       "norm_label": "handlesubmitcloseout()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L579"
+      "source_location": "L581"
     },
     {
       "community": 6,
@@ -73501,7 +73480,7 @@
       "label": "handleSubmitOpeningFloatCorrection()",
       "norm_label": "handlesubmitopeningfloatcorrection()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L633"
+      "source_location": "L635"
     },
     {
       "community": 6,
@@ -73510,7 +73489,7 @@
       "label": "isCloseoutRejectionEvent()",
       "norm_label": "iscloseoutrejectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L301"
+      "source_location": "L303"
     },
     {
       "community": 6,
@@ -73519,7 +73498,7 @@
       "label": "isManagerStaff()",
       "norm_label": "ismanagerstaff()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L270"
+      "source_location": "L272"
     },
     {
       "community": 6,
@@ -73528,7 +73507,7 @@
       "label": "isOpeningFloatCorrectionEvent()",
       "norm_label": "isopeningfloatcorrectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L305"
+      "source_location": "L307"
     },
     {
       "community": 6,
@@ -73537,7 +73516,7 @@
       "label": "isRegisterSessionCorrectionEvent()",
       "norm_label": "isregistersessioncorrectionevent()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L321"
+      "source_location": "L323"
     },
     {
       "community": 6,
@@ -73546,7 +73525,7 @@
       "label": "runOpeningFloatCorrection()",
       "norm_label": "runopeningfloatcorrection()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L757"
+      "source_location": "L759"
     },
     {
       "community": 6,
@@ -73555,7 +73534,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L265"
+      "source_location": "L267"
     },
     {
       "community": 60,
@@ -75670,7 +75649,7 @@
       "label": "canOperateRegister()",
       "norm_label": "canoperateregister()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L148"
+      "source_location": "L160"
     },
     {
       "community": 68,
@@ -75733,7 +75712,7 @@
       "label": "useRegisterViewModel()",
       "norm_label": "useregisterviewmodel()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L157"
+      "source_location": "L169"
     },
     {
       "community": 680,
@@ -77196,73 +77175,73 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -77448,73 +77427,73 @@
     {
       "community": 74,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -77700,74 +77679,74 @@
     {
       "community": 75,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
     },
     {
       "community": 750,
@@ -77952,74 +77931,74 @@
     {
       "community": 76,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 760,
@@ -78204,74 +78183,74 @@
     {
       "community": 77,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
     },
     {
       "community": 77,
       "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 770,
@@ -78456,74 +78435,74 @@
     {
       "community": 78,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 780,
@@ -78708,74 +78687,74 @@
     {
       "community": 79,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
+      "id": "expensesessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2359"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
+      "id": "expensesessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2353"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
+      "id": "expensesessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2349"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
+      "id": "expensesessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2369"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
+      "id": "expensesessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2115"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
+      "id": "expensesessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2205"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
+      "id": "expensesessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2097"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 790,
@@ -79176,74 +79155,74 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2359"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2353"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2349"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2369"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2115"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2205"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2097"
     },
     {
       "community": 800,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1549
-- Graph nodes: 4139
-- Graph edges: 3772
+- Graph nodes: 4138
+- Graph edges: 3771
 - Communities: 1477
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -175,6 +175,7 @@ describe("cash control closeouts", () => {
     expect(source).toContain("internal.operations.registerSessions.correctRegisterSessionOpeningFloat");
     expect(source).toContain("register_session_opening_float_corrected");
     expect(source).toContain("opening_float_corrected");
+    expect(source).toContain("requestedByStaffProfileId: args.actorStaffProfileId");
   });
 
   it("returns user_error for invalid opening float corrections without mutating", async () => {

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -59,12 +59,13 @@ type CashControlsConfig = {
 
 type CloseoutApprovalRequestRecord = Pick<
   Doc<"approvalRequest">,
-  "_id" | "createdAt" | "reason" | "registerSessionId" | "requestType" | "requestedByStaffProfileId" | "status"
+  "_id" | "createdAt" | "notes" | "reason" | "registerSessionId" | "requestType" | "requestedByStaffProfileId" | "status"
 >;
 
 type CloseoutApprovalRequestSummary = {
   _id: Id<"approvalRequest">;
   createdAt: number;
+  notes?: string;
   reason?: string;
   requestedByStaffName: string | null;
   status: string;
@@ -523,29 +524,33 @@ export const getCloseoutSnapshot = query({
     ctx: QueryCtx,
     args: { storeId: Id<"store"> }
   ): Promise<CloseoutSnapshot> => {
-    const [registerSessions, pendingApprovalRequests, store] = await Promise.all([
+    const [registerSessions, store] = await Promise.all([
       listRegisterSessionsForCloseout(ctx, args.storeId),
-      ctx.db
-        .query("approvalRequest")
-        .withIndex("by_storeId_status", (q) =>
-          q.eq("storeId", args.storeId).eq("status", "pending")
-        )
-        .take(CLOSEOUT_SESSION_LIMIT),
       ctx.runQuery(internal.inventory.stores.findById, { id: args.storeId }),
     ]);
     const config = getCashControlsConfig(store);
-    const approvalMap = new Map<Id<"approvalRequest">, CloseoutApprovalRequestRecord>(
-      pendingApprovalRequests
-        .filter(
-          (approvalRequest: Doc<"approvalRequest">) =>
-            approvalRequest.registerSessionId &&
-            approvalRequest.requestType === "variance_review"
-        )
-        .map((approvalRequest: Doc<"approvalRequest">) => [
-          approvalRequest._id,
-          approvalRequest,
-        ])
+    const approvalRequestIds = Array.from(
+      new Set(
+        registerSessions
+          .map((registerSession) => registerSession.managerApprovalRequestId)
+          .filter(Boolean) as Id<"approvalRequest">[],
+      ),
     );
+    const approvalRequests = await Promise.all(
+      approvalRequestIds.map((approvalRequestId) =>
+        ctx.db.get("approvalRequest", approvalRequestId),
+      ),
+    );
+    const approvalMap = new Map<Id<"approvalRequest">, CloseoutApprovalRequestRecord>();
+    for (const approvalRequest of approvalRequests) {
+      if (
+        approvalRequest &&
+        approvalRequest.registerSessionId &&
+        approvalRequest.requestType === "variance_review"
+      ) {
+        approvalMap.set(approvalRequest._id, approvalRequest);
+      }
+    }
     const staffProfileIds = new Set<Id<"staffProfile">>();
 
     for (const registerSession of registerSessions) {
@@ -589,6 +594,7 @@ export const getCloseoutSnapshot = query({
             ? {
                 _id: approvalRequest._id,
                 createdAt: approvalRequest.createdAt,
+                notes: approvalRequest.notes,
                 reason: approvalRequest.reason,
                 requestedByStaffName: approvalRequest.requestedByStaffProfileId
                   ? staffMap.get(approvalRequest.requestedByStaffProfileId) ?? null
@@ -1109,6 +1115,7 @@ export const correctRegisterSessionOpeningFloat = mutation({
       action: REGISTER_OPENING_FLOAT_CORRECTION_ACTION,
       approvalProofId: args.approvalProofId,
       requiredRole: "manager",
+      requestedByStaffProfileId: args.actorStaffProfileId,
       storeId: args.storeId,
       subject: {
         type: "register_session",

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -27,6 +27,7 @@ describe("cash control deposits", () => {
           "session_closing" as Id<"registerSession">,
           {
             _id: "approval_1" as Id<"approvalRequest">,
+            notes: "Counted twice before manager review.",
             reason: "Variance review required.",
             status: "pending",
           },
@@ -110,6 +111,7 @@ describe("cash control deposits", () => {
       _id: "session_closing",
       pendingApprovalRequest: {
         _id: "approval_1",
+        notes: "Counted twice before manager review.",
         status: "pending",
       },
       terminalName: "Back counter",

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -59,7 +59,7 @@ type StaffNameMap = Map<Id<"staffProfile">, string>;
 
 type CashControlApprovalRequest = Pick<
   Doc<"approvalRequest">,
-  "_id" | "reason" | "requestedByStaffProfileId" | "status"
+  "_id" | "notes" | "reason" | "requestedByStaffProfileId" | "status"
 >;
 
 type CashControlDepositAllocation = Pick<
@@ -211,6 +211,7 @@ function buildRegisterSessionSummary(args: {
     pendingApprovalRequest: args.approvalRequest
       ? {
           _id: args.approvalRequest._id,
+          notes: args.approvalRequest.notes,
           reason: args.approvalRequest.reason,
           requestedByStaffName: args.approvalRequest.requestedByStaffProfileId
             ? args.staffNamesById.get(args.approvalRequest.requestedByStaffProfileId) ?? null

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -1208,6 +1208,7 @@ describe("RegisterSessionViewContent", () => {
             ...baseSnapshot.registerSession,
             pendingApprovalRequest: {
               _id: "approval-1",
+              notes: "Counted twice before handoff.",
               reason:
                 "Variance of -500 exceeded the closeout approval threshold.",
               requestedByStaffName: "Ama Mensah",
@@ -1224,6 +1225,10 @@ describe("RegisterSessionViewContent", () => {
       screen.getByRole("heading", { name: "Review closeout variance" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Manager approval pending")).toBeInTheDocument();
+    expect(screen.getByText("Request notes")).toBeInTheDocument();
+    expect(
+      screen.getByText("Counted twice before handoff."),
+    ).toBeInTheDocument();
     expect(screen.queryByText("Closeout workflow")).not.toBeInTheDocument();
     expect(
       screen.queryByText(

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -70,6 +70,7 @@ const LINKED_TRANSACTIONS_PREVIEW_LIMIT = 5;
 
 type RegisterSessionApprovalRequest = {
   _id: string;
+  notes?: string | null;
   reason?: string | null;
   requestedByStaffName?: string | null;
   status: string;
@@ -82,6 +83,7 @@ type RegisterSessionDetail = {
   countedCash?: number;
   expectedCash: number;
   netExpectedCash?: number;
+  notes?: string | null;
   openedAt: number;
   openedByStaffName?: string | null;
   openingFloat: number;
@@ -863,6 +865,8 @@ export function RegisterSessionViewContent({
     reviewReasonFormatter,
     registerSession?.pendingApprovalRequest?.reason,
   );
+  const closeoutRequestNotes =
+    registerSession?.pendingApprovalRequest?.notes ?? registerSession?.notes;
   const formattedCloseoutReviewReason = formatReviewReason(
     reviewReasonFormatter,
     registerSessionSnapshot?.closeoutReview?.reason,
@@ -1007,15 +1011,27 @@ export function RegisterSessionViewContent({
               </p>
             </div>
           </div>
-          <p className="mt-4 border-t border-amber-200/70 pt-3 text-xs text-muted-foreground">
-            Requested by{" "}
-            {registerSession.pendingApprovalRequest?.requestedByStaffName
-              ? formatStaffDisplayName({
-                  fullName:
-                    registerSession.pendingApprovalRequest.requestedByStaffName,
-                })
-              : "staff not recorded"}
-          </p>
+          <div className="mt-4 space-y-3 border-t border-amber-200/70 pt-3 text-xs text-muted-foreground">
+            <p>
+              Requested by{" "}
+              {registerSession.pendingApprovalRequest?.requestedByStaffName
+                ? formatStaffDisplayName({
+                    fullName:
+                      registerSession.pendingApprovalRequest.requestedByStaffName,
+                  })
+                : "staff not recorded"}
+            </p>
+            {closeoutRequestNotes ? (
+              <div className="space-y-1 rounded-md bg-amber-50/60 px-3 py-2 text-muted-foreground">
+                <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-amber-900/70">
+                  Request notes
+                </p>
+                <p className="text-sm leading-5 text-foreground">
+                  {closeoutRequestNotes}
+                </p>
+              </div>
+            ) : null}
+          </div>
         </div>
 
         <label className="block w-[480px] space-y-2">

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
@@ -193,6 +193,42 @@ describe("CommandApprovalDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("formats closeout variance approval copy as stored currency", () => {
+    renderDialog({
+      approval: {
+        ...inlineApproval,
+        action: {
+          key: "register.closeout.submit",
+          label: "Submit register closeout",
+        },
+        copy: {
+          title: "Manager approval required",
+          message:
+            "Variance of -20000 exceeded the closeout approval threshold.",
+          primaryActionLabel: "Approve closeout",
+        },
+        reason:
+          "Variance of -20000 exceeded the closeout approval threshold.",
+        subject: {
+          id: "3",
+          label: "3",
+          type: "register_session",
+        },
+      },
+    });
+
+    expect(
+      screen.getByText(
+        "Variance of GH₵-200 exceeded the closeout approval threshold.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Variance of -20000 exceeded the closeout approval threshold.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("authenticates a manager, creates an approval proof, and returns proof id for retry", async () => {
     const { user, onAuthenticateForApproval, onApproved } = renderDialog();
 

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
@@ -6,6 +6,7 @@ import {
   type StaffAuthenticationResult,
 } from "@/components/staff-auth/StaffAuthenticationDialog";
 import { Button } from "@/components/ui/button";
+import { formatReviewReason } from "@/components/cash-controls/formatReviewReason";
 import {
   Dialog,
   DialogContent,
@@ -23,6 +24,7 @@ import {
   GENERIC_UNEXPECTED_ERROR_MESSAGE,
   GENERIC_UNEXPECTED_ERROR_TITLE,
 } from "~/shared/commandResult";
+import { currencyFormatter } from "~/shared/currencyFormatter";
 
 type InlineManagerResolutionMode = Extract<
   ApprovalResolutionMode,
@@ -105,6 +107,9 @@ export function CommandApprovalDialog({
   }
 
   const inlineResolution = getInlineManagerResolution(approval);
+  const approvalMessage =
+    formatReviewReason(currencyFormatter("GHS"), approval.copy.message) ??
+    approval.copy.message;
 
   if (!inlineResolution) {
     const asyncResolution = getAsyncResolution(approval);
@@ -118,7 +123,7 @@ export function CommandApprovalDialog({
                 ? "Manager review required"
                 : approval.copy.title}
             </DialogTitle>
-            <DialogDescription>{approval.copy.message}</DialogDescription>
+            <DialogDescription>{approvalMessage}</DialogDescription>
           </div>
 
           <div className="flex justify-end">
@@ -137,7 +142,7 @@ export function CommandApprovalDialog({
         <div className="flex shrink-0 flex-col gap-layout-md border-b border-border/80 px-layout-lg pb-layout-md pt-layout-lg sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 space-y-layout-xs">
             <DialogTitle>{approval.copy.title}</DialogTitle>
-            <DialogDescription>{approval.copy.message}</DialogDescription>
+            <DialogDescription>{approvalMessage}</DialogDescription>
           </div>
         </div>
 

--- a/packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx
+++ b/packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx
@@ -258,6 +258,7 @@ describe("useApprovedCommand", () => {
       kind: "approval_required",
       approval: asyncApproval,
     });
-    expect(result.current.approvalDialog?.approval).toEqual(asyncApproval);
+    expect(result.current.approvalDialog).toBeNull();
+    expect(result.current.pendingApproval).toBeNull();
   });
 });

--- a/packages/athena-webapp/src/components/operations/useApprovedCommand.tsx
+++ b/packages/athena-webapp/src/components/operations/useApprovedCommand.tsx
@@ -64,6 +64,12 @@ function hasInlineManagerProof(approval: ApprovalRequirement) {
   );
 }
 
+function hasAsyncApprovalRequest(approval: ApprovalRequirement) {
+  return approval.resolutionModes.some(
+    (mode) => mode.kind === "async_request" && Boolean(mode.approvalRequestId),
+  );
+}
+
 export function useApprovedCommand({ onAuthenticateForApproval, storeId }: UseApprovedCommandArgs) {
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval<unknown> | null>(null);
@@ -75,6 +81,13 @@ export function useApprovedCommand({ onAuthenticateForApproval, storeId }: UseAp
     ) => {
       if (isApprovalRequiredResult(result)) {
         pending.onApprovalRequired?.(result.approval);
+
+        if (hasAsyncApprovalRequest(result.approval)) {
+          setPendingApproval(null);
+          await pending.onResult(result);
+          return result;
+        }
+
         setPendingApproval({
           ...pending,
           approval: result.approval,

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -17,9 +17,35 @@ vi.mock("@/components/ui/sidebar", () => ({
 }));
 
 vi.mock("@tanstack/react-router", () => ({
-  Link: ({ children, to }: { children: ReactNode; to: string }) => (
-    <a href={to}>{children}</a>
-  ),
+  Link: ({
+    children,
+    params,
+    search,
+    to,
+  }: {
+    children: ReactNode;
+    params?:
+      | ((params: Record<string, string>) => Record<string, string>)
+      | Record<string, string>;
+    search?: Record<string, string>;
+    to: string;
+  }) => {
+    const resolvedParams =
+      typeof params === "function"
+        ? params({
+            orgUrlSlug: "$orgUrlSlug",
+            sessionId: "$sessionId",
+            storeUrlSlug: "$storeUrlSlug",
+          })
+        : params;
+    const href = to.replace(
+      "$sessionId",
+      resolvedParams?.sessionId ?? "$sessionId",
+    );
+    const query = search ? `?${new URLSearchParams(search)}` : "";
+
+    return <a href={`${href}${query}`}>{children}</a>;
+  },
 }));
 
 vi.mock("@/components/View", () => ({
@@ -290,7 +316,10 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("Set up this register")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /open register setup/i }),
-    ).toHaveAttribute("href", "/$orgUrlSlug/store/$storeUrlSlug/pos/settings");
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/pos/settings?o=%252F",
+    );
     expect(screen.queryByText("product-search-input")).not.toBeInTheDocument();
     expect(
       screen.queryByText("register-checkout-panel"),
@@ -1124,6 +1153,7 @@ describe("POSRegisterView", () => {
         registerLabel: "Front Counter",
         registerNumber: "1",
         currency: "GHS",
+        canOpenCashControls: false,
         openingFloat: "50.00",
         notes: "",
         errorMessage: null,
@@ -1159,6 +1189,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /cash controls/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders recovery copy, inline errors, and escape actions in the product lookup space", async () => {
@@ -1187,6 +1220,7 @@ describe("POSRegisterView", () => {
         registerLabel: "Front Counter",
         registerNumber: "1",
         currency: "GHS",
+        canOpenCashControls: true,
         openingFloat: "50.00",
         notes: "",
         errorMessage:
@@ -1225,7 +1259,10 @@ describe("POSRegisterView", () => {
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
-    ).toHaveAttribute("href", "/$orgUrlSlug/store/$storeUrlSlug/cash-controls");
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls?o=%252F",
+    );
 
     await userEvent.click(screen.getByRole("button", { name: /sign out/i }));
 
@@ -1259,6 +1296,8 @@ describe("POSRegisterView", () => {
         registerLabel: "Front Counter",
         registerNumber: "1",
         currency: "GHS",
+        canOpenCashControls: true,
+        cashControlsRegisterSessionId: "drawer-1",
         closeoutCountedCash: "",
         closeoutDraftVariance: -500,
         closeoutNotes: "",
@@ -1293,7 +1332,10 @@ describe("POSRegisterView", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/drawer-1?o=%252F",
+    );
     expect(screen.getByText("Expected")).toBeInTheDocument();
     expect(screen.getByText("GH₵50")).toBeInTheDocument();
     expect(screen.getByText("GH₵-5")).toBeInTheDocument();
@@ -1359,6 +1401,7 @@ describe("POSRegisterView", () => {
         expectedCash: 868_100,
         errorMessage: null,
         canOpenCashControls: true,
+        cashControlsRegisterSessionId: "drawer-1",
         hasPendingCloseoutApproval: true,
         isReopeningCloseout: false,
         onReopenRegister: vi.fn(),
@@ -1384,7 +1427,10 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("GH₵-5,681")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/drawer-1?o=%252F",
+    );
     expect(
       screen.getByRole("button", { name: /reopen register/i }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -16,9 +16,11 @@ import {
 
 function CashControlsButton({
   className,
+  registerSessionId,
   variant = "ghost",
 }: {
   className?: string;
+  registerSessionId?: string;
   variant?: "default" | "ghost";
 }) {
   return (
@@ -28,12 +30,17 @@ function CashControlsButton({
         params={(params) => ({
           ...params,
           orgUrlSlug: params.orgUrlSlug!,
+          ...(registerSessionId ? { sessionId: registerSessionId } : {}),
           storeUrlSlug: params.storeUrlSlug!,
         })}
         search={{
           o: getOrigin(),
         }}
-        to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls"
+        to={
+          registerSessionId
+            ? "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
+            : "/$orgUrlSlug/store/$storeUrlSlug/cash-controls"
+        }
       >
         Cash controls
         <ArrowRightIcon className="ml-2 h-4 w-4" />
@@ -260,6 +267,7 @@ export function RegisterDrawerGate({
               {drawerGate.canOpenCashControls ? (
                 <CashControlsButton
                   className="w-full sm:w-auto"
+                  registerSessionId={drawerGate.cashControlsRegisterSessionId}
                   variant="default"
                 />
               ) : null}
@@ -405,7 +413,12 @@ export function RegisterDrawerGate({
                     "Reopen register"}
                 </LoadingButton>
 
-                <CashControlsButton className="w-full sm:w-auto" />
+                {drawerGate.canOpenCashControls ? (
+                  <CashControlsButton
+                    className="w-full sm:w-auto"
+                    registerSessionId={drawerGate.cashControlsRegisterSessionId}
+                  />
+                ) : null}
 
                 <Button
                   className="w-full sm:w-auto"
@@ -516,7 +529,12 @@ export function RegisterDrawerGate({
             Sign out
           </Button>
 
-          <CashControlsButton className="w-full sm:w-auto" />
+          {drawerGate.canOpenCashControls ? (
+            <CashControlsButton
+              className="w-full sm:w-auto"
+              registerSessionId={drawerGate.cashControlsRegisterSessionId}
+            />
+          ) : null}
         </div>
       </form>
     </div>

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -808,18 +808,13 @@ describe("TransactionView", () => {
     await user.click(screen.getByRole("button", { name: "Confirm" }));
 
     expect(
-      await screen.findByText("Manager approval required"),
-    ).toBeInTheDocument();
+      screen.queryByText("Manager approval required"),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "A manager needs to review this completed transaction payment method update before it is applied.",
       ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Approval request approval-1 is pending in the review queue.",
-      ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(approvalMutation).not.toHaveBeenCalled();
     expect(authMutation).toHaveBeenCalledWith({
       allowedRoles: ["cashier", "manager"],
@@ -912,7 +907,9 @@ describe("TransactionView", () => {
         transactionId: "txn_19",
       });
     });
-    expect(screen.queryByText("Manager approval required")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Manager approval required"),
+    ).not.toBeInTheDocument();
   });
 
   it("exits the correction workflow after an async payment correction request is queued", async () => {
@@ -988,10 +985,6 @@ describe("TransactionView", () => {
       screen.getByRole("button", { name: "Submit payment update" }),
     );
     await user.click(screen.getByRole("button", { name: "Confirm" }));
-    await screen.findByText(
-      "Approval request approval-1 is pending in the review queue.",
-    );
-
     await waitFor(() => {
       expect(approvalMutation).not.toHaveBeenCalled();
       expect(paymentMutation).toHaveBeenNthCalledWith(1, {
@@ -1005,6 +998,7 @@ describe("TransactionView", () => {
     expect(
       screen.queryByText("Transaction updates"),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText("Manager approval required")).not.toBeInTheDocument();
   });
 
   it("renders correction history when operational events are present", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -120,7 +120,11 @@ function formatPaymentMethodLabel(method: unknown) {
 }
 
 function requiresInlineManagerProof(approval: ApprovalRequirement) {
-  return approval.resolutionModes.some(
+  const hasAsyncApprovalRequest = approval.resolutionModes.some(
+    (mode) => mode.kind === "async_request" && Boolean(mode.approvalRequestId),
+  );
+
+  return !hasAsyncApprovalRequest && approval.resolutionModes.some(
     (mode) => mode.kind === "inline_manager_proof",
   );
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -151,6 +151,7 @@ export interface RegisterDrawerGateState {
   closeoutSecondaryActionLabel?: string;
   expectedCash?: number;
   canOpenCashControls?: boolean;
+  cashControlsRegisterSessionId?: Id<"registerSession">;
   canOpenDrawer?: boolean;
   hasPendingCloseoutApproval?: boolean;
   notes?: string;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -600,6 +600,9 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate?.expectedCash).toBe(5_000);
     expect(result.current.drawerGate?.hasPendingCloseoutApproval).toBe(true);
     expect(result.current.drawerGate?.canOpenCashControls).toBe(true);
+    expect(result.current.drawerGate?.cashControlsRegisterSessionId).toBe(
+      "drawer-1",
+    );
     expect(result.current.drawerGate?.closeoutSubmittedCountedCash).toBe(4_500);
     expect(result.current.drawerGate?.closeoutSubmittedVariance).toBe(-500);
   });
@@ -719,36 +722,11 @@ describe("useRegisterViewModel", () => {
       resumableSession: null,
     };
     mockActiveSession = null;
-    mockSubmitRegisterSessionCloseout
-      .mockResolvedValueOnce({
-        kind: "approval_required",
-        approval: {
-          action: {
-            key: "cash_controls.register_session.review_variance",
-            label: "Review register closeout variance",
-          },
-          copy: {
-            title: "Manager approval required",
-            message:
-              "Enter manager credentials to approve this register closeout variance.",
-            primaryActionLabel: "Approve closeout",
-            secondaryActionLabel: "Cancel",
-          },
-          reason: "End of shift count",
-          requiredRole: "manager",
-          resolutionModes: [{ kind: "inline_manager_proof" }],
-          subject: {
-            id: "drawer-1",
-            label: "Register 1",
-            type: "register_session",
-          },
-        },
-      })
-      .mockResolvedValueOnce(
-        ok({
-          action: "closed",
-        }),
-      );
+    mockSubmitRegisterSessionCloseout.mockResolvedValueOnce(
+      ok({
+        action: "closed",
+      }),
+    );
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -768,18 +746,13 @@ describe("useRegisterViewModel", () => {
       await result.current.drawerGate?.onSubmitCloseout?.();
     });
 
-    expect(mockSubmitRegisterSessionCloseout).toHaveBeenCalledWith({
-      actorStaffProfileId: "staff-1",
-      actorUserId: "user-1",
-      approvalProofId: undefined,
-      countedCash: 4_800,
-      notes: "End of shift count",
-      registerSessionId: "drawer-1",
-      storeId: "store-1",
-    });
+    expect(mockSubmitRegisterSessionCloseout).not.toHaveBeenCalled();
     expect(result.current.closeoutApprovalDialog?.open).toBe(true);
     expect(result.current.closeoutApprovalDialog?.approval?.action.key).toBe(
       "cash_controls.register_session.review_variance",
+    );
+    expect(result.current.closeoutApprovalDialog?.approval?.reason).toBe(
+      "End of shift count",
     );
 
     await act(async () => {
@@ -791,11 +764,7 @@ describe("useRegisterViewModel", () => {
           requiredRole: "manager",
           requestedByStaffProfileId: "staff-1" as Id<"staffProfile">,
           storeId: "store-1" as Id<"store">,
-          subject: {
-            id: "drawer-1",
-            label: "Register 1",
-            type: "register_session",
-          },
+          subject: result.current.closeoutApprovalDialog.approval!.subject,
           username: "ama",
         });
 
@@ -818,7 +787,7 @@ describe("useRegisterViewModel", () => {
       storeId: "store-1",
       subject: {
         id: "drawer-1",
-        label: "Register 1",
+        label: "1",
         type: "register_session",
       },
       username: "ama",
@@ -969,6 +938,91 @@ describe("useRegisterViewModel", () => {
     expect(mockCorrectRegisterSessionOpeningFloat).toHaveBeenCalledWith({
       actorStaffProfileId: "staff-1",
       actorUserId: "user-1",
+      approvalProofId: undefined,
+      correctedOpeningFloat: 4_500,
+      reason: "Cashier typo",
+      registerSessionId: "drawer-1",
+      storeId: "store-1",
+    });
+    expect(toast.success).toHaveBeenCalledWith("Opening float corrected");
+  });
+
+  it("opens manager re-auth when opening float correction requires approval", async () => {
+    mockCorrectRegisterSessionOpeningFloat
+      .mockResolvedValueOnce({
+        kind: "approval_required",
+        approval: {
+          action: {
+            key: "cash_controls.register_session.correct_opening_float",
+            label: "Correct opening float",
+          },
+          copy: {
+            title: "Manager approval required",
+            message:
+              "Authorization is needed from a manager to correct this register opening float.",
+            primaryActionLabel: "Approve correction",
+            secondaryActionLabel: "Cancel",
+          },
+          reason:
+            "Manager approval is required to correct the register opening float.",
+          requiredRole: "manager",
+          resolutionModes: [{ kind: "inline_manager_proof" }],
+          selfApproval: "allowed",
+          subject: {
+            id: "drawer-1",
+            label: "1",
+            type: "register_session",
+          },
+        },
+      })
+      .mockResolvedValueOnce(
+        ok({
+          action: "corrected",
+        }),
+      );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestOpeningFloatCorrection();
+    });
+
+    act(() => {
+      result.current.drawerGate?.onCorrectedOpeningFloatChange?.("45.00");
+      result.current.drawerGate?.onCorrectionReasonChange?.("Cashier typo");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmitOpeningFloatCorrection?.();
+    });
+
+    expect(result.current.drawerGate?.errorMessage).toBeNull();
+    expect(result.current.closeoutApprovalDialog?.open).toBe(true);
+    expect(result.current.closeoutApprovalDialog?.approval?.action.key).toBe(
+      "cash_controls.register_session.correct_opening_float",
+    );
+
+    await act(async () => {
+      const approval = result.current.closeoutApprovalDialog!.approval!;
+      await result.current.closeoutApprovalDialog?.onApproved({
+        approval,
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvedByStaffProfileId: "staff-1" as Id<"staffProfile">,
+        expiresAt: Date.now() + 60_000,
+      });
+    });
+
+    expect(mockCorrectRegisterSessionOpeningFloat).toHaveBeenLastCalledWith({
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-1",
+      approvalProofId: "proof-1",
       correctedOpeningFloat: 4_500,
       reason: "Cashier typo",
       registerSessionId: "drawer-1",
@@ -1305,6 +1359,7 @@ describe("useRegisterViewModel", () => {
 
     expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.drawerGate?.canOpenDrawer).toBe(false);
+    expect(result.current.drawerGate?.canOpenCashControls).toBe(false);
     expect(
       result.current.closeoutControl?.canShowOpeningFloatCorrection,
     ).toBe(false);

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -145,6 +145,18 @@ type StaffProfileRosterRow = {
   status?: "active" | "inactive";
 };
 
+type PendingManagerCloseoutApproval = {
+  approval: ApprovalRequirement;
+  countedCash: number;
+  notes?: string;
+  registerSessionId: Id<"registerSession">;
+};
+
+const REGISTER_VARIANCE_REVIEW_ACTION = {
+  key: "cash_controls.register_session.review_variance",
+  label: "Review register closeout variance",
+};
+
 function canOperateRegister(staff: StaffProfileRosterRow): boolean {
   if (staff.status !== "active" || staff.credentialStatus !== "active") {
     return false;
@@ -182,6 +194,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     useState("");
   const [closeoutCountedCash, setCloseoutCountedCash] = useState("");
   const [closeoutNotes, setCloseoutNotes] = useState("");
+  const [pendingManagerCloseoutApproval, setPendingManagerCloseoutApproval] =
+    useState<PendingManagerCloseoutApproval | null>(null);
   const [drawerErrorMessage, setDrawerErrorMessage] = useState<string | null>(
     null,
   );
@@ -283,9 +297,17 @@ export function useRegisterViewModel(): RegisterViewModel {
   const authenticateStaffCredentialForApproval = useMutation(
     api.operations.staffCredentials.authenticateStaffCredentialForApproval,
   );
-  const closeoutApprovalRunner = useApprovedCommand({
-    storeId: activeStore?._id,
-    onAuthenticateForApproval: (args) => {
+  const authenticateForCloseoutApproval = useCallback(
+    (args: {
+      actionKey: string;
+      pinHash: string;
+      reason?: string;
+      requiredRole: ApprovalRequirement["requiredRole"];
+      requestedByStaffProfileId?: Id<"staffProfile">;
+      storeId: Id<"store">;
+      subject: ApprovalRequirement["subject"];
+      username: string;
+    }) => {
       if (!activeStore?._id) {
         return Promise.resolve(
           userError({
@@ -309,6 +331,11 @@ export function useRegisterViewModel(): RegisterViewModel {
           }) as Promise<CommandResult<CommandApprovalProofResult>>,
       );
     },
+    [activeStore?._id, authenticateStaffCredentialForApproval],
+  );
+  const closeoutApprovalRunner = useApprovedCommand({
+    storeId: activeStore?._id,
+    onAuthenticateForApproval: authenticateForCloseoutApproval,
   });
   const reopenRegisterSessionCloseout = useMutation(
     api.cashControls.closeouts.reopenRegisterSessionCloseout,
@@ -1149,6 +1176,46 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
+    if (hasCloseoutVariance && isCashierManager) {
+      setDrawerErrorMessage(null);
+      setPendingManagerCloseoutApproval({
+        approval: {
+          action: REGISTER_VARIANCE_REVIEW_ACTION,
+          copy: {
+            title: "Manager approval required",
+            message:
+              "Re-enter manager credentials to approve this register closeout variance.",
+            primaryActionLabel: "Approve closeout",
+            secondaryActionLabel: "Cancel",
+          },
+          metadata: {
+            countedCash: parsedCountedCash,
+            expectedCash: expectedCloseoutCash,
+            variance: parsedCountedCash - expectedCloseoutCash,
+          },
+          reason:
+            trimmedCloseoutNotes ??
+            "Manager approval is required before this register session can close.",
+          requiredRole: "manager",
+          resolutionModes: [
+            {
+              kind: "inline_manager_proof",
+            },
+          ],
+          selfApproval: "allowed",
+          subject: {
+            id: registerSessionId,
+            label: activeCloseoutRegisterSession?.registerNumber,
+            type: "register_session",
+          },
+        },
+        countedCash: parsedCountedCash,
+        notes: trimmedCloseoutNotes,
+        registerSessionId,
+      });
+      return;
+    }
+
     await runRegisterCloseoutSubmit({
       countedCash: parsedCountedCash,
       notes: trimmedCloseoutNotes,
@@ -1161,6 +1228,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeCloseoutRegisterSession?.registerNumber,
     closeoutCountedCash,
     closeoutNotes,
+    isCashierManager,
     runRegisterCloseoutSubmit,
     staffProfileId,
     user?._id,
@@ -1261,43 +1329,51 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     setDrawerErrorMessage(null);
-    setIsCorrectingOpeningFloat(true);
+    await closeoutApprovalRunner.run({
+      requestedByStaffProfileId: staffProfileId,
+      execute: async (approvalArgs) => {
+        setIsCorrectingOpeningFloat(true);
+        try {
+          return await runCommand(() =>
+            correctRegisterSessionOpeningFloat({
+              actorStaffProfileId: staffProfileId,
+              actorUserId: user._id,
+              approvalProofId: approvalArgs.approvalProofId,
+              correctedOpeningFloat: parsedOpeningFloat,
+              reason,
+              registerSessionId,
+              storeId: activeStore._id,
+            }),
+          );
+        } finally {
+          setIsCorrectingOpeningFloat(false);
+        }
+      },
+      onResult: (result) => {
+        if (isApprovalRequiredResult(result)) {
+          return;
+        }
 
-    const result = await runCommand(() =>
-      correctRegisterSessionOpeningFloat({
-        actorStaffProfileId: staffProfileId,
-        actorUserId: user._id,
-        correctedOpeningFloat: parsedOpeningFloat,
-        reason,
-        registerSessionId,
-        storeId: activeStore._id,
-      }),
-    );
+        if (result.kind !== "ok") {
+          setDrawerErrorMessage(toOperatorMessage(result.error.message));
+          return;
+        }
 
-    setIsCorrectingOpeningFloat(false);
-
-    if (isApprovalRequiredResult(result)) {
-      setDrawerErrorMessage(toOperatorMessage(result.approval.copy.message));
-      return;
-    }
-
-    if (result.kind !== "ok") {
-      setDrawerErrorMessage(toOperatorMessage(result.error.message));
-      return;
-    }
-
-    setCorrectedOpeningFloat("");
-    setOpeningFloatCorrectionReason("");
-    setIsOpeningFloatCorrectionRequested(false);
-    requestBootstrap();
-    toast.success(
-      result.data?.action === "unchanged"
-        ? "Opening float unchanged"
-        : "Opening float corrected",
-    );
+        setCorrectedOpeningFloat("");
+        setOpeningFloatCorrectionReason("");
+        setIsOpeningFloatCorrectionRequested(false);
+        requestBootstrap();
+        toast.success(
+          result.data?.action === "unchanged"
+            ? "Opening float unchanged"
+            : "Opening float corrected",
+        );
+      },
+    });
   }, [
     activeOpeningFloatCorrectionRegisterSession?._id,
     activeStore?._id,
+    closeoutApprovalRunner,
     correctedOpeningFloat,
     correctRegisterSessionOpeningFloat,
     openingFloatCorrectionReason,
@@ -2183,6 +2259,10 @@ export function useRegisterViewModel(): RegisterViewModel {
                 : "Return to sale",
               expectedCash: activeCloseoutRegisterSession?.expectedCash,
               canOpenCashControls: isCashierManager,
+              cashControlsRegisterSessionId:
+                activeCloseoutRegisterSession?._id as
+                  | Id<"registerSession">
+                  | undefined,
               hasPendingCloseoutApproval: Boolean(
                 activeCloseoutRegisterSession?.managerApprovalRequestId,
               ),
@@ -2206,6 +2286,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               registerLabel: terminal.displayName,
               registerNumber,
               currency: activeStore.currency,
+              canOpenCashControls: isCashierManager,
               canOpenDrawer: isCashierManager,
               openingFloat: drawerOpeningFloat,
               notes: drawerNotes,
@@ -2286,7 +2367,31 @@ export function useRegisterViewModel(): RegisterViewModel {
       : null;
 
   const closeoutApprovalDialog: RegisterCloseoutApprovalDialogState | null =
-    closeoutApprovalRunner.approvalDialog as RegisterCloseoutApprovalDialogState | null;
+    pendingManagerCloseoutApproval && activeStore?._id
+      ? {
+          approval: pendingManagerCloseoutApproval.approval,
+          onApproved: async (result) => {
+            const pending = pendingManagerCloseoutApproval;
+            setPendingManagerCloseoutApproval(null);
+
+            if (!pending) {
+              return;
+            }
+
+            await runRegisterCloseoutSubmit({
+              approvalProofId: result.approvalProofId,
+              countedCash: pending.countedCash,
+              notes: pending.notes,
+              registerSessionId: pending.registerSessionId,
+            });
+          },
+          onAuthenticateForApproval: authenticateForCloseoutApproval,
+          onDismiss: () => setPendingManagerCloseoutApproval(null),
+          open: true,
+          requestedByStaffProfileId: staffProfileId ?? undefined,
+          storeId: activeStore._id,
+        }
+      : (closeoutApprovalRunner.approvalDialog as RegisterCloseoutApprovalDialogState | null);
 
   return {
     hasActiveStore: Boolean(activeStore),


### PR DESCRIPTION
## Summary
- format approval variance amounts with the shared GHS currency formatter
- avoid inline manager dialogs for async approval requests and keep POS manager closeout re-auth on the inline path
- surface closeout request notes, manager-gate Cash controls links, route POS Cash controls to the register session detail with origin preserved, and fix opening-float proof requester binding

Refs V26-446
Related V26-439

## Validation
- bun run --filter '@athena/webapp' test -- convex/cashControls/closeouts.test.ts convex/cashControls/deposits.test.ts src/components/cash-controls/RegisterSessionView.test.tsx src/components/operations/CommandApprovalDialog.test.tsx src/components/operations/useApprovedCommand.test.tsx src/components/pos/transactions/TransactionView.test.tsx src/components/pos/register/POSRegisterView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- git diff --check
- bun run graphify:rebuild
- git push pre-push suite: graphify check, architecture check, harness review, webapp build, full webapp tests, Convex audit, changed Convex lint, runtime behavior scenarios