### PR TITLE
[V26-439]: Move POS closeout approval onto command requirements

### DIFF
--- a/docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md
+++ b/docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md
@@ -27,9 +27,10 @@ If proof minting succeeds, the runner retries the same command with `approvalPro
 - Do not store or reuse PIN hashes. Pass the current modal submission credentials directly into one immediate proof attempt.
 - Do not replace `CommandApprovalDialog`. It remains the fallback when the same-submission fast path is unavailable.
 - Keep audit and trace behavior server-owned through approval proof creation/consumption and the domain command.
+- For POS register closeout, manager actors should receive an inline-only server-returned requirement before async approval request creation. Non-manager actors should continue through the async approval request rail.
 
 ## Current Consumers
 
 - Transaction payment-method correction uses the same staff-auth submission to resolve the returned payment correction approval requirement.
 - Cash-controls register-session closeout uses the shared runner instead of bespoke manager variance logic.
-- POS register closeout routes through the same coordinator contract and can fast-path only when fresh closeout credentials are available.
+- POS register closeout submits to the command first, then opens `CommandApprovalDialog` from the server-returned inline requirement for manager actors.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -7931,7 +7931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L489",
+      "source_location": "L495",
       "target": "closeouts_cancelpendingapprovalifneeded",
       "weight": 1
     },
@@ -7955,7 +7955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L407",
+      "source_location": "L413",
       "target": "closeouts_listregistersessionsforcloseout",
       "weight": 1
     },
@@ -7967,7 +7967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L437",
+      "source_location": "L443",
       "target": "closeouts_liststaffnames",
       "weight": 1
     },
@@ -7991,7 +7991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L454",
+      "source_location": "L460",
       "target": "closeouts_staffprofilecanreviewcloseoutvariance",
       "weight": 1
     },
@@ -27719,7 +27719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L160",
+      "source_location": "L148",
       "target": "useregisterviewmodel_canoperateregister",
       "weight": 1
     },
@@ -27803,7 +27803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L169",
+      "source_location": "L157",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -45047,7 +45047,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L368",
+      "source_location": "L354",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -45059,7 +45059,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_trimoptional",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L177",
+      "source_location": "L165",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -64561,7 +64561,7 @@
       "label": "cancelPendingApprovalIfNeeded()",
       "norm_label": "cancelpendingapprovalifneeded()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L489"
+      "source_location": "L495"
     },
     {
       "community": 34,
@@ -64579,7 +64579,7 @@
       "label": "listRegisterSessionsForCloseout()",
       "norm_label": "listregistersessionsforcloseout()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L407"
+      "source_location": "L413"
     },
     {
       "community": 34,
@@ -64588,7 +64588,7 @@
       "label": "listStaffNames()",
       "norm_label": "liststaffnames()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L437"
+      "source_location": "L443"
     },
     {
       "community": 34,
@@ -64606,7 +64606,7 @@
       "label": "staffProfileCanReviewCloseoutVariance()",
       "norm_label": "staffprofilecanreviewcloseoutvariance()",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L454"
+      "source_location": "L460"
     },
     {
       "community": 34,
@@ -75649,7 +75649,7 @@
       "label": "canOperateRegister()",
       "norm_label": "canoperateregister()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L160"
+      "source_location": "L148"
     },
     {
       "community": 68,
@@ -75712,7 +75712,7 @@
       "label": "useRegisterViewModel()",
       "norm_label": "useregisterviewmodel()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L169"
+      "source_location": "L157"
     },
     {
       "community": 680,

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -230,6 +230,89 @@ describe("cash control closeouts", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
+  it("returns an inline-only approval requirement for manager closeout variance submissions", async () => {
+    const registerSession = {
+      _id: "session-1",
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "open",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const runMutation = vi.fn(async () => ({
+      ...registerSession,
+      countedCash: 20000,
+      status: "closing",
+    }));
+    const insert = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") {
+            return registerSession;
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "staff-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS" };
+          }
+          return null;
+        }),
+        insert,
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            take: vi.fn(async () => [
+              {
+                organizationId: "org-1",
+                role: "manager",
+                status: "active",
+                storeId: "store-1",
+              },
+            ]),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-1",
+      countedCash: 20000,
+      notes: "Manager counted the shortage.",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "approval_required",
+      approval: {
+        action: {
+          key: "cash_controls.register_session.review_variance",
+        },
+        requiredRole: "manager",
+        resolutionModes: [{ kind: "inline_manager_proof" }],
+        subject: {
+          id: "session-1",
+          type: "register_session",
+        },
+      },
+    });
+    expect(result.approval.resolutionModes).not.toContainEqual(
+      expect.objectContaining({ kind: "async_request" }),
+    );
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it("requires manager approval for same opening float corrections", async () => {
     const runMutation = vi.fn();
     const ctx = {

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -385,16 +385,22 @@ export function buildRegisterSessionVarianceApprovalRequirement(args: {
       args.closeoutReview.reason ??
       "Manager approval is required before this register session can close.",
     requiredRole: "manager",
-    resolutionModes: [
-      {
-        kind: "inline_manager_proof",
-      },
-      {
-        approvalRequestId: args.approvalRequestId,
-        kind: "async_request",
-        requestType: "variance_review",
-      },
-    ],
+    resolutionModes: args.approvalRequestId
+      ? [
+          {
+            kind: "inline_manager_proof",
+          },
+          {
+            approvalRequestId: args.approvalRequestId,
+            kind: "async_request",
+            requestType: "variance_review",
+          },
+        ]
+      : [
+          {
+            kind: "inline_manager_proof",
+          },
+        ],
     selfApproval: "allowed",
     subject: {
       id: args.registerSession._id,
@@ -703,6 +709,33 @@ export const submitRegisterSessionCloseout = mutation({
       }
 
       approvedByStaffProfileId = proof.data.approvedByStaffProfileId;
+    }
+
+    if (
+      closeoutReview.requiresApproval &&
+      !args.approvalProofId &&
+      args.actorStaffProfileId &&
+      registerSession.organizationId
+    ) {
+      const actorCanReviewVariance = await staffProfileCanReviewCloseoutVariance(
+        ctx,
+        {
+          organizationId: registerSession.organizationId,
+          staffProfileId: args.actorStaffProfileId,
+          storeId: args.storeId,
+        },
+      );
+
+      if (actorCanReviewVariance) {
+        return approvalRequired(
+          buildRegisterSessionVarianceApprovalRequirement({
+            closeoutReview,
+            countedCash: args.countedCash,
+            expectedCash: registerSession.expectedCash,
+            registerSession,
+          }),
+        );
+      }
     }
 
     const closingSession = await ctx.runMutation(

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -736,19 +736,19 @@ export function POSRegisterView({
         />
       )}
 
-      {viewModel.closeoutApprovalDialog ? (
+      {viewModel.commandApprovalDialog ? (
         <CommandApprovalDialog
-          approval={viewModel.closeoutApprovalDialog.approval}
-          onApproved={viewModel.closeoutApprovalDialog.onApproved}
+          approval={viewModel.commandApprovalDialog.approval}
+          onApproved={viewModel.commandApprovalDialog.onApproved}
           onAuthenticateForApproval={
-            viewModel.closeoutApprovalDialog.onAuthenticateForApproval
+            viewModel.commandApprovalDialog.onAuthenticateForApproval
           }
-          onDismiss={viewModel.closeoutApprovalDialog.onDismiss}
-          open={viewModel.closeoutApprovalDialog.open}
+          onDismiss={viewModel.commandApprovalDialog.onDismiss}
+          open={viewModel.commandApprovalDialog.open}
           requestedByStaffProfileId={
-            viewModel.closeoutApprovalDialog.requestedByStaffProfileId
+            viewModel.commandApprovalDialog.requestedByStaffProfileId
           }
-          storeId={viewModel.closeoutApprovalDialog.storeId}
+          storeId={viewModel.commandApprovalDialog.storeId}
         />
       ) : null}
     </View>

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -611,7 +611,7 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
             onDismiss: handleNavigateBack,
           }
         : null,
-    closeoutApprovalDialog: null,
+    commandApprovalDialog: null,
     onNavigateBack: handleNavigateBack,
   };
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -191,7 +191,7 @@ export interface RegisterAuthDialogState {
   onDismiss: () => void;
 }
 
-export interface RegisterCloseoutApprovalDialogState {
+export interface RegisterCommandApprovalDialogState {
   approval: CommandApprovalDialogProps["approval"];
   onApproved: CommandApprovalDialogProps["onApproved"];
   onAuthenticateForApproval: CommandApprovalDialogProps["onAuthenticateForApproval"];
@@ -227,7 +227,7 @@ export interface RegisterViewModel {
   drawerGate: RegisterDrawerGateState | null;
   closeoutControl: RegisterCloseoutControlState | null;
   authDialog: RegisterAuthDialogState | null;
-  closeoutApprovalDialog: RegisterCloseoutApprovalDialogState | null;
+  commandApprovalDialog: RegisterCommandApprovalDialogState | null;
   onNavigateBack: () => Promise<void>;
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -699,7 +699,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("reauthenticates a manager before applying closeout variance approval from POS", async () => {
+  it("reauthenticates a manager from the server-returned closeout approval requirement", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -722,11 +722,36 @@ describe("useRegisterViewModel", () => {
       resumableSession: null,
     };
     mockActiveSession = null;
-    mockSubmitRegisterSessionCloseout.mockResolvedValueOnce(
-      ok({
-        action: "closed",
-      }),
-    );
+    mockSubmitRegisterSessionCloseout
+      .mockResolvedValueOnce({
+        kind: "approval_required",
+        approval: {
+          action: {
+            key: "cash_controls.register_session.review_variance",
+            label: "Review register closeout variance",
+          },
+          copy: {
+            title: "Manager approval required",
+            message: "Variance requires manager approval.",
+            primaryActionLabel: "Approve closeout",
+            secondaryActionLabel: "Cancel",
+          },
+          reason: "Variance requires manager approval.",
+          requiredRole: "manager",
+          resolutionModes: [{ kind: "inline_manager_proof" }],
+          selfApproval: "allowed",
+          subject: {
+            id: "drawer-1",
+            label: "1",
+            type: "register_session",
+          },
+        },
+      })
+      .mockResolvedValueOnce(
+        ok({
+          action: "closed",
+        }),
+      );
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -746,32 +771,40 @@ describe("useRegisterViewModel", () => {
       await result.current.drawerGate?.onSubmitCloseout?.();
     });
 
-    expect(mockSubmitRegisterSessionCloseout).not.toHaveBeenCalled();
-    expect(result.current.closeoutApprovalDialog?.open).toBe(true);
-    expect(result.current.closeoutApprovalDialog?.approval?.action.key).toBe(
+    expect(mockSubmitRegisterSessionCloseout).toHaveBeenCalledWith({
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-1",
+      approvalProofId: undefined,
+      countedCash: 4_800,
+      notes: "End of shift count",
+      registerSessionId: "drawer-1",
+      storeId: "store-1",
+    });
+    expect(result.current.commandApprovalDialog?.open).toBe(true);
+    expect(result.current.commandApprovalDialog?.approval?.action.key).toBe(
       "cash_controls.register_session.review_variance",
     );
-    expect(result.current.closeoutApprovalDialog?.approval?.reason).toBe(
-      "End of shift count",
+    expect(result.current.commandApprovalDialog?.approval?.reason).toBe(
+      "Variance requires manager approval.",
     );
 
     await act(async () => {
       const proofResult =
-        await result.current.closeoutApprovalDialog?.onAuthenticateForApproval({
+        await result.current.commandApprovalDialog?.onAuthenticateForApproval({
           actionKey: "cash_controls.register_session.review_variance",
           pinHash: "pin-hash",
-          reason: "End of shift count",
+          reason: "Variance requires manager approval.",
           requiredRole: "manager",
           requestedByStaffProfileId: "staff-1" as Id<"staffProfile">,
           storeId: "store-1" as Id<"store">,
-          subject: result.current.closeoutApprovalDialog.approval!.subject,
+          subject: result.current.commandApprovalDialog.approval!.subject,
           username: "ama",
         });
 
       expect(proofResult?.kind).toBe("ok");
 
-      result.current.closeoutApprovalDialog?.onApproved({
-        approval: result.current.closeoutApprovalDialog.approval!,
+      result.current.commandApprovalDialog?.onApproved({
+        approval: result.current.commandApprovalDialog.approval!,
         approvalProofId: "proof-1" as Id<"approvalProof">,
         approvedByStaffProfileId: "staff-1" as Id<"staffProfile">,
         expiresAt: Date.now() + 60_000,
@@ -781,7 +814,7 @@ describe("useRegisterViewModel", () => {
     expect(mockAuthenticateStaffCredentialForApproval).toHaveBeenCalledWith({
       actionKey: "cash_controls.register_session.review_variance",
       pinHash: "pin-hash",
-      reason: "End of shift count",
+      reason: "Variance requires manager approval.",
       requiredRole: "manager",
       requestedByStaffProfileId: "staff-1",
       storeId: "store-1",
@@ -1004,14 +1037,14 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate?.errorMessage).toBeNull();
-    expect(result.current.closeoutApprovalDialog?.open).toBe(true);
-    expect(result.current.closeoutApprovalDialog?.approval?.action.key).toBe(
+    expect(result.current.commandApprovalDialog?.open).toBe(true);
+    expect(result.current.commandApprovalDialog?.approval?.action.key).toBe(
       "cash_controls.register_session.correct_opening_float",
     );
 
     await act(async () => {
-      const approval = result.current.closeoutApprovalDialog!.approval!;
-      await result.current.closeoutApprovalDialog?.onApproved({
+      const approval = result.current.commandApprovalDialog!.approval!;
+      await result.current.commandApprovalDialog?.onApproved({
         approval,
         approvalProofId: "proof-1" as Id<"approvalProof">,
         approvedByStaffProfileId: "staff-1" as Id<"staffProfile">,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -54,7 +54,7 @@ import {
 } from "@/lib/pos/infrastructure/convex/sessionGateway";
 
 import type {
-  RegisterCloseoutApprovalDialogState,
+  RegisterCommandApprovalDialogState,
   RegisterViewModel,
 } from "./registerUiState";
 import { EMPTY_REGISTER_CUSTOMER_INFO } from "./registerUiState";
@@ -145,18 +145,6 @@ type StaffProfileRosterRow = {
   status?: "active" | "inactive";
 };
 
-type PendingManagerCloseoutApproval = {
-  approval: ApprovalRequirement;
-  countedCash: number;
-  notes?: string;
-  registerSessionId: Id<"registerSession">;
-};
-
-const REGISTER_VARIANCE_REVIEW_ACTION = {
-  key: "cash_controls.register_session.review_variance",
-  label: "Review register closeout variance",
-};
-
 function canOperateRegister(staff: StaffProfileRosterRow): boolean {
   if (staff.status !== "active" || staff.credentialStatus !== "active") {
     return false;
@@ -194,8 +182,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     useState("");
   const [closeoutCountedCash, setCloseoutCountedCash] = useState("");
   const [closeoutNotes, setCloseoutNotes] = useState("");
-  const [pendingManagerCloseoutApproval, setPendingManagerCloseoutApproval] =
-    useState<PendingManagerCloseoutApproval | null>(null);
   const [drawerErrorMessage, setDrawerErrorMessage] = useState<string | null>(
     null,
   );
@@ -1103,8 +1089,15 @@ export function useRegisterViewModel(): RegisterViewModel {
           setIsSubmittingCloseout(false);
           return result;
         },
-        onApprovalRequired: () => {
-          toast.success("Closeout submitted for manager review");
+        onApprovalRequired: (approval) => {
+          const createdAsyncRequest = approval.resolutionModes.some(
+            (mode) =>
+              mode.kind === "async_request" && Boolean(mode.approvalRequestId),
+          );
+
+          if (createdAsyncRequest) {
+            toast.success("Closeout submitted for manager review");
+          }
         },
         onResult: (result) => {
           if (isApprovalRequiredResult(result)) {
@@ -1176,46 +1169,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    if (hasCloseoutVariance && isCashierManager) {
-      setDrawerErrorMessage(null);
-      setPendingManagerCloseoutApproval({
-        approval: {
-          action: REGISTER_VARIANCE_REVIEW_ACTION,
-          copy: {
-            title: "Manager approval required",
-            message:
-              "Re-enter manager credentials to approve this register closeout variance.",
-            primaryActionLabel: "Approve closeout",
-            secondaryActionLabel: "Cancel",
-          },
-          metadata: {
-            countedCash: parsedCountedCash,
-            expectedCash: expectedCloseoutCash,
-            variance: parsedCountedCash - expectedCloseoutCash,
-          },
-          reason:
-            trimmedCloseoutNotes ??
-            "Manager approval is required before this register session can close.",
-          requiredRole: "manager",
-          resolutionModes: [
-            {
-              kind: "inline_manager_proof",
-            },
-          ],
-          selfApproval: "allowed",
-          subject: {
-            id: registerSessionId,
-            label: activeCloseoutRegisterSession?.registerNumber,
-            type: "register_session",
-          },
-        },
-        countedCash: parsedCountedCash,
-        notes: trimmedCloseoutNotes,
-        registerSessionId,
-      });
-      return;
-    }
-
     await runRegisterCloseoutSubmit({
       countedCash: parsedCountedCash,
       notes: trimmedCloseoutNotes,
@@ -1225,10 +1178,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeStore?._id,
     activeCloseoutRegisterSession?._id,
     activeCloseoutRegisterSession?.expectedCash,
-    activeCloseoutRegisterSession?.registerNumber,
     closeoutCountedCash,
     closeoutNotes,
-    isCashierManager,
     runRegisterCloseoutSubmit,
     staffProfileId,
     user?._id,
@@ -2366,32 +2317,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
 
-  const closeoutApprovalDialog: RegisterCloseoutApprovalDialogState | null =
-    pendingManagerCloseoutApproval && activeStore?._id
-      ? {
-          approval: pendingManagerCloseoutApproval.approval,
-          onApproved: async (result) => {
-            const pending = pendingManagerCloseoutApproval;
-            setPendingManagerCloseoutApproval(null);
-
-            if (!pending) {
-              return;
-            }
-
-            await runRegisterCloseoutSubmit({
-              approvalProofId: result.approvalProofId,
-              countedCash: pending.countedCash,
-              notes: pending.notes,
-              registerSessionId: pending.registerSessionId,
-            });
-          },
-          onAuthenticateForApproval: authenticateForCloseoutApproval,
-          onDismiss: () => setPendingManagerCloseoutApproval(null),
-          open: true,
-          requestedByStaffProfileId: staffProfileId ?? undefined,
-          storeId: activeStore._id,
-        }
-      : (closeoutApprovalRunner.approvalDialog as RegisterCloseoutApprovalDialogState | null);
+  const commandApprovalDialog =
+    closeoutApprovalRunner.approvalDialog as RegisterCommandApprovalDialogState | null;
 
   return {
     hasActiveStore: Boolean(activeStore),
@@ -2460,7 +2387,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     drawerGate,
     closeoutControl,
     authDialog,
-    closeoutApprovalDialog,
+    commandApprovalDialog,
     onNavigateBack: handleNavigateBack,
   };
 }


### PR DESCRIPTION
## Summary
- make register closeout variance approval requirements inline-only for manager actors before async approval request creation
- remove POS-local closeout approval requirement construction so POS submits to the closeout command first
- rename the register view-model approval surface to the generic `commandApprovalDialog` and refresh the command-approval learning doc

## Why
POS closeout still had a temporary UI-built manager approval path. That kept approval policy details in `useRegisterViewModel` and let the ticket look done while the command layer was not the source of truth. This moves the decision back to `submitRegisterSessionCloseout`: manager actors receive a server-returned inline requirement; non-manager actors continue to create async approval requests.

## Validation
- `bun run --filter @athena/webapp test -- convex/cashControls/closeouts.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx src/components/cash-controls/RegisterSessionView.test.tsx src/components/operations/useApprovedCommand.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `git diff --check`
- `bun run graphify:rebuild`
- `git push` pre-push suite: graphify check, architecture check, harness review, webapp build, full webapp tests, Convex audit, changed Convex lint, runtime behavior scenarios

Linear: https://linear.app/v26-labs/issue/V26-439/move-pos-register-closeout-approval-onto-server-returned-requirements