### PR TITLE
Fix storefront QA API proxy target

### DIFF
--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -36,7 +36,13 @@ describe("VPS QA deploy contract", () => {
     expect(deployScript).toContain("pm2 delete storefront-qa");
     expect(deployScript).toContain("pm2 start bun --name athena-qa");
     expect(deployScript).toContain("pm2 start bun --name storefront-qa");
-    expect(deployScript).toContain('VITE_API_URL="$DEV_CONVEX_SITE"');
+    expect(deployScript).toContain('DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"');
+    expect(deployScript).toContain(
+      'remote_script "$REMOTE_SOURCE_DIR" "$STOREFRONT_QA_PORT" "$DEV_API_URL" "$STOREFRONT_QA_HOST"',
+    );
+    expect(deployScript).toContain('DEV_API_URL="$3"');
+    expect(deployScript).toContain('VITE_API_URL="$DEV_API_URL"');
+    expect(deployScript).not.toContain('VITE_API_URL="$DEV_CONVEX_SITE"');
     expect(deployScript).toContain('STOREFRONT_QA_HOST="$STOREFRONT_QA_HOST"');
     expect(deployScript).not.toContain('VITE_STOREFRONT_URL="$STOREFRONT_URL"');
   });

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -15,6 +15,7 @@ PROD_CONVEX_CLOUD="${PROD_CONVEX_CLOUD:-https://colorless-cardinal-870.convex.cl
 PROD_CONVEX_SITE="${PROD_CONVEX_SITE:-https://colorless-cardinal-870.convex.site}"
 DEV_CONVEX_CLOUD="${DEV_CONVEX_CLOUD:-https://jovial-wildebeest-179.convex.cloud}"
 DEV_CONVEX_SITE="${DEV_CONVEX_SITE:-https://jovial-wildebeest-179.convex.site}"
+DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"
 STOREFRONT_URL="${STOREFRONT_URL:-https://wigclub.store}"
 
 usage() {
@@ -361,12 +362,12 @@ REMOTE_SCRIPT
 deploy_storefront_qa() {
   configure_storefront_qa_nginx
 
-  remote_script "$REMOTE_SOURCE_DIR" "$STOREFRONT_QA_PORT" "$DEV_CONVEX_SITE" "$STOREFRONT_QA_HOST" <<'REMOTE_SCRIPT'
+  remote_script "$REMOTE_SOURCE_DIR" "$STOREFRONT_QA_PORT" "$DEV_API_URL" "$STOREFRONT_QA_HOST" <<'REMOTE_SCRIPT'
 set -euo pipefail
 
 REMOTE_SOURCE_DIR="$1"
 STOREFRONT_QA_PORT="$2"
-DEV_CONVEX_SITE="$3"
+DEV_API_URL="$3"
 STOREFRONT_QA_HOST="$4"
 
 export BUN_INSTALL="${BUN_INSTALL:-/root/.bun}"
@@ -378,7 +379,7 @@ if pm2 describe storefront-qa >/dev/null 2>&1; then
   pm2 delete storefront-qa
 fi
 
-VITE_API_URL="$DEV_CONVEX_SITE" \
+VITE_API_URL="$DEV_API_URL" \
 STOREFRONT_QA_HOST="$STOREFRONT_QA_HOST" \
   pm2 start bun --name storefront-qa -- run dev -- --host 127.0.0.1 --port "$STOREFRONT_QA_PORT" --strictPort
 


### PR DESCRIPTION
## Summary
- route storefront QA backend calls through the dev API proxy instead of the raw Convex site
- keep the deploy contract covered so QA cannot regress to direct Convex `.site` requests

## Validation
- bun test scripts/deploy-qa-vps.test.ts
- bun run graphify:rebuild
- bun run pr:athena
- git push pre-push validation