### PR TITLE
Allow storefront QA through dev API CORS

### DIFF
--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -15,6 +15,7 @@ describe("VPS QA deploy contract", () => {
     expect(setupScript).toContain('STOREFRONT_QA_HOST="${STOREFRONT_QA_HOST:-qa.wigclub.store}"');
     expect(setupScript).toContain('ATHENA_QA_HOST="${ATHENA_QA_HOST:-athena-qa.wigclub.store}"');
     expect(setupScript).toContain('STOREFRONT_QA_PORT="${STOREFRONT_QA_PORT:-5176}"');
+    expect(setupScript).toContain('"https://$STOREFRONT_QA_HOST" "https://$STOREFRONT_QA_HOST";');
     expect(setupScript).toContain("server_name $STOREFRONT_QA_HOST;");
     expect(setupScript).toContain("proxy_pass http://127.0.0.1:$STOREFRONT_QA_PORT;");
     expect(setupScript).toContain("server_name $ATHENA_QA_HOST;");
@@ -29,6 +30,9 @@ describe("VPS QA deploy contract", () => {
     expect(deployScript).toContain("deploy_athena_qa()");
     expect(deployScript).toContain("deploy_storefront_qa()");
     expect(deployScript).toContain("configure_storefront_qa_nginx()");
+    expect(deployScript).toContain("configure_api_gateway_cors()");
+    expect(deployScript).toContain('python3 - "$config_file" "https://$STOREFRONT_QA_HOST"');
+    expect(deployScript).toContain("Could not find the nginx CORS origin map.");
     expect(deployScript).toContain("/etc/nginx/conf.d/wigclub.conf");
     expect(deployScript).toContain("nginx -t");
     expect(deployScript).toContain("systemctl reload nginx");

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -359,8 +359,55 @@ systemctl reload nginx
 REMOTE_SCRIPT
 }
 
+configure_api_gateway_cors() {
+  remote_script "$STOREFRONT_QA_HOST" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+STOREFRONT_QA_HOST="$1"
+config_file="/etc/nginx/conf.d/wigclub.conf"
+
+if [ ! -f "$config_file" ]; then
+  printf 'Missing %s. Run scripts/setup-production-vps.sh first.\n' "$config_file" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y python3
+fi
+
+python3 - "$config_file" "https://$STOREFRONT_QA_HOST" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+config_path = Path(sys.argv[1])
+origin = sys.argv[2]
+text = config_path.read_text()
+entry = f'    "{origin}" "{origin}";'
+map_match = re.search(
+    r"map\s+\$http_origin\s+\$cors_allow_origin\s*\{(?P<body>.*?)\n\}",
+    text,
+    re.DOTALL,
+)
+
+if not map_match:
+    raise SystemExit("Could not find the nginx CORS origin map.")
+
+if entry not in map_match.group("body"):
+    insert_at = map_match.end("body")
+    text = text[:insert_at] + "\n" + entry + text[insert_at:]
+    config_path.write_text(text)
+PY
+
+nginx -t
+systemctl reload nginx
+REMOTE_SCRIPT
+}
+
 deploy_storefront_qa() {
   configure_storefront_qa_nginx
+  configure_api_gateway_cors
 
   remote_script "$REMOTE_SOURCE_DIR" "$STOREFRONT_QA_PORT" "$DEV_API_URL" "$STOREFRONT_QA_HOST" <<'REMOTE_SCRIPT'
 set -euo pipefail

--- a/scripts/setup-production-vps.sh
+++ b/scripts/setup-production-vps.sh
@@ -44,6 +44,7 @@ map \$http_origin \$cors_allow_origin {
     "http://localhost:5174" "http://localhost:5174";
     "https://$STOREFRONT_HOST" "https://$STOREFRONT_HOST";
     "https://$STOREFRONT_WWW_HOST" "https://$STOREFRONT_WWW_HOST";
+    "https://$STOREFRONT_QA_HOST" "https://$STOREFRONT_QA_HOST";
 }
 
 resolver 127.0.0.53 valid=300s ipv6=off;


### PR DESCRIPTION
## Summary
- add qa.wigclub.store to the nginx API CORS allowlist used by setup
- patch the live API CORS map during storefront QA deploys before restarting the dev server
- cover the deploy contract so the QA origin remains allowed

## Validation
- bun test scripts/deploy-qa-vps.test.ts
- bun run graphify:rebuild
- bun run pr:athena
- git push pre-push validation