### PR TITLE
[V26-455]: Clear Athena webapp production chunk-size warnings

### DIFF
--- a/packages/athena-webapp/src/components/homepage/VideoPlayer.tsx
+++ b/packages/athena-webapp/src/components/homepage/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import Hls from "hls.js";
+import type Hls from "hls.js";
 
 interface VideoPlayerProps {
   hlsUrl: string;
@@ -12,18 +12,31 @@ export const VideoPlayer = ({ hlsUrl }: VideoPlayerProps) => {
     const video = videoRef.current;
     if (!video || !hlsUrl) return;
 
-    if (!Hls.isSupported()) return;
+    let disposed = false;
+    let hls: Hls | null = null;
 
-    const hls = new Hls();
-    hls.loadSource(hlsUrl);
-    hls.attachMedia(video);
-    hls.on(Hls.Events.MANIFEST_PARSED, () => {
-      video.play().catch((e) => console.error("Error playing video:", e));
-    });
+    const attachHls = async () => {
+      const { default: HlsConstructor } = (await import(
+        // @ts-expect-error hls.js publishes its light build without declarations.
+        "hls.js/light"
+      )) as unknown as { default: typeof Hls };
+
+      if (disposed || !HlsConstructor.isSupported()) return;
+
+      hls = new HlsConstructor();
+      hls.loadSource(hlsUrl);
+      hls.attachMedia(video);
+      hls.on(HlsConstructor.Events.MANIFEST_PARSED, () => {
+        video.play().catch((e) => console.error("Error playing video:", e));
+      });
+    };
+
+    void attachHls();
 
     return () => {
-      hls.destroy();
-    }
+      disposed = true;
+      hls?.destroy();
+    };
   }, [hlsUrl]);
 
   return (

--- a/packages/athena-webapp/src/routeTree.browser-boundary.test.ts
+++ b/packages/athena-webapp/src/routeTree.browser-boundary.test.ts
@@ -121,6 +121,6 @@ describe("Athena route tree browser boundary", () => {
         warnSpy.mockRestore();
       }
     },
-    15000
+    30000
   );
 });

--- a/packages/athena-webapp/src/routes/__root.tsx
+++ b/packages/athena-webapp/src/routes/__root.tsx
@@ -5,7 +5,6 @@ import {
   createRootRouteWithContext,
 } from "@tanstack/react-router";
 
-import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { QueryClient } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/sonner";
 import { DefaultCatchBoundary } from "@/components/auth/DefaultCatchBoundary";

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx
@@ -98,7 +98,7 @@ export function WorkflowTraceRouteShell({
   );
 }
 
-export function WorkflowTraceRoute() {
+function WorkflowTraceRoute() {
   const { orgUrlSlug, storeUrlSlug, traceId } = Route.useParams();
 
   return (

--- a/packages/athena-webapp/vite.config.ts
+++ b/packages/athena-webapp/vite.config.ts
@@ -21,7 +21,66 @@ export default defineConfig(({ mode }) => ({
       output: {
         manualChunks(id) {
           if (id.includes("node_modules")) {
+            const normalizedId = id.split(path.sep).join("/");
+
+            if (
+              normalizedId.includes("/node_modules/react/") ||
+              normalizedId.includes("/node_modules/react-dom/") ||
+              normalizedId.includes("/node_modules/scheduler/") ||
+              normalizedId.includes("/node_modules/use-sync-external-store/")
+            ) {
+              return "react-vendor";
+            }
+            if (id.includes("@tanstack")) return "tanstack-vendor";
+            if (id.includes("@radix-ui")) return "radix-vendor";
+            if (id.includes("convex")) return "convex-vendor";
+            if (id.includes("lucide-react")) return "icons-vendor";
+            if (id.includes("recharts")) return "charts-vendor";
+            if (
+              id.includes("react-hook-form") ||
+              id.includes("@hookform") ||
+              id.includes("@tanstack/zod-form-adapter") ||
+              id.includes("zod")
+            ) {
+              return "forms-vendor";
+            }
+            if (id.includes("date-fns")) return "date-vendor";
+            if (id.includes("framer-motion")) return "motion-vendor";
             if (id.includes("hls.js")) return "hls-js-vendor";
+            if (id.includes("@aws-sdk") || id.includes("@smithy")) {
+              return "aws-vendor";
+            }
+            if (
+              id.includes("cmdk") ||
+              id.includes("input-otp") ||
+              id.includes("next-themes") ||
+              id.includes("react-day-picker") ||
+              id.includes("react-hot-toast") ||
+              id.includes("react-qr-code") ||
+              id.includes("react-resizable-panels") ||
+              id.includes("sonner") ||
+              id.includes("tailwind-merge") ||
+              id.includes("class-variance-authority") ||
+              id.includes("clsx")
+            ) {
+              return "ui-vendor";
+            }
+            if (id.includes("zustand") || id.includes("immer")) {
+              return "state-vendor";
+            }
+            if (id.includes("@auth/core") || id.includes("jose")) {
+              return "auth-vendor";
+            }
+            if (id.includes("@floating-ui")) return "floating-ui-vendor";
+            if (id.includes("@hello-pangea")) return "dnd-vendor";
+            if (
+              id.includes("react-dropzone") ||
+              id.includes("html-to-image") ||
+              id.includes("@jsquash") ||
+              id.includes("webp-converter-browser")
+            ) {
+              return "media-tools-vendor";
+            }
 
             return "vendor";
           }
@@ -35,6 +94,7 @@ export default defineConfig(({ mode }) => ({
         TanStackRouterVite({
           // Keep colocated route tests out of route generation.
           routeFileIgnorePattern: "\\.test\\.",
+          autoCodeSplitting: true,
         }),
         react(),
       ]) as any,


### PR DESCRIPTION
## Summary
- enable TanStack route auto code splitting and split large Athena vendor families into targeted Rollup chunks
- load the homepage HLS player with the lighter dynamic hls.js build so it stays off the initial route bundle
- align route exports and the browser-boundary timeout with the split route tree behavior

## Validation
- bun run --filter '@athena/webapp' build
- bun run pr:athena
- pre-push validation suite
- Computer Use validation against built preview at http://127.0.0.1:4174/login: rendered LOG IN page, accessible email field, Continue button, athena link, and interactive email entry

Linear: https://linear.app/v26-labs/issue/V26-455/clear-athena-webapp-production-chunk-size-warnings