### PR TITLE
[V26-456]: Clear storefront webapp production chunk-size warnings

### DIFF
--- a/packages/storefront-webapp/src/components/home/VideoPlayer.tsx
+++ b/packages/storefront-webapp/src/components/home/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import Hls from "hls.js";
+import type Hls from "hls.js";
 import { useEffect, useRef } from "react";
 
 interface VideoPlayerProps {
@@ -13,15 +13,30 @@ export const VideoPlayer = ({ hlsUrl }: VideoPlayerProps) => {
     const video = videoRef.current;
     if (!video || !hlsUrl) return;
 
-    const hls = new Hls();
-    hls.loadSource(hlsUrl);
-    hls.attachMedia(video);
-    hls.on(Hls.Events.MANIFEST_PARSED, () => {
-      video.play().catch((e) => console.error("Error playing video:", e));
-    });
+    let disposed = false;
+    let hls: Hls | null = null;
+
+    const attachHls = async () => {
+      const { default: HlsConstructor } = (await import(
+        // @ts-expect-error hls.js publishes its light build without declarations.
+        "hls.js/light"
+      )) as unknown as { default: typeof Hls };
+
+      if (disposed || !HlsConstructor.isSupported()) return;
+
+      hls = new HlsConstructor();
+      hls.loadSource(hlsUrl);
+      hls.attachMedia(video);
+      hls.on(HlsConstructor.Events.MANIFEST_PARSED, () => {
+        video.play().catch((e) => console.error("Error playing video:", e));
+      });
+    };
+
+    void attachHls();
 
     return () => {
-      hls.destroy();
+      disposed = true;
+      hls?.destroy();
     };
   }, [hlsUrl]);
 

--- a/packages/storefront-webapp/vite.config.ts
+++ b/packages/storefront-webapp/vite.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (id.includes("node_modules")) {
+            const normalizedId = id.split(path.sep).join("/");
+
+            if (
+              normalizedId.includes("/node_modules/react/") ||
+              normalizedId.includes("/node_modules/react-dom/") ||
+              normalizedId.includes("/node_modules/scheduler/") ||
+              normalizedId.includes("/node_modules/use-sync-external-store/")
+            ) {
+              return "react-vendor";
+            }
             if (id.includes("@tanstack")) return "tanstack-vendor";
 
             if (id.includes("zod")) return "zod-vendor";
@@ -37,6 +47,51 @@ export default defineConfig({
 
             if (id.includes("posthog-js")) return "posthog-js-vendor";
 
+            if (id.includes("lucide-react")) return "icons-vendor";
+
+            if (
+              id.includes("react-hook-form") ||
+              id.includes("@hookform")
+            ) {
+              return "forms-vendor";
+            }
+
+            if (
+              id.includes("@aws-sdk") ||
+              id.includes("@smithy") ||
+              id.includes("aws-amplify") ||
+              id.includes("amazon-cognito-identity-js")
+            ) {
+              return "aws-vendor";
+            }
+
+            if (id.includes("recharts")) return "charts-vendor";
+
+            if (id.includes("zustand")) return "state-vendor";
+
+            if (id.includes("jose") || id.includes("jsonwebtoken")) {
+              return "auth-vendor";
+            }
+
+            if (
+              id.includes("cmdk") ||
+              id.includes("input-otp") ||
+              id.includes("next-themes") ||
+              id.includes("react-day-picker") ||
+              id.includes("react-hot-toast") ||
+              id.includes("react-resizable-panels") ||
+              id.includes("sonner") ||
+              id.includes("tailwind-merge") ||
+              id.includes("class-variance-authority") ||
+              id.includes("clsx")
+            ) {
+              return "ui-vendor";
+            }
+
+            if (id.includes("react-dropzone")) {
+              return "media-tools-vendor";
+            }
+
             // Fallback for other node_modules
             return "vendor";
           }
@@ -44,7 +99,12 @@ export default defineConfig({
       },
     },
   },
-  plugins: [TanStackRouterVite(), react() as unknown as PluginOption],
+  plugins: [
+    TanStackRouterVite({
+      autoCodeSplitting: true,
+    }),
+    react() as unknown as PluginOption,
+  ],
   resolve: {
     alias: {
       "~": __dirname,


### PR DESCRIPTION
## Summary
- split the storefront production bundle into smaller vendor chunks, including React, UI, forms, auth, charts, icons, AWS, state, media helpers, and existing storefront-specific vendors
- enabled TanStack Router auto code splitting for route-level production chunks
- lazy-load the HLS light build from the home page video player so the media parser stays out of initial app code

## Validation
- bun run --filter @athena/storefront-webapp build
- bun run --filter @athena/storefront-webapp test -- src/components/home/BestSellersSection.test.tsx src/components/product-page/ProductPage.test.tsx src/components/product-page/ProductActions.test.tsx
- computer-use production preview smoke at http://127.0.0.1:4175/ and /login; built app rendered the storefront maintenance view with accessible heading/status text
- bun run graphify:rebuild
- bun run pr:athena
- git diff --check

Linear: https://linear.app/v26-labs/issue/V26-456/clear-storefront-webapp-production-chunk-size-warnings