### PR TITLE
fix(deploy): point storefront prod at API gateway

### DIFF
--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -40,6 +40,9 @@ describe("VPS QA deploy contract", () => {
     expect(deployScript).toContain("pm2 delete storefront-qa");
     expect(deployScript).toContain("pm2 start bun --name athena-qa");
     expect(deployScript).toContain("pm2 start bun --name storefront-qa");
+    expect(deployScript).toContain('PROD_API_URL="${PROD_API_URL:-https://api.wigclub.store}"');
+    expect(deployScript).toContain('VITE_API_URL=$PROD_API_URL');
+    expect(deployScript).not.toContain('VITE_API_URL=$PROD_CONVEX_SITE');
     expect(deployScript).toContain('DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"');
     expect(deployScript).toContain(
       'remote_script "$REMOTE_SOURCE_DIR" "$STOREFRONT_QA_PORT" "$DEV_API_URL" "$STOREFRONT_QA_HOST"',

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -13,6 +13,7 @@ STOREFRONT_QA_HOST="${STOREFRONT_QA_HOST:-qa.wigclub.store}"
 
 PROD_CONVEX_CLOUD="${PROD_CONVEX_CLOUD:-https://colorless-cardinal-870.convex.cloud}"
 PROD_CONVEX_SITE="${PROD_CONVEX_SITE:-https://colorless-cardinal-870.convex.site}"
+PROD_API_URL="${PROD_API_URL:-https://api.wigclub.store}"
 DEV_CONVEX_CLOUD="${DEV_CONVEX_CLOUD:-https://jovial-wildebeest-179.convex.cloud}"
 DEV_CONVEX_SITE="${DEV_CONVEX_SITE:-https://jovial-wildebeest-179.convex.site}"
 DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"
@@ -207,7 +208,7 @@ deploy_storefront() {
   deploy_static_app \
     "storefront" \
     "packages/storefront-webapp" \
-    "VITE_API_URL=$PROD_CONVEX_SITE"
+    "VITE_API_URL=$PROD_API_URL"
 }
 
 deploy_valkey_proxy() {


### PR DESCRIPTION
## Summary
- default production storefront builds to use https://api.wigclub.store via PROD_API_URL
- keep Convex site URL available for backend/proxy deploy plumbing, but stop injecting it into VITE_API_URL
- add deploy-script regression coverage so storefront prod cannot silently switch back to the Convex site

## Production verification
- reproduced live console failures on https://wigclub.store with Computer Use: old bundle called https://colorless-cardinal-870.convex.site directly
- deployed storefront from the patched worktree with scripts/deploy-vps.sh storefront
- verified live HTML now loads /assets/index-DbOX3Md9.js
- verified live bundle contains https://api.wigclub.store and no direct colorless-cardinal-870.convex.site frontend API target

## Validation
- bun run --filter '@athena/storefront-webapp' test -- src/routes/-homePageLoader.test.ts src/hooks/useQueryEnabled.test.ts
- bun test scripts/deploy-qa-vps.test.ts
- PROD_API_URL=https://api.wigclub.store bash -n scripts/deploy-vps.sh && VITE_API_URL=https://api.wigclub.store bun run --filter '@athena/storefront-webapp' build
- bun run graphify:rebuild
- git push pre-push suite: graphify:check, harness:self-review, architecture:check, harness:review, harness:inferential-review