### PR TITLE
feat(athena): refine stock adjustment workspace

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4232 nodes · 3874 edges · 1498 communities detected
+- 4234 nodes · 3875 edges · 1498 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1620,48 +1620,48 @@ Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
 ### Community 21 - "Community 21"
+Cohesion: 0.12
+Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
+
+### Community 22 - "Community 22"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.13
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.17
 Nodes (9): expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), normalizeCustomerSnapshot(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), registerSessionMatchesIdentity(), resolveCustomerTraceStage() (+1 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.23
 Nodes (13): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listProductSkusForStockAdjustmentScopeWithCtx(), mapSubmitStockAdjustmentBatchError() (+5 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.15
-Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
 ### Community 32 - "Community 32"
 Cohesion: 0.24
@@ -1984,16 +1984,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 112 - "Community 112"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 113 - "Community 113"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 114 - "Community 114"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 115 - "Community 115"
 Cohesion: 0.48
@@ -2528,16 +2528,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.67
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
-
-### Community 249 - "Community 249"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 250 - "Community 250"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.5
@@ -2564,68 +2564,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 258 - "Community 258"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 258 - "Community 258"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 261 - "Community 261"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 262 - "Community 262"
+### Community 261 - "Community 261"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 263 - "Community 263"
+### Community 262 - "Community 262"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
+
+### Community 263 - "Community 263"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 266 - "Community 266"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 267 - "Community 267"
+### Community 266 - "Community 266"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 268 - "Community 268"
+### Community 267 - "Community 267"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 269 - "Community 269"
+### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 270 - "Community 270"
+### Community 269 - "Community 269"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 271 - "Community 271"
+### Community 270 - "Community 270"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 272 - "Community 272"
+### Community 271 - "Community 271"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 272 - "Community 272"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 0.5
@@ -2652,55 +2652,55 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 279 - "Community 279"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 281 - "Community 281"
+### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 282 - "Community 282"
+### Community 281 - "Community 281"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 283 - "Community 283"
+### Community 282 - "Community 282"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 284 - "Community 284"
+### Community 283 - "Community 283"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 285 - "Community 285"
+### Community 284 - "Community 284"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 288 - "Community 288"
+### Community 287 - "Community 287"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 289 - "Community 289"
+### Community 288 - "Community 288"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 290 - "Community 290"
+### Community 289 - "Community 289"
 Cohesion: 0.83
 Nodes (3): runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts(), stageTrackedWorkingTreeChanges()
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 0.5
+Nodes (0):
+
+### Community 291 - "Community 291"
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 292 - "Community 292"
@@ -2753,35 +2753,35 @@ Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 305 - "Community 305"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 307 - "Community 307"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 308 - "Community 308"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+
+### Community 308 - "Community 308"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 311 - "Community 311"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 311 - "Community 311"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
@@ -2792,36 +2792,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 315 - "Community 315"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 316 - "Community 316"
+### Community 315 - "Community 315"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 317 - "Community 317"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 319 - "Community 319"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 320 - "Community 320"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (1): View()
+
+### Community 321 - "Community 321"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
@@ -2836,24 +2836,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 326 - "Community 326"
 Cohesion: 1.0
 Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.67
 Nodes (1): FadeIn()
+
+### Community 329 - "Community 329"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.67
@@ -2861,11 +2861,11 @@ Nodes (0):
 
 ### Community 331 - "Community 331"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 1.0

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -83,7 +83,7 @@
       "relation": "calls",
       "source": "adjustments_mapsubmitstockadjustmentbatcherror",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L785",
+      "source_location": "L786",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -95,7 +95,7 @@
       "relation": "calls",
       "source": "adjustments_submitstockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L783",
+      "source_location": "L784",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -107,7 +107,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L685",
+      "source_location": "L686",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -119,7 +119,7 @@
       "relation": "calls",
       "source": "adjustments_assertdistinctstockadjustmentlineitems",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L551",
+      "source_location": "L552",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -131,7 +131,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L641",
+      "source_location": "L642",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -143,7 +143,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L539",
+      "source_location": "L540",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -155,7 +155,7 @@
       "relation": "calls",
       "source": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L484",
+      "source_location": "L485",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -7777,18 +7777,6 @@
       "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
       "source_location": "L19",
       "target": "operationsqueryindexes_test_expectindex",
-      "weight": 1
-    },
-    {
-      "_src": "operationsqueueview_setdecisioningapprovalrequestid",
-      "_tgt": "operationsqueueview_getapprovalrequestcopy",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "operationsqueueview_getapprovalrequestcopy",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L500",
-      "target": "operationsqueueview_setdecisioningapprovalrequestid",
       "weight": 1
     },
     {
@@ -15779,7 +15767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L725",
+      "source_location": "L726",
       "target": "adjustments_mapsubmitstockadjustmentbatcherror",
       "weight": 1
     },
@@ -15803,7 +15791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L778",
+      "source_location": "L779",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -15815,7 +15803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L535",
+      "source_location": "L536",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -15827,7 +15815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L454",
+      "source_location": "L455",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -19751,7 +19739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L88",
+      "source_location": "L83",
       "target": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
       "weight": 1
     },
@@ -19775,7 +19763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L549",
+      "source_location": "L544",
       "target": "cashcontrolsdashboard_if",
       "weight": 1
     },
@@ -19787,7 +19775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L102",
+      "source_location": "L97",
       "target": "cashcontrolsdashboard_metriccardskeleton",
       "weight": 1
     },
@@ -19799,7 +19787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L271",
+      "source_location": "L266",
       "target": "cashcontrolsdashboard_switch",
       "weight": 1
     },
@@ -21047,7 +21035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L64",
+      "source_location": "L61",
       "target": "operationsqueueview_getapprovalrequestcopy",
       "weight": 1
     },
@@ -21059,20 +21047,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L55",
+      "source_location": "L52",
       "target": "operationsqueueview_getdefaultworkflow",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "_tgt": "operationsqueueview_setdecisioningapprovalrequestid",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L481",
-      "target": "operationsqueueview_setdecisioningapprovalrequestid",
       "weight": 1
     },
     {
@@ -21083,7 +21059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
-      "source_location": "L89",
+      "source_location": "L88",
       "target": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "weight": 1
     },
@@ -21095,7 +21071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L177",
+      "source_location": "L161",
       "target": "stockadjustmentworkspace_buildcyclecountdrafts",
       "weight": 1
     },
@@ -21107,7 +21083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L173",
+      "source_location": "L157",
       "target": "stockadjustmentworkspace_buildmanualdrafts",
       "weight": 1
     },
@@ -21119,7 +21095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L183",
+      "source_location": "L167",
       "target": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
       "weight": 1
     },
@@ -21131,7 +21107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1086",
+      "source_location": "L182",
       "target": "stockadjustmentworkspace_formatinventorynumber",
       "weight": 1
     },
@@ -21143,7 +21119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L165",
+      "source_location": "L149",
       "target": "stockadjustmentworkspace_getcountscopekey",
       "weight": 1
     },
@@ -21155,7 +21131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L169",
+      "source_location": "L153",
       "target": "stockadjustmentworkspace_getcountscopelabel",
       "weight": 1
     },
@@ -21167,8 +21143,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L202",
+      "source_location": "L186",
       "target": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "_tgt": "stockadjustmentworkspace_getskudetailentries",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L190",
+      "target": "stockadjustmentworkspace_getskudetailentries",
       "weight": 1
     },
     {
@@ -21179,7 +21167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L685",
+      "source_location": "L734",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -21191,8 +21179,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L206",
+      "source_location": "L207",
       "target": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "_tgt": "stockadjustmentworkspace_parsecountscopekeys",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L211",
+      "target": "stockadjustmentworkspace_parsecountscopekeys",
       "weight": 1
     },
     {
@@ -21203,7 +21203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L194",
+      "source_location": "L178",
       "target": "stockadjustmentworkspace_pluralize",
       "weight": 1
     },
@@ -21215,7 +21215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L233",
+      "source_location": "L247",
       "target": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
       "weight": 1
     },
@@ -21227,8 +21227,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L210",
+      "source_location": "L224",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "_tgt": "stockadjustmentworkspace_serializecountscopekeys",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L220",
+      "target": "stockadjustmentworkspace_serializecountscopekeys",
       "weight": 1
     },
     {
@@ -21239,7 +21251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L675",
+      "source_location": "L724",
       "target": "stockadjustmentworkspace_setdraftvalue",
       "weight": 1
     },
@@ -21251,7 +21263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L189",
+      "source_location": "L173",
       "target": "stockadjustmentworkspace_trimoptional",
       "weight": 1
     },
@@ -44447,7 +44459,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_setdraftvalue",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L686",
+      "source_location": "L735",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -44459,7 +44471,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_getinventoryitemdisplayname",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L218",
+      "source_location": "L232",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -49557,65 +49569,65 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1120,
@@ -49710,65 +49722,65 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1130,
@@ -49863,65 +49875,65 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1140,
@@ -52864,7 +52876,7 @@
       "label": "CashControlsHeaderSkeleton()",
       "norm_label": "cashcontrolsheaderskeleton()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L88"
+      "source_location": "L83"
     },
     {
       "community": 132,
@@ -52873,7 +52885,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L378"
+      "source_location": "L373"
     },
     {
       "community": 132,
@@ -52882,7 +52894,7 @@
       "label": "if()",
       "norm_label": "if()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L549"
+      "source_location": "L544"
     },
     {
       "community": 132,
@@ -52891,7 +52903,7 @@
       "label": "MetricCardSkeleton()",
       "norm_label": "metriccardskeleton()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L102"
+      "source_location": "L97"
     },
     {
       "community": 132,
@@ -52900,7 +52912,7 @@
       "label": "switch()",
       "norm_label": "switch()",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L271"
+      "source_location": "L266"
     },
     {
       "community": 132,
@@ -59700,164 +59712,164 @@
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L182"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopekey",
+      "label": "getCountScopeKey()",
+      "norm_label": "getcountscopekey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L153"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L186"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L190"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L734"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
+      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "label": "normalizeStockAdjustmentSearch()",
+      "norm_label": "normalizestockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L207"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
+      "id": "stockadjustmentworkspace_parsecountscopekeys",
+      "label": "parseCountScopeKeys()",
+      "norm_label": "parsecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L211"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L178"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L247"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
+      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "label": "rowMatchesStockAdjustmentSearch()",
+      "norm_label": "rowmatchesstockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L224"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
+      "id": "stockadjustmentworkspace_serializecountscopekeys",
+      "label": "serializeCountScopeKeys()",
+      "norm_label": "serializecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L220"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L724"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L1"
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L173"
     },
     {
       "community": 210,
@@ -60240,154 +60252,163 @@
     {
       "community": 22,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
     },
     {
@@ -60753,154 +60774,154 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -61266,154 +61287,154 @@
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1"
     },
     {
@@ -61707,42 +61728,6 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "operationsqueueview_getapprovalrequestcopy",
-      "label": "getApprovalRequestCopy()",
-      "norm_label": "getapprovalrequestcopy()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "operationsqueueview_getdefaultworkflow",
-      "label": "getDefaultWorkflow()",
-      "norm_label": "getdefaultworkflow()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "operationsqueueview_setdecisioningapprovalrequestid",
-      "label": "setDecisioningApprovalRequestId()",
-      "norm_label": "setdecisioningapprovalrequestid()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L481"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
       "norm_label": "useapprovedcommand.tsx",
@@ -61750,7 +61735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -61759,7 +61744,7 @@
       "source_location": "L67"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -61768,7 +61753,7 @@
       "source_location": "L61"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -61777,151 +61762,7 @@
       "source_location": "L73"
     },
     {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_buildcashcontrolsdashboardsnapshot",
-      "label": "buildCashControlsDashboardSnapshot()",
-      "norm_label": "buildcashcontrolsdashboardsnapshot()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_buildregistersessiondeposittargetid",
-      "label": "buildRegisterSessionDepositTargetId()",
-      "norm_label": "buildregistersessiondeposittargetid()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_buildregistersessionsummary",
-      "label": "buildRegisterSessionSummary()",
-      "norm_label": "buildregistersessionsummary()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_collectstaffprofileids",
-      "label": "collectStaffProfileIds()",
-      "norm_label": "collectstaffprofileids()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L372"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_iscashcontroldepositallocation",
-      "label": "isCashControlDepositAllocation()",
-      "norm_label": "iscashcontroldepositallocation()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listregistersessionsfordashboard",
-      "label": "listRegisterSessionsForDashboard()",
-      "norm_label": "listregistersessionsfordashboard()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listregistersessiontimeline",
-      "label": "listRegisterSessionTimeline()",
-      "norm_label": "listregistersessiontimeline()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listregistersessiontransactions",
-      "label": "listRegisterSessionTransactions()",
-      "norm_label": "listregistersessiontransactions()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L359"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listsessiondeposits",
-      "label": "listSessionDeposits()",
-      "norm_label": "listsessiondeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L332"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_liststoredeposits",
-      "label": "listStoreDeposits()",
-      "norm_label": "liststoredeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_listterminalnames",
-      "label": "listTerminalNames()",
-      "norm_label": "listterminalnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L301"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_sumdepositsbysession",
-      "label": "sumDepositsBySession()",
-      "norm_label": "sumdepositsbysession()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "deposits_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
-      "label": "deposits.ts",
-      "norm_label": "deposits.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 250,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -61930,7 +61771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 249,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -61939,7 +61780,7 @@
       "source_location": "L105"
     },
     {
-      "community": 250,
+      "community": 249,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -61948,7 +61789,7 @@
       "source_location": "L97"
     },
     {
-      "community": 250,
+      "community": 249,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -61957,7 +61798,160 @@
       "source_location": "L83"
     },
     {
-      "community": 251,
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -61966,7 +61960,7 @@
       "source_location": "L91"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -61975,7 +61969,7 @@
       "source_location": "L68"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -61984,7 +61978,7 @@
       "source_location": "L22"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -61993,7 +61987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -62002,7 +61996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -62011,7 +62005,7 @@
       "source_location": "L162"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -62020,7 +62014,7 @@
       "source_location": "L384"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -62029,7 +62023,7 @@
       "source_location": "L345"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -62038,7 +62032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -62047,7 +62041,7 @@
       "source_location": "L22"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -62056,7 +62050,7 @@
       "source_location": "L27"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -62065,7 +62059,7 @@
       "source_location": "L40"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -62074,7 +62068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -62083,7 +62077,7 @@
       "source_location": "L78"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -62092,7 +62086,7 @@
       "source_location": "L118"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -62101,7 +62095,7 @@
       "source_location": "L89"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -62110,7 +62104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -62119,7 +62113,7 @@
       "source_location": "L63"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -62128,7 +62122,7 @@
       "source_location": "L54"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -62137,7 +62131,7 @@
       "source_location": "L11"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -62146,7 +62140,7 @@
       "source_location": "L16"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -62155,7 +62149,7 @@
       "source_location": "L35"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -62164,7 +62158,7 @@
       "source_location": "L6"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -62173,7 +62167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -62182,7 +62176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -62191,7 +62185,7 @@
       "source_location": "L5"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -62200,7 +62194,7 @@
       "source_location": "L30"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -62209,7 +62203,7 @@
       "source_location": "L21"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -62218,7 +62212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -62227,7 +62221,7 @@
       "source_location": "L178"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -62236,7 +62230,7 @@
       "source_location": "L205"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -62245,7 +62239,7 @@
       "source_location": "L806"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -62254,7 +62248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -62263,7 +62257,7 @@
       "source_location": "L41"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -62272,7 +62266,7 @@
       "source_location": "L45"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -62281,151 +62275,7 @@
       "source_location": "L65"
     },
     {
-      "community": 26,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_expirepossessionnow",
-      "label": "expirePosSessionNow()",
-      "norm_label": "expirepossessionnow()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L368"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_loadsessioncustomer",
-      "label": "loadSessionCustomer()",
-      "norm_label": "loadsessioncustomer()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L353"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_usererrorfromsessioncommandfailure",
-      "label": "userErrorFromSessionCommandFailure()",
-      "norm_label": "usererrorfromsessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_usererrorfromvalidationmessage",
-      "label": "userErrorFromValidationMessage()",
-      "norm_label": "usererrorfromvalidationmessage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_validatesessiondrawerbinding",
-      "label": "validateSessionDrawerBinding()",
-      "norm_label": "validatesessiondrawerbinding()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 260,
+      "community": 259,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -62434,7 +62284,7 @@
       "source_location": "L75"
     },
     {
-      "community": 260,
+      "community": 259,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -62443,7 +62293,7 @@
       "source_location": "L82"
     },
     {
-      "community": 260,
+      "community": 259,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -62452,7 +62302,7 @@
       "source_location": "L93"
     },
     {
-      "community": 260,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -62461,7 +62311,151 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_buildcashcontrolsdashboardsnapshot",
+      "label": "buildCashControlsDashboardSnapshot()",
+      "norm_label": "buildcashcontrolsdashboardsnapshot()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_buildregistersessiondeposittargetid",
+      "label": "buildRegisterSessionDepositTargetId()",
+      "norm_label": "buildregistersessiondeposittargetid()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_buildregistersessionsummary",
+      "label": "buildRegisterSessionSummary()",
+      "norm_label": "buildregistersessionsummary()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_collectstaffprofileids",
+      "label": "collectStaffProfileIds()",
+      "norm_label": "collectstaffprofileids()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_iscashcontroldepositallocation",
+      "label": "isCashControlDepositAllocation()",
+      "norm_label": "iscashcontroldepositallocation()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listregistersessionsfordashboard",
+      "label": "listRegisterSessionsForDashboard()",
+      "norm_label": "listregistersessionsfordashboard()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listregistersessiontimeline",
+      "label": "listRegisterSessionTimeline()",
+      "norm_label": "listregistersessiontimeline()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listregistersessiontransactions",
+      "label": "listRegisterSessionTransactions()",
+      "norm_label": "listregistersessiontransactions()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L359"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listsessiondeposits",
+      "label": "listSessionDeposits()",
+      "norm_label": "listsessiondeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L332"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_liststoredeposits",
+      "label": "listStoreDeposits()",
+      "norm_label": "liststoredeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_listterminalnames",
+      "label": "listTerminalNames()",
+      "norm_label": "listterminalnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L301"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_sumdepositsbysession",
+      "label": "sumDepositsBySession()",
+      "norm_label": "sumdepositsbysession()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "deposits_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
+      "label": "deposits.ts",
+      "norm_label": "deposits.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -62470,7 +62464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -62479,7 +62473,7 @@
       "source_location": "L15"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -62488,7 +62482,7 @@
       "source_location": "L28"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -62497,7 +62491,7 @@
       "source_location": "L54"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -62506,7 +62500,7 @@
       "source_location": "L66"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -62515,7 +62509,7 @@
       "source_location": "L121"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -62524,7 +62518,7 @@
       "source_location": "L74"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -62533,7 +62527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -62542,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -62551,7 +62545,7 @@
       "source_location": "L34"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -62560,7 +62554,7 @@
       "source_location": "L28"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -62569,7 +62563,7 @@
       "source_location": "L48"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -62578,7 +62572,7 @@
       "source_location": "L51"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -62587,7 +62581,7 @@
       "source_location": "L92"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -62596,7 +62590,7 @@
       "source_location": "L16"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -62605,7 +62599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -62614,7 +62608,7 @@
       "source_location": "L22"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -62623,7 +62617,7 @@
       "source_location": "L10"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -62632,7 +62626,7 @@
       "source_location": "L57"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -62641,7 +62635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -62650,7 +62644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -62659,7 +62653,7 @@
       "source_location": "L83"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -62668,7 +62662,7 @@
       "source_location": "L100"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -62677,7 +62671,7 @@
       "source_location": "L79"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -62686,7 +62680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -62695,7 +62689,7 @@
       "source_location": "L38"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -62704,7 +62698,7 @@
       "source_location": "L65"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -62713,7 +62707,7 @@
       "source_location": "L91"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -62722,7 +62716,7 @@
       "source_location": "L4"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -62731,7 +62725,7 @@
       "source_location": "L20"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -62740,7 +62734,7 @@
       "source_location": "L42"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -62749,7 +62743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -62758,7 +62752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -62767,7 +62761,7 @@
       "source_location": "L36"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -62776,7 +62770,7 @@
       "source_location": "L48"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -62785,151 +62779,7 @@
       "source_location": "L64"
     },
     {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L156"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L250"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_getstockadjustmentscopekey",
-      "label": "getStockAdjustmentScopeKey()",
-      "norm_label": "getstockadjustmentscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
-      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
-      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L725"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L778"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L535"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
-      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
-      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L454"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 270,
+      "community": 269,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -62938,7 +62788,7 @@
       "source_location": "L13"
     },
     {
-      "community": 270,
+      "community": 269,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -62947,7 +62797,7 @@
       "source_location": "L46"
     },
     {
-      "community": 270,
+      "community": 269,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -62956,7 +62806,7 @@
       "source_location": "L21"
     },
     {
-      "community": 270,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -62965,7 +62815,151 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 27,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_expirepossessionnow",
+      "label": "expirePosSessionNow()",
+      "norm_label": "expirepossessionnow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L368"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_loadsessioncustomer",
+      "label": "loadSessionCustomer()",
+      "norm_label": "loadsessioncustomer()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L353"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L379"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_validatesessiondrawerbinding",
+      "label": "validateSessionDrawerBinding()",
+      "norm_label": "validatesessiondrawerbinding()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 270,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -62974,7 +62968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -62983,7 +62977,7 @@
       "source_location": "L8"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -62992,7 +62986,7 @@
       "source_location": "L5"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -63001,7 +62995,7 @@
       "source_location": "L20"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -63010,7 +63004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -63019,7 +63013,7 @@
       "source_location": "L11"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -63028,7 +63022,7 @@
       "source_location": "L9"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -63037,7 +63031,7 @@
       "source_location": "L25"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -63046,7 +63040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -63055,7 +63049,7 @@
       "source_location": "L50"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -63064,7 +63058,7 @@
       "source_location": "L92"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -63073,7 +63067,7 @@
       "source_location": "L74"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -63082,7 +63076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -63091,7 +63085,7 @@
       "source_location": "L62"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -63100,7 +63094,7 @@
       "source_location": "L109"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -63109,7 +63103,7 @@
       "source_location": "L177"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -63118,7 +63112,7 @@
       "source_location": "L18"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -63127,7 +63121,7 @@
       "source_location": "L52"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -63136,7 +63130,7 @@
       "source_location": "L68"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -63145,7 +63139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -63154,7 +63148,7 @@
       "source_location": "L68"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -63163,7 +63157,7 @@
       "source_location": "L26"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -63172,7 +63166,7 @@
       "source_location": "L7"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -63181,7 +63175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -63190,7 +63184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -63199,7 +63193,7 @@
       "source_location": "L81"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -63208,7 +63202,7 @@
       "source_location": "L85"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -63217,7 +63211,7 @@
       "source_location": "L27"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -63226,7 +63220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -63235,7 +63229,7 @@
       "source_location": "L43"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -63244,7 +63238,7 @@
       "source_location": "L13"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -63253,7 +63247,7 @@
       "source_location": "L88"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -63262,7 +63256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -63271,7 +63265,7 @@
       "source_location": "L111"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -63280,7 +63274,7 @@
       "source_location": "L66"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -63289,151 +63283,7 @@
       "source_location": "L127"
     },
     {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 280,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -63442,7 +63292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 279,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -63451,7 +63301,7 @@
       "source_location": "L25"
     },
     {
-      "community": 280,
+      "community": 279,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -63460,7 +63310,7 @@
       "source_location": "L90"
     },
     {
-      "community": 280,
+      "community": 279,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -63469,7 +63319,151 @@
       "source_location": "L82"
     },
     {
-      "community": 281,
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L156"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L250"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_getstockadjustmentscopekey",
+      "label": "getStockAdjustmentScopeKey()",
+      "norm_label": "getstockadjustmentscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
+      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
+      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L726"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L779"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L536"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
+      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
+      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L455"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -63478,7 +63472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -63487,7 +63481,7 @@
       "source_location": "L115"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -63496,7 +63490,7 @@
       "source_location": "L105"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -63505,7 +63499,7 @@
       "source_location": "L110"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -63514,7 +63508,7 @@
       "source_location": "L121"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -63523,7 +63517,7 @@
       "source_location": "L26"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -63532,7 +63526,7 @@
       "source_location": "L71"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -63541,7 +63535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -63550,7 +63544,7 @@
       "source_location": "L46"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -63559,7 +63553,7 @@
       "source_location": "L24"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -63568,7 +63562,7 @@
       "source_location": "L20"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -63577,7 +63571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -63586,7 +63580,7 @@
       "source_location": "L17"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -63595,7 +63589,7 @@
       "source_location": "L11"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -63604,7 +63598,7 @@
       "source_location": "L24"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -63613,7 +63607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -63622,7 +63616,7 @@
       "source_location": "L20"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -63631,7 +63625,7 @@
       "source_location": "L65"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -63640,7 +63634,7 @@
       "source_location": "L14"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -63649,7 +63643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -63658,7 +63652,7 @@
       "source_location": "L126"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -63667,7 +63661,7 @@
       "source_location": "L130"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -63676,7 +63670,7 @@
       "source_location": "L879"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -63685,7 +63679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -63694,7 +63688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -63703,7 +63697,7 @@
       "source_location": "L8"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -63712,7 +63706,7 @@
       "source_location": "L79"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -63721,7 +63715,7 @@
       "source_location": "L61"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -63730,7 +63724,7 @@
       "source_location": "L49"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -63739,7 +63733,7 @@
       "source_location": "L17"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -63748,7 +63742,7 @@
       "source_location": "L11"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -63757,7 +63751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -63766,7 +63760,7 @@
       "source_location": "L26"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -63775,7 +63769,7 @@
       "source_location": "L72"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -63784,7 +63778,7 @@
       "source_location": "L36"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -63793,151 +63787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror",
-      "label": "CheckoutSessionError",
-      "norm_label": "checkoutsessionerror",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_createcheckoutsession",
-      "label": "createCheckoutSession()",
-      "norm_label": "createcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_defaultcheckoutactionmessage",
-      "label": "defaultCheckoutActionMessage()",
-      "norm_label": "defaultcheckoutactionmessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_getactivecheckoutsession",
-      "label": "getActiveCheckoutSession()",
-      "norm_label": "getactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutactionerrormessage",
-      "label": "getCheckoutActionErrorMessage()",
-      "norm_label": "getcheckoutactionerrormessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "label": "getCheckoutErrorMessageFromPayload()",
-      "norm_label": "getcheckouterrormessagefrompayload()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutsession",
-      "label": "getCheckoutSession()",
-      "norm_label": "getcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_getpendingcheckoutsessions",
-      "label": "getPendingCheckoutSessions()",
-      "norm_label": "getpendingcheckoutsessions()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_parsecheckoutresponse",
-      "label": "parseCheckoutResponse()",
-      "norm_label": "parsecheckoutresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_parsejson",
-      "label": "parseJson()",
-      "norm_label": "parsejson()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_updatecheckoutsession",
-      "label": "updateCheckoutSession()",
-      "norm_label": "updatecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "checkoutsession_verifycheckoutsessionpayment",
-      "label": "verifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L274"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 290,
+      "community": 289,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -63946,7 +63796,7 @@
       "source_location": "L81"
     },
     {
-      "community": 290,
+      "community": 289,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "label": "stageTrackedGeneratedArtifacts()",
@@ -63955,7 +63805,7 @@
       "source_location": "L29"
     },
     {
-      "community": 290,
+      "community": 289,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedworkingtreechanges",
       "label": "stageTrackedWorkingTreeChanges()",
@@ -63964,7 +63814,7 @@
       "source_location": "L56"
     },
     {
-      "community": 290,
+      "community": 289,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -63973,7 +63823,151 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -63982,7 +63976,7 @@
       "source_location": "L96"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -63991,7 +63985,7 @@
       "source_location": "L94"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -64000,7 +63994,7 @@
       "source_location": "L95"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -64009,7 +64003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -64018,7 +64012,7 @@
       "source_location": "L15"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -64027,7 +64021,7 @@
       "source_location": "L11"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -64036,7 +64030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -64045,7 +64039,7 @@
       "source_location": "L98"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -64054,7 +64048,7 @@
       "source_location": "L33"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -64063,7 +64057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -64072,7 +64066,7 @@
       "source_location": "L85"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -64081,7 +64075,7 @@
       "source_location": "L31"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -64090,7 +64084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -64099,7 +64093,7 @@
       "source_location": "L12"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -64108,7 +64102,7 @@
       "source_location": "L21"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -64117,7 +64111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -64126,7 +64120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -64135,7 +64129,7 @@
       "source_location": "L5"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -64144,7 +64138,7 @@
       "source_location": "L12"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -64153,7 +64147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -64162,7 +64156,7 @@
       "source_location": "L14"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -64171,7 +64165,7 @@
       "source_location": "L10"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -64180,7 +64174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -64189,7 +64183,7 @@
       "source_location": "L6"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -64198,7 +64192,7 @@
       "source_location": "L9"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -64207,7 +64201,7 @@
       "source_location": "L43"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -64216,13 +64210,40 @@
       "source_location": "L11"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
       "norm_label": "analyticsutils.ts",
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
+      "label": "staffCredentials.test.ts",
+      "norm_label": "staffcredentials.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
+      "label": "createStaffCredentialsMutationCtx()",
+      "norm_label": "createstaffcredentialsmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "staffcredentials_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L118"
     },
     {
       "community": 3,
@@ -64515,176 +64536,149 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_addgroupederror",
-      "label": "addGroupedError()",
-      "norm_label": "addgroupederror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L102"
+      "id": "checkoutsession_checkoutsessionerror",
+      "label": "CheckoutSessionError",
+      "norm_label": "checkoutsessionerror",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L64"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_collectlivesurfaceentries",
-      "label": "collectLiveSurfaceEntries()",
-      "norm_label": "collectlivesurfaceentries()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L145"
+      "id": "checkoutsession_checkoutsessionerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L69"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L57"
+      "id": "checkoutsession_createcheckoutsession",
+      "label": "createCheckoutSession()",
+      "norm_label": "createcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L184"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_formatgroupederrors",
-      "label": "formatGroupedErrors()",
-      "norm_label": "formatgroupederrors()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L351"
+      "id": "checkoutsession_defaultcheckoutactionmessage",
+      "label": "defaultCheckoutActionMessage()",
+      "norm_label": "defaultcheckoutactionmessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L135"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_formatmissingvalidationpatherror",
-      "label": "formatMissingValidationPathError()",
-      "norm_label": "formatmissingvalidationpatherror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L116"
+      "id": "checkoutsession_getactivecheckoutsession",
+      "label": "getActiveCheckoutSession()",
+      "norm_label": "getactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L204"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66"
+      "id": "checkoutsession_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L5"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_infergroupfromerror",
-      "label": "inferGroupFromError()",
-      "norm_label": "infergroupfromerror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L126"
+      "id": "checkoutsession_getcheckoutactionerrormessage",
+      "label": "getCheckoutActionErrorMessage()",
+      "norm_label": "getcheckoutactionerrormessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L147"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_loadaudittarget",
-      "label": "loadAuditTarget()",
-      "norm_label": "loadaudittarget()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "harness_audit_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "harness_audit_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "checkoutsession_getcheckouterrormessagefrompayload",
+      "label": "getCheckoutErrorMessageFromPayload()",
+      "norm_label": "getcheckouterrormessagefrompayload()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L39"
+      "id": "checkoutsession_getcheckoutsession",
+      "label": "getCheckoutSession()",
+      "norm_label": "getcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L226"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L90"
+      "id": "checkoutsession_getpendingcheckoutsessions",
+      "label": "getPendingCheckoutSessions()",
+      "norm_label": "getpendingcheckoutsessions()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L215"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L86"
+      "id": "checkoutsession_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L78"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_runharnessaudit",
-      "label": "runHarnessAudit()",
-      "norm_label": "runharnessaudit()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L366"
+      "id": "checkoutsession_parsecheckoutresponse",
+      "label": "parseCheckoutResponse()",
+      "norm_label": "parsecheckoutresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L115"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "harness_audit_shouldskipsurfaceentry",
-      "label": "shouldSkipSurfaceEntry()",
-      "norm_label": "shouldskipsurfaceentry()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L131"
+      "id": "checkoutsession_parsejson",
+      "label": "parseJson()",
+      "norm_label": "parsejson()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L81"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "scripts_harness_audit_ts",
-      "label": "harness-audit.ts",
-      "norm_label": "harness-audit.ts",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "checkoutsession_updatecheckoutsession",
+      "label": "updateCheckoutSession()",
+      "norm_label": "updatecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "checkoutsession_verifycheckoutsessionpayment",
+      "label": "verifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1"
     },
     {
       "community": 300,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
-      "label": "staffCredentials.test.ts",
-      "norm_label": "staffcredentials.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
-      "label": "createStaffCredentialsMutationCtx()",
-      "norm_label": "createstaffcredentialsmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "staffcredentials_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 301,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -64693,7 +64687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -64702,7 +64696,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -64711,7 +64705,7 @@
       "source_location": "L92"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -64720,7 +64714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -64729,7 +64723,7 @@
       "source_location": "L21"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -64738,7 +64732,7 @@
       "source_location": "L31"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -64747,7 +64741,7 @@
       "source_location": "L7"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -64756,7 +64750,7 @@
       "source_location": "L109"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -64765,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -64774,7 +64768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -64783,7 +64777,7 @@
       "source_location": "L18"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -64792,7 +64786,7 @@
       "source_location": "L9"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -64801,7 +64795,7 @@
       "source_location": "L8"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -64810,7 +64804,7 @@
       "source_location": "L9"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -64819,7 +64813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -64828,7 +64822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -64837,7 +64831,7 @@
       "source_location": "L7"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -64846,7 +64840,7 @@
       "source_location": "L29"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -64855,7 +64849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -64864,7 +64858,7 @@
       "source_location": "L13"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -64873,7 +64867,7 @@
       "source_location": "L45"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -64882,7 +64876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -64891,7 +64885,7 @@
       "source_location": "L36"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -64900,7 +64894,7 @@
       "source_location": "L13"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -64909,7 +64903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -64918,7 +64912,7 @@
       "source_location": "L14"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -64927,142 +64921,7 @@
       "source_location": "L18"
     },
     {
-      "community": 31,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L183"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopekey",
-      "label": "getCountScopeKey()",
-      "norm_label": "getcountscopekey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L165"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L202"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L685"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
-      "label": "normalizeStockAdjustmentSearch()",
-      "norm_label": "normalizestockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L206"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L233"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "label": "rowMatchesStockAdjustmentSearch()",
-      "norm_label": "rowmatchesstockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L210"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L675"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 310,
+      "community": 309,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -65071,7 +64930,7 @@
       "source_location": "L17"
     },
     {
-      "community": 310,
+      "community": 309,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -65080,7 +64939,7 @@
       "source_location": "L61"
     },
     {
-      "community": 310,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -65089,7 +64948,151 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_addgroupederror",
+      "label": "addGroupedError()",
+      "norm_label": "addgroupederror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_collectlivesurfaceentries",
+      "label": "collectLiveSurfaceEntries()",
+      "norm_label": "collectlivesurfaceentries()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_formatgroupederrors",
+      "label": "formatGroupedErrors()",
+      "norm_label": "formatgroupederrors()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L351"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_formatmissingvalidationpatherror",
+      "label": "formatMissingValidationPathError()",
+      "norm_label": "formatmissingvalidationpatherror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_infergroupfromerror",
+      "label": "inferGroupFromError()",
+      "norm_label": "infergroupfromerror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_loadaudittarget",
+      "label": "loadAuditTarget()",
+      "norm_label": "loadaudittarget()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_runharnessaudit",
+      "label": "runHarnessAudit()",
+      "norm_label": "runharnessaudit()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L366"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "label": "shouldSkipSurfaceEntry()",
+      "norm_label": "shouldskipsurfaceentry()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "scripts_harness_audit_ts",
+      "label": "harness-audit.ts",
+      "norm_label": "harness-audit.ts",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -65098,7 +65101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -65107,7 +65110,7 @@
       "source_location": "L23"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -65116,7 +65119,7 @@
       "source_location": "L16"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -65125,7 +65128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -65134,7 +65137,7 @@
       "source_location": "L20"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -65143,7 +65146,7 @@
       "source_location": "L16"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -65152,7 +65155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -65161,7 +65164,7 @@
       "source_location": "L12"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -65170,7 +65173,7 @@
       "source_location": "L7"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -65179,7 +65182,7 @@
       "source_location": "L25"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -65188,7 +65191,7 @@
       "source_location": "L21"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -65197,7 +65200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -65206,7 +65209,7 @@
       "source_location": "L7"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -65215,7 +65218,7 @@
       "source_location": "L14"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -65224,7 +65227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -65233,7 +65236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -65242,7 +65245,7 @@
       "source_location": "L45"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -65251,7 +65254,7 @@
       "source_location": "L37"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -65260,7 +65263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -65269,7 +65272,7 @@
       "source_location": "L10"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -65278,7 +65281,7 @@
       "source_location": "L44"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -65287,7 +65290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -65296,7 +65299,7 @@
       "source_location": "L84"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -65305,7 +65308,7 @@
       "source_location": "L100"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -65314,7 +65317,7 @@
       "source_location": "L5"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -65323,13 +65326,40 @@
       "source_location": "L25"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
       "norm_label": "currencyformatter.ts",
       "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "workflowtrace_createworkflowtraceid",
+      "label": "createWorkflowTraceId()",
+      "norm_label": "createworkflowtraceid()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "label": "normalizeWorkflowTraceLookupValue()",
+      "norm_label": "normalizeworkflowtracelookupvalue()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L25"
     },
     {
       "community": 32,
@@ -65469,33 +65499,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_workflowtrace_ts",
-      "label": "workflowTrace.ts",
-      "norm_label": "workflowtrace.ts",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "workflowtrace_createworkflowtraceid",
-      "label": "createWorkflowTraceId()",
-      "norm_label": "createworkflowtraceid()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
-      "label": "normalizeWorkflowTraceLookupValue()",
-      "norm_label": "normalizeworkflowtracelookupvalue()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
       "norm_label": "view.tsx",
@@ -65503,7 +65506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -65512,7 +65515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -65521,7 +65524,7 @@
       "source_location": "L4"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -65530,7 +65533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -65539,7 +65542,7 @@
       "source_location": "L19"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -65548,7 +65551,7 @@
       "source_location": "L5"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -65557,7 +65560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -65566,7 +65569,7 @@
       "source_location": "L19"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -65575,7 +65578,7 @@
       "source_location": "L11"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -65584,7 +65587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -65593,7 +65596,7 @@
       "source_location": "L22"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -65602,7 +65605,7 @@
       "source_location": "L8"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -65611,7 +65614,7 @@
       "source_location": "L21"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -65620,7 +65623,7 @@
       "source_location": "L13"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -65629,7 +65632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -65638,7 +65641,7 @@
       "source_location": "L100"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -65647,7 +65650,7 @@
       "source_location": "L10"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -65656,7 +65659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -65665,7 +65668,7 @@
       "source_location": "L100"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -65674,7 +65677,7 @@
       "source_location": "L10"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -65683,7 +65686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -65692,7 +65695,7 @@
       "source_location": "L15"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -65701,7 +65704,7 @@
       "source_location": "L39"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -65710,7 +65713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -65719,7 +65722,7 @@
       "source_location": "L3"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -65728,12 +65731,39 @@
       "source_location": "L1"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
       "norm_label": "fadein.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "bestsellers_handleremovebestseller",
+      "label": "handleRemoveBestSeller()",
+      "norm_label": "handleremovebestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "bestsellers_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
+      "label": "BestSellers.tsx",
+      "norm_label": "bestsellers.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1"
     },
     {
@@ -65874,33 +65904,6 @@
     {
       "community": 330,
       "file_type": "code",
-      "id": "bestsellers_handleremovebestseller",
-      "label": "handleRemoveBestSeller()",
-      "norm_label": "handleremovebestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "bestsellers_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "label": "BestSellers.tsx",
-      "norm_label": "bestsellers.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 331,
-      "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
       "norm_label": "handlehighlighteditem()",
@@ -65908,7 +65911,7 @@
       "source_location": "L47"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -65917,7 +65920,7 @@
       "source_location": "L53"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -65926,7 +65929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -65935,7 +65938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -65944,13 +65947,40 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
       "norm_label": "videoplayer()",
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "operationsqueueview_getapprovalrequestcopy",
+      "label": "getApprovalRequestCopy()",
+      "norm_label": "getapprovalrequestcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "operationsqueueview_getdefaultworkflow",
+      "label": "getDefaultWorkflow()",
+      "norm_label": "getdefaultworkflow()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 333,
@@ -73870,7 +73900,7 @@
       "label": "renderStockAdjustmentWorkspace()",
       "norm_label": "renderstockadjustmentworkspace()",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
-      "source_location": "L89"
+      "source_location": "L88"
     },
     {
       "community": 552,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1570
-- Graph nodes: 4232
-- Graph edges: 3874
+- Graph nodes: 4234
+- Graph edges: 3875
 - Communities: 1498
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 9) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 29) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 30) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 9) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -425,6 +425,7 @@ export const listInventorySnapshot = query({
 
         return {
           _id: productSku._id,
+          barcode: productSku.barcode ?? null,
           colorName: color?.name ?? null,
           imageUrl: productSku.images[0] ?? null,
           inventoryCount: productSku.inventoryCount,

--- a/packages/athena-webapp/src/components/View.tsx
+++ b/packages/athena-webapp/src/components/View.tsx
@@ -79,7 +79,7 @@ export default function View({
         {header && (
           <header
             className={cn(
-              "overflow-hidden",
+              "shrink-0 overflow-hidden",
               !hideHeaderBottomBorder && "border-b",
               headerClassName,
             )}

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
@@ -344,7 +344,7 @@ describe("CashControlsDashboardContent", () => {
     expect(
       screen.getByRole("heading", { name: "Cash controls" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Cashroom status")).toBeInTheDocument();
+    expect(screen.getByText("Cashroom Landing")).toBeInTheDocument();
     expect(screen.getByText("Expected in drawers")).toBeInTheDocument();
     expect(screen.getByText("$424")).toBeInTheDocument();
     expect(screen.getByText("1 live drawer, 1 in review")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -1,11 +1,6 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import {
-  ArrowRight,
-  ArrowUpRight,
-  Banknote,
-  ShieldAlert,
-} from "lucide-react";
+import { ArrowRight, ArrowUpRight, Banknote, ShieldAlert } from "lucide-react";
 
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { capitalizeWords, cn, currencyFormatter } from "@/lib/utils";
@@ -571,7 +566,12 @@ function WorkflowSummaryItem({
       <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
         {label}
       </p>
-      <p className={cn("mt-1 font-numeric tabular-nums text-base text-foreground", tone)}>
+      <p
+        className={cn(
+          "mt-1 font-numeric tabular-nums text-base text-foreground",
+          tone,
+        )}
+      >
         {value}
       </p>
     </div>
@@ -960,8 +960,12 @@ function ClosedSessionsSnapshot({
     (total, session) => total + (session.variance ?? 0),
     0,
   );
-  const shortSessions = sessions.filter((session) => (session.variance ?? 0) < 0);
-  const overSessions = sessions.filter((session) => (session.variance ?? 0) > 0);
+  const shortSessions = sessions.filter(
+    (session) => (session.variance ?? 0) < 0,
+  );
+  const overSessions = sessions.filter(
+    (session) => (session.variance ?? 0) > 0,
+  );
   const balancedSessions = sessions.filter(
     (session) => (session.variance ?? 0) === 0,
   );
@@ -1007,10 +1011,7 @@ function ClosedSessionsSnapshot({
       </div>
 
       <dl className="grid gap-layout-sm md:grid-cols-2 2xl:grid-cols-4">
-        <WorkflowSummaryItem
-          label="Closed sessions"
-          value={`${closedCount}`}
-        />
+        <WorkflowSummaryItem label="Closed sessions" value={`${closedCount}`} />
         <WorkflowSummaryItem
           label="Expected cash"
           value={formatCurrency(currency, expectedTotal)}
@@ -1063,7 +1064,9 @@ function ClosedSessionsSnapshot({
 
       <div className="rounded-lg border border-border/70 bg-background/70 px-layout-md py-layout-sm">
         <div className="flex flex-wrap items-center justify-between gap-layout-sm text-sm">
-          <span className="text-muted-foreground">Deposited across closed sessions</span>
+          <span className="text-muted-foreground">
+            Deposited across closed sessions
+          </span>
           <span className="font-numeric tabular-nums text-foreground">
             {formatCurrency(currency, depositedTotal)}
           </span>
@@ -1315,7 +1318,7 @@ export function CashControlsDashboardContent({
                     Current control snapshot
                   </p>
                   <h2 className="font-display text-2xl font-semibold tracking-tight text-foreground">
-                    Cashroom status
+                    Cashroom Landing
                   </h2>
                 </div>
                 <div className="inline-flex items-center gap-2 rounded-md border border-border bg-surface-raised px-layout-sm py-layout-xs text-sm text-muted-foreground">

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -115,12 +115,17 @@ describe("OperationsQueueViewContent", () => {
       isLoading: false,
     });
     mockedHooks.useMutation.mockReturnValue(vi.fn());
-    mockedHooks.useQuery
-      .mockReturnValueOnce({
-        approvalRequests: [],
-        workItems: [],
-      })
-      .mockReturnValueOnce([]);
+    const queueSnapshot = {
+      approvalRequests: [],
+      workItems: [],
+    };
+    const inventorySnapshot: typeof baseProps.inventoryItems = [];
+    let queryCallIndex = 0;
+    mockedHooks.useQuery.mockImplementation(() => {
+      queryCallIndex += 1;
+
+      return queryCallIndex % 2 === 1 ? queueSnapshot : inventorySnapshot;
+    });
   });
 
   it("shows a loading state while permissions are resolving", () => {
@@ -259,7 +264,6 @@ describe("OperationsQueueViewContent", () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
     const submitStockBatch = vi.fn();
-    const deleteStockScopeSkus = vi.fn();
     const decideApprovalRequest = vi
       .fn()
       .mockResolvedValue(ok({ _id: "approval-1" }));
@@ -268,7 +272,6 @@ describe("OperationsQueueViewContent", () => {
     mockedHooks.useQuery.mockReset();
     mockedHooks.useMutation
       .mockReturnValueOnce(submitStockBatch)
-      .mockReturnValueOnce(deleteStockScopeSkus)
       .mockReturnValueOnce(decideApprovalRequest);
     mockedHooks.useQuery
       .mockReturnValueOnce({
@@ -300,7 +303,6 @@ describe("OperationsQueueViewContent", () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
     const submitStockBatch = vi.fn();
-    const deleteStockScopeSkus = vi.fn();
     const decideApprovalRequest = vi
       .fn()
       .mockRejectedValue(new Error("Leaked backend approval detail"));
@@ -312,7 +314,6 @@ describe("OperationsQueueViewContent", () => {
     mockedHooks.useQuery.mockReset();
     mockedHooks.useMutation
       .mockReturnValueOnce(submitStockBatch)
-      .mockReturnValueOnce(deleteStockScopeSkus)
       .mockReturnValueOnce(decideApprovalRequest);
     mockedHooks.useQuery
       .mockReturnValueOnce({

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
-import { ok } from "~/shared/commandResult";
 import { FadeIn } from "../common/FadeIn";
 import { EmptyState } from "../states/empty/empty-state";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
@@ -18,8 +17,6 @@ import {
   StockAdjustmentWorkspaceContent,
 } from "./StockAdjustmentWorkspace";
 import type {
-  DeleteStockAdjustmentScopeSkusArgs,
-  DeleteStockAdjustmentScopeSkusResult,
   InventorySnapshotItem,
   StockAdjustmentSearchPatch,
   StockAdjustmentSearchState,
@@ -174,14 +171,10 @@ type OperationsQueueViewContentProps = {
   approvalRequests: QueueApprovalRequest[];
   hasFullAdminAccess: boolean;
   inventoryItems: InventorySnapshotItem[];
-  isDeletingStockScopeSkus?: boolean;
   isDecidingApprovalRequestId?: Id<"approvalRequest"> | null;
   isLoadingPermissions: boolean;
   isLoadingQueue: boolean;
   isSubmittingStockBatch: boolean;
-  onDeleteStockAdjustmentScopeSkus?: (
-    args: DeleteStockAdjustmentScopeSkusArgs,
-  ) => Promise<NormalizedCommandResult<DeleteStockAdjustmentScopeSkusResult>>;
   onDecideApprovalRequest: (args: {
     approvalRequestId: Id<"approvalRequest">;
     decision: "approved" | "rejected";
@@ -200,12 +193,10 @@ export function OperationsQueueViewContent({
   approvalRequests,
   hasFullAdminAccess,
   inventoryItems,
-  isDeletingStockScopeSkus,
   isDecidingApprovalRequestId,
   isLoadingPermissions,
   isLoadingQueue,
   isSubmittingStockBatch,
-  onDeleteStockAdjustmentScopeSkus,
   onDecideApprovalRequest,
   onSubmitStockBatch,
   onStockAdjustmentSearchChange,
@@ -245,9 +236,7 @@ export function OperationsQueueViewContent({
         {resolvedWorkflow === "stock" ? (
           <StockAdjustmentWorkspaceContent
             inventoryItems={inventoryItems}
-            isDeletingScopeSkus={isDeletingStockScopeSkus}
             isSubmitting={isSubmittingStockBatch}
-            onDeleteSelectedScopeSkus={onDeleteStockAdjustmentScopeSkus}
             onSearchStateChange={onStockAdjustmentSearchChange}
             onSubmitBatch={onSubmitStockBatch}
             searchState={stockAdjustmentSearch}
@@ -413,8 +402,6 @@ export function OperationsQueueView({
     isLoadingAccess,
   } = useProtectedAdminPageState();
   const [isSubmittingStockBatch, setIsSubmittingStockBatch] = useState(false);
-  const [isDeletingStockScopeSkus, setIsDeletingStockScopeSkus] =
-    useState(false);
   const [decisioningApprovalRequestId, setDecisioningApprovalRequestId] =
     useState<Id<"approvalRequest"> | null>(null);
 
@@ -434,9 +421,6 @@ export function OperationsQueueView({
   const submitStockAdjustmentBatch = useMutation(
     stockOpsApi.adjustments.submitStockAdjustmentBatch,
   );
-  const temporaryDeleteStockAdjustmentScopeSkus = useMutation(
-    stockOpsApi.adjustments.temporaryDeleteStockAdjustmentScopeSkus,
-  );
   const decideApprovalRequest = useMutation(
     operationsApi.approvalRequests.decideApprovalRequest,
   );
@@ -448,29 +432,6 @@ export function OperationsQueueView({
       return await runCommand(() => submitStockAdjustmentBatch(args));
     } finally {
       setIsSubmittingStockBatch(false);
-    }
-  };
-
-  const handleDeleteStockAdjustmentScopeSkus = async (
-    args: DeleteStockAdjustmentScopeSkusArgs,
-  ) => {
-    setIsDeletingStockScopeSkus(true);
-
-    try {
-      return await runCommand<DeleteStockAdjustmentScopeSkusResult>(
-        async () => {
-          const result = await temporaryDeleteStockAdjustmentScopeSkus({
-            confirmation: "delete-stock-adjustment-scope-skus",
-            dryRun: false,
-            scopeKey: args.scopeKey,
-            storeId: args.storeId,
-          });
-
-          return ok(result);
-        },
-      );
-    } finally {
-      setIsDeletingStockScopeSkus(false);
     }
   };
 
@@ -541,11 +502,9 @@ export function OperationsQueueView({
       approvalRequests={queue?.approvalRequests ?? []}
       hasFullAdminAccess={hasFullAdminAccess}
       inventoryItems={inventoryItems ?? []}
-      isDeletingStockScopeSkus={isDeletingStockScopeSkus}
       isDecidingApprovalRequestId={decisioningApprovalRequestId}
       isLoadingPermissions={false}
       isLoadingQueue={queue === undefined || inventoryItems === undefined}
-      onDeleteStockAdjustmentScopeSkus={handleDeleteStockAdjustmentScopeSkus}
       onDecideApprovalRequest={handleDecideApprovalRequest}
       isSubmittingStockBatch={isSubmittingStockBatch}
       onSubmitStockBatch={handleSubmitStockBatch}

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -8,7 +8,6 @@ import { ok, userError } from "~/shared/commandResult";
 import { StockAdjustmentWorkspaceContent } from "./StockAdjustmentWorkspace";
 
 const mockedHandlers = vi.hoisted(() => ({
-  onDeleteSelectedScopeSkus: vi.fn(),
   onSubmitBatch: vi.fn(),
 }));
 
@@ -59,6 +58,7 @@ const baseProps = {
   inventoryItems: [
     {
       _id: "sku-1" as Id<"productSku">,
+      barcode: "1234567890123",
       colorName: "natural black",
       imageUrl: "https://cdn.example.com/closure-wig.jpg",
       inventoryCount: 8,
@@ -81,7 +81,6 @@ const baseProps = {
     },
   ],
   isSubmitting: false,
-  onDeleteSelectedScopeSkus: mockedHandlers.onDeleteSelectedScopeSkus,
   onSubmitBatch: mockedHandlers.onSubmitBatch,
   storeId: "store-1" as Id<"store">,
 };
@@ -98,19 +97,10 @@ describe("StockAdjustmentWorkspaceContent", () => {
     vi.restoreAllMocks();
     mockedToast.error.mockReset();
     mockedToast.success.mockReset();
-    mockedHandlers.onDeleteSelectedScopeSkus.mockReset();
     mockedHandlers.onSubmitBatch.mockReset();
   });
 
   beforeEach(() => {
-    mockedHandlers.onDeleteSelectedScopeSkus.mockResolvedValue(
-      ok({
-        deletedCount: 1,
-        dryRun: false,
-        productSkuIds: ["sku-1"],
-        scopeKey: "Hair",
-      }),
-    );
     mockedHandlers.onSubmitBatch.mockResolvedValue(ok({ _id: "batch-1" }));
     window.history.replaceState(
       null,
@@ -288,9 +278,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /9 of 11 units are available to sell\. Choose a scope/i,
-      ),
+      screen.getByText(/9 of 11 units are available to sell\. Choose a scope/i),
     ).toBeInTheDocument();
     expect(screen.getAllByText("On hand").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
@@ -320,9 +308,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     });
 
     expect(
-      screen.getByText(
-        /20\.7k of 20\.7k units are available to sell\./i,
-      ),
+      screen.getByText(/20\.7k of 20\.7k units are available to sell\./i),
     ).toBeInTheDocument();
     expect(screen.getAllByText("20.7k").length).toBeGreaterThan(1);
   });
@@ -334,7 +320,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     const table = screen.getByRole("table");
 
-    expect(within(table).getByText('18" Natural Black Closure Wig')).toBeInTheDocument();
+    expect(
+      within(table).getByText('18" Natural Black Closure Wig'),
+    ).toBeInTheDocument();
     expect(within(table).getByText("Body Wave Bundle")).toBeInTheDocument();
 
     await user.type(
@@ -342,7 +330,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
       "body",
     );
 
-    expect(within(table).queryByText('18" Natural Black Closure Wig')).not.toBeInTheDocument();
+    expect(
+      within(table).queryByText('18" Natural Black Closure Wig'),
+    ).not.toBeInTheDocument();
     expect(within(table).getByText("Body Wave Bundle")).toBeInTheDocument();
 
     await user.clear(
@@ -351,11 +341,141 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(
       screen.getByRole("combobox", { name: /filter by availability/i }),
     );
-    await user.click(await screen.findByRole("option", { name: "Unavailable" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Unavailable" }),
+    );
 
-    expect(within(table).getByText('18" Natural Black Closure Wig')).toBeInTheDocument();
-    expect(within(table).queryByText("Body Wave Bundle")).not.toBeInTheDocument();
+    expect(
+      within(table).getByText('18" Natural Black Closure Wig'),
+    ).toBeInTheDocument();
+    expect(
+      within(table).queryByText("Body Wave Bundle"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Showing 1 of 2 SKUs.")).toBeInTheDocument();
+  });
+
+  it("shows available SKU identifiers in the table and detail rail", () => {
+    renderStockAdjustmentWorkspace();
+
+    const table = screen.getByRole("table");
+    const row = within(table)
+      .getByText('18" Natural Black Closure Wig')
+      .closest("tr");
+
+    expect(row).not.toBeNull();
+    expect(within(row!).getByText("CW-18")).toBeInTheDocument();
+    expect(within(row!).getByText("1234567890123")).toBeInTheDocument();
+    expect(within(row!).getByText("Hair")).toBeInTheDocument();
+    expect(within(row!).getByText('18"')).toBeInTheDocument();
+    expect(within(row!).getByText("natural black")).toBeInTheDocument();
+    expect(screen.getAllByText("SKU").length).toBeGreaterThan(1);
+    expect(screen.getByText("Barcode")).toBeInTheDocument();
+    expect(screen.getByText("Category")).toBeInTheDocument();
+    expect(screen.getByText("Length")).toBeInTheDocument();
+    expect(screen.getByText("Color")).toBeInTheDocument();
+  });
+
+  it("renders the fallback image slot when the active SKU has no image", () => {
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-no-image" as Id<"productSku">,
+          colorName: "black",
+          inventoryCount: 2,
+          length: 12,
+          productCategory: "Hair",
+          productId: "product-no-image" as Id<"product">,
+          productName: "closure",
+          quantityAvailable: 2,
+          sku: "NO-IMG",
+        },
+      ],
+    });
+
+    expect(screen.getByLabelText("SKU image unavailable")).toBeInTheDocument();
+    expect(screen.getAllByText("NO-IMG").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("black").length).toBeGreaterThan(1);
+  });
+
+  it("filters to unavailable SKUs from the inventory state metric", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-unavailable-hair" as Id<"productSku">,
+          inventoryCount: 8,
+          productCategory: "Hair",
+          productName: "closure wig",
+          quantityAvailable: 6,
+          sku: "CW-18",
+        },
+        {
+          _id: "sku-available-hair" as Id<"productSku">,
+          inventoryCount: 3,
+          productCategory: "Hair",
+          productName: "body wave bundle",
+          quantityAvailable: 3,
+          sku: "BW-24",
+        },
+        {
+          _id: "sku-unavailable-books" as Id<"productSku">,
+          inventoryCount: 4,
+          productCategory: "Books",
+          productName: "ai engineering",
+          quantityAvailable: 2,
+          sku: "BOOK-1",
+        },
+        {
+          _id: "sku-available-makeup" as Id<"productSku">,
+          inventoryCount: 5,
+          productCategory: "Makeup",
+          productName: "lip gloss",
+          quantityAvailable: 5,
+          sku: "LIP-1",
+        },
+      ],
+      onSearchStateChange,
+    });
+
+    const table = screen.getByRole("table");
+
+    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
+    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /unavailable 4/i }));
+
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      availability: "unavailable",
+      page: 1,
+      query: undefined,
+      scope: "Books,Hair",
+      sku: undefined,
+    });
+    expect(
+      screen.getByRole("button", { name: /unavailable 4/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
+    expect(within(table).queryByText("Body Wave Bundle")).not.toBeInTheDocument();
+    expect(within(table).queryByText("Lip Gloss")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 3 SKUs.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /unavailable 4/i }));
+
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      availability: undefined,
+      page: 1,
+      query: undefined,
+      scope: undefined,
+      sku: undefined,
+    });
+    expect(
+      screen.getByRole("button", { name: /unavailable 4/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
+    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
   });
 
   it("reports stock filter changes for route search", async () => {
@@ -379,7 +499,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(
       screen.getByRole("combobox", { name: /filter by availability/i }),
     );
-    await user.click(await screen.findByRole("option", { name: "Unavailable" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Unavailable" }),
+    );
 
     expect(onSearchStateChange).toHaveBeenLastCalledWith({
       availability: "unavailable",
@@ -431,63 +553,8 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(row).not.toBeNull();
     expect(within(row!).getByText("None available")).toBeInTheDocument();
     expect(within(row!).queryByText("All available")).not.toBeInTheDocument();
-    expect(within(row!).queryByText("0 None available")).not.toBeInTheDocument();
-  });
-
-  it("exposes temporary selected scope deletion behind confirmation", async () => {
-    const user = userEvent.setup();
-    const onSearchStateChange = vi.fn();
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-
-    renderStockAdjustmentWorkspace({ onSearchStateChange });
-
-    await user.click(
-      screen.getByRole("button", { name: /delete scope skus/i }),
-    );
-
-    expect(confirm).toHaveBeenCalledWith(
-      "Delete 2 SKUs in Hair? This temporary cleanup cannot be undone.",
-    );
-    await waitFor(() =>
-      expect(mockedHandlers.onDeleteSelectedScopeSkus).toHaveBeenCalledWith({
-        scopeKey: "Hair",
-        storeId: "store-1",
-      }),
-    );
-    expect(mockedToast.success).toHaveBeenCalledWith("Deleted 1 SKU from Hair");
-    expect(onSearchStateChange).toHaveBeenCalledWith({
-      page: 1,
-      sku: undefined,
-    });
-  });
-
-  it("does not delete selected scope SKUs when confirmation is canceled", async () => {
-    const user = userEvent.setup();
-    vi.spyOn(window, "confirm").mockReturnValue(false);
-
-    renderStockAdjustmentWorkspace();
-
-    await user.click(
-      screen.getByRole("button", { name: /delete scope skus/i }),
-    );
-
-    expect(mockedHandlers.onDeleteSelectedScopeSkus).not.toHaveBeenCalled();
-    expect(mockedToast.success).not.toHaveBeenCalled();
-  });
-
-  it("keeps temporary scope deletion out of manual adjustments", async () => {
-    const user = userEvent.setup();
-
-    renderStockAdjustmentWorkspace();
-
     expect(
-      screen.getByRole("button", { name: /delete scope skus/i }),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("tab", { name: /manual adjustment/i }));
-
-    expect(
-      screen.queryByRole("button", { name: /delete scope skus/i }),
+      within(row!).queryByText("0 None available"),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -7,7 +7,6 @@ import {
   Package,
   RotateCcw,
   Search,
-  Trash2,
   X,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -43,6 +42,7 @@ import { Textarea } from "../ui/textarea";
 
 export type InventorySnapshotItem = {
   _id: Id<"productSku">;
+  barcode?: string | null;
   colorName?: string | null;
   imageUrl?: string | null;
   inventoryCount: number;
@@ -72,18 +72,6 @@ export type SubmitStockAdjustmentArgs = {
   submissionKey: string;
 };
 
-export type DeleteStockAdjustmentScopeSkusArgs = {
-  scopeKey: string;
-  storeId: Id<"store">;
-};
-
-export type DeleteStockAdjustmentScopeSkusResult = {
-  deletedCount: number;
-  dryRun: boolean;
-  productSkuIds: Array<Id<"productSku">>;
-  scopeKey: string;
-};
-
 export type StockAdjustmentType = "manual" | "cycle_count";
 export type StockAdjustmentAvailabilityFilter =
   | "all"
@@ -104,11 +92,7 @@ export type StockAdjustmentSearchPatch = Partial<StockAdjustmentSearchState>;
 
 type StockAdjustmentWorkspaceContentProps = {
   inventoryItems: InventorySnapshotItem[];
-  isDeletingScopeSkus?: boolean;
   isSubmitting: boolean;
-  onDeleteSelectedScopeSkus?: (
-    args: DeleteStockAdjustmentScopeSkusArgs,
-  ) => Promise<NormalizedCommandResult<DeleteStockAdjustmentScopeSkusResult>>;
   onSearchStateChange?: (patch: StockAdjustmentSearchPatch) => void;
   onSubmitBatch: (
     args: SubmitStockAdjustmentArgs,
@@ -203,8 +187,38 @@ function getInventoryItemDisplayName(item: InventorySnapshotItem) {
   return getProductName(item) || item.sku || String(item._id);
 }
 
+function getSkuDetailEntries(item: InventorySnapshotItem) {
+  return [
+    item.sku ? { label: "SKU", value: item.sku } : null,
+    item.barcode ? { label: "Barcode", value: item.barcode } : null,
+    item.productCategory
+      ? { label: "Category", value: item.productCategory }
+      : null,
+    item.length !== null && item.length !== undefined
+      ? { label: "Length", value: `${item.length}"` }
+      : null,
+    item.colorName ? { label: "Color", value: item.colorName } : null,
+  ].filter(
+    (entry): entry is { label: string; value: string } =>
+      entry !== null && entry.value.trim().length > 0,
+  );
+}
+
 function normalizeStockAdjustmentSearch(value?: string | null) {
   return value?.trim().toLowerCase() ?? "";
+}
+
+function parseCountScopeKeys(value?: string | null) {
+  return (
+    value
+      ?.split(",")
+      .map((scope) => scope.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
+function serializeCountScopeKeys(keys: string[]) {
+  return keys.length > 0 ? keys.join(",") : undefined;
 }
 
 function rowMatchesStockAdjustmentSearch(
@@ -245,9 +259,7 @@ function rowMatchesAvailabilityFilter(
 
 export function StockAdjustmentWorkspaceContent({
   inventoryItems,
-  isDeletingScopeSkus = false,
   isSubmitting,
-  onDeleteSelectedScopeSkus,
   onSearchStateChange,
   onSubmitBatch,
   searchState,
@@ -275,9 +287,9 @@ export function StockAdjustmentWorkspaceContent({
         inventoryItems[0]?._id ??
         null,
     );
-  const [selectedCountScopeKey, setSelectedCountScopeKey] = useState<
-    string | null
-  >(searchState?.scope ?? null);
+  const [selectedCountScopeKeys, setSelectedCountScopeKeys] = useState<
+    string[]
+  >(() => parseCountScopeKeys(searchState?.scope));
   const [filters, setFilters] = useState<StockAdjustmentFilterState>({
     availability: searchState?.availability ?? "all",
     query: searchState?.query ?? "",
@@ -298,7 +310,7 @@ export function StockAdjustmentWorkspaceContent({
   useEffect(() => {
     if (searchState?.scope === undefined) return;
 
-    setSelectedCountScopeKey(searchState.scope || null);
+    setSelectedCountScopeKeys(parseCountScopeKeys(searchState.scope));
   }, [searchState?.scope]);
 
   useEffect(() => {
@@ -418,19 +430,22 @@ export function StockAdjustmentWorkspaceContent({
       a.label.localeCompare(b.label),
     );
   }, [rows]);
-  const selectedCountScope =
-    countScopeOptions.find((scope) => scope.key === selectedCountScopeKey) ??
-    countScopeOptions[0] ??
-    null;
+  const selectedCountScopes = countScopeOptions.filter((scope) =>
+    selectedCountScopeKeys.includes(scope.key),
+  );
+  const selectedCountScope = selectedCountScopes[0] ?? null;
+  const selectedCountScopeKeySet = useMemo(
+    () => new Set(selectedCountScopeKeys),
+    [selectedCountScopeKeys],
+  );
   const scopedRows = useMemo(
     () =>
-      adjustmentType === "cycle_count" && selectedCountScope
-        ? rows.filter(
-            (row) =>
-              getCountScopeKey(row.inventoryItem) === selectedCountScope.key,
+      adjustmentType === "cycle_count" && selectedCountScopeKeys.length > 0
+        ? rows.filter((row) =>
+            selectedCountScopeKeySet.has(getCountScopeKey(row.inventoryItem)),
           )
         : rows,
-    [adjustmentType, rows, selectedCountScope],
+    [adjustmentType, rows, selectedCountScopeKeySet, selectedCountScopeKeys],
   );
   const normalizedFilterQuery = normalizeStockAdjustmentSearch(filters.query);
   const filteredRows = useMemo(
@@ -442,6 +457,24 @@ export function StockAdjustmentWorkspaceContent({
       ),
     [filters.availability, normalizedFilterQuery, scopedRows],
   );
+  const unavailableCountScopeKeys = useMemo(() => {
+    const keys = new Set<string>();
+
+    for (const row of rows) {
+      const item = row.inventoryItem;
+
+      if (item.inventoryCount > item.quantityAvailable) {
+        keys.add(getCountScopeKey(item));
+      }
+    }
+
+    return Array.from(keys).sort();
+  }, [rows]);
+  const isUnavailableScopeSelectionActive =
+    filters.availability === "unavailable" &&
+    unavailableCountScopeKeys.length > 0 &&
+    selectedCountScopeKeys.length === unavailableCountScopeKeys.length &&
+    unavailableCountScopeKeys.every((key) => selectedCountScopeKeySet.has(key));
   const summary = summarizeStockAdjustmentLineItems(
     changedRows.map((row) => ({
       quantityDelta: row.quantityDelta,
@@ -455,6 +488,9 @@ export function StockAdjustmentWorkspaceContent({
     inventoryItems.find((item) => item._id === activeInventoryItemId) ??
     inventoryItems[0] ??
     null;
+  const activeInventoryItemDetails = activeInventoryItem
+    ? getSkuDetailEntries(activeInventoryItem)
+    : [];
   const inventoryState = useMemo(() => {
     const totals = inventoryItems.reduce(
       (current, item) => {
@@ -532,14 +568,25 @@ export function StockAdjustmentWorkspaceContent({
     if (adjustmentType !== "cycle_count") return;
 
     if (
-      selectedCountScopeKey &&
-      countScopeOptions.some((scope) => scope.key === selectedCountScopeKey)
+      selectedCountScopeKeys.length > 0 &&
+      selectedCountScopeKeys.every((selectedKey) =>
+        countScopeOptions.some((scope) => scope.key === selectedKey),
+      )
     ) {
       return;
     }
 
-    setSelectedCountScopeKey(countScopeOptions[0]?.key ?? null);
-  }, [adjustmentType, countScopeOptions, selectedCountScopeKey]);
+    const fallbackScopeKey = countScopeOptions[0]?.key;
+
+    if (!fallbackScopeKey) {
+      if (selectedCountScopeKeys.length === 0) return;
+
+      setSelectedCountScopeKeys([]);
+      return;
+    }
+
+    setSelectedCountScopeKeys([fallbackScopeKey]);
+  }, [adjustmentType, countScopeOptions, selectedCountScopeKeys]);
 
   useEffect(() => {
     if (adjustmentType !== "cycle_count" || !selectedCountScope) return;
@@ -575,20 +622,22 @@ export function StockAdjustmentWorkspaceContent({
           <DataTableColumnHeader column={column} title="SKU" />
         ),
         cell: ({ row }) => {
-          const primaryLabel = getInventoryItemDisplayName(
-            row.original.inventoryItem,
-          );
-          const secondaryLabel =
-            row.original.inventoryItem.sku ?? row.original.inventoryItem._id;
-          const showSecondaryLabel = secondaryLabel !== primaryLabel;
+          const item = row.original.inventoryItem;
+          const primaryLabel = getInventoryItemDisplayName(item);
+          const detailEntries = getSkuDetailEntries(item);
 
           return (
-            <div className="min-w-0">
+            <div className="min-w-0 space-y-1.5">
               <p className="truncate text-sm font-medium">{primaryLabel}</p>
-              {showSecondaryLabel ? (
-                <p className="truncate text-xs text-muted-foreground">
-                  {secondaryLabel}
-                </p>
+              {detailEntries.length > 0 ? (
+                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  {detailEntries.map((entry) => (
+                    <span className="min-w-0" key={entry.label}>
+                      <span className="sr-only">{entry.label}: </span>
+                      {entry.value}
+                    </span>
+                  ))}
+                </div>
               ) : null}
             </div>
           );
@@ -761,14 +810,21 @@ export function StockAdjustmentWorkspaceContent({
       setCycleCountSubmissionOutcome(null);
     }
 
+    const currentScopeKeys =
+      selectedCountScopeKeys.length > 0
+        ? selectedCountScopeKeys
+        : countScopeOptions[0]?.key
+          ? [countScopeOptions[0].key]
+          : [];
     const nextScope =
       nextType === "cycle_count"
-        ? (selectedCountScope?.key ?? countScopeOptions[0]?.key)
+        ? serializeCountScopeKeys(currentScopeKeys)
         : undefined;
     const nextActiveItem =
-      nextType === "cycle_count" && nextScope
-        ? rows.find((row) => getCountScopeKey(row.inventoryItem) === nextScope)
-            ?.inventoryItem
+      nextType === "cycle_count" && currentScopeKeys.length > 0
+        ? rows.find((row) =>
+            currentScopeKeys.includes(getCountScopeKey(row.inventoryItem)),
+          )?.inventoryItem
         : rows[0]?.inventoryItem;
 
     if (nextActiveItem) {
@@ -809,6 +865,39 @@ export function StockAdjustmentWorkspaceContent({
       availability: undefined,
       page: 1,
       query: undefined,
+      sku: undefined,
+    });
+  };
+
+  const handleUnavailableMetricClick = () => {
+    if (inventoryState.unavailableUnits === 0) return;
+
+    if (isUnavailableScopeSelectionActive) {
+      setSelectedCountScopeKeys(
+        countScopeOptions[0]?.key ? [countScopeOptions[0].key] : [],
+      );
+      setFilters((current) => ({
+        ...current,
+        availability: "all",
+      }));
+      onSearchStateChange?.({
+        availability: undefined,
+        page: 1,
+        scope: undefined,
+        sku: undefined,
+      });
+      return;
+    }
+
+    setSelectedCountScopeKeys(unavailableCountScopeKeys);
+    setFilters((current) => ({
+      ...current,
+      availability: "unavailable",
+    }));
+    onSearchStateChange?.({
+      availability: "unavailable",
+      page: 1,
+      scope: serializeCountScopeKeys(unavailableCountScopeKeys),
       sku: undefined,
     });
   };
@@ -863,35 +952,6 @@ export function StockAdjustmentWorkspaceContent({
     setSubmissionKey(buildStockAdjustmentSubmissionKey(adjustmentType));
   };
 
-  const handleDeleteSelectedScopeSkus = async () => {
-    if (!storeId || !selectedCountScope || !onDeleteSelectedScopeSkus) {
-      return;
-    }
-
-    const skuLabel = selectedCountScope.itemCount === 1 ? "SKU" : "SKUs";
-    const confirmed = window.confirm(
-      `Delete ${selectedCountScope.itemCount} ${skuLabel} in ${selectedCountScope.label}? This temporary cleanup cannot be undone.`,
-    );
-
-    if (!confirmed) return;
-
-    const result = await onDeleteSelectedScopeSkus({
-      scopeKey: selectedCountScope.key,
-      storeId,
-    });
-
-    if (result.kind !== "ok") {
-      presentCommandToast(result);
-      return;
-    }
-
-    const deletedSkuLabel = result.data.deletedCount === 1 ? "SKU" : "SKUs";
-    toast.success(
-      `Deleted ${result.data.deletedCount} ${deletedSkuLabel} from ${selectedCountScope.label}`,
-    );
-    onSearchStateChange?.({ page: 1, sku: undefined });
-  };
-
   return (
     <div className="grid gap-layout-xl xl:grid-cols-[minmax(0,1fr)_320px]">
       <section className="min-w-0 space-y-layout-2xl">
@@ -911,32 +971,48 @@ export function StockAdjustmentWorkspaceContent({
                   : "Record known deltas when the physical stock needs an adjustment."}
               </p>
             </div>
-            <dl className="grid max-w-xl grid-cols-3 gap-2">
+            <div className="grid max-w-xl grid-cols-3 gap-2">
               <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                <dt className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                   On hand
-                </dt>
-                <dd className="mt-1 text-sm font-medium tabular-nums text-foreground">
+                </p>
+                <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
                   {formatInventoryNumber(inventoryState.onHandUnits)}
-                </dd>
+                </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                <dt className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                   Available
-                </dt>
-                <dd className="mt-1 text-sm font-medium tabular-nums text-foreground">
+                </p>
+                <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
                   {formatInventoryNumber(inventoryState.availableUnits)}
-                </dd>
+                </p>
               </div>
-              <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                <dt className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  Unavailable
-                </dt>
-                <dd className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                  {formatInventoryNumber(inventoryState.unavailableUnits)}
-                </dd>
+              <div
+                className={`overflow-hidden rounded-md border ${
+                  inventoryState.unavailableUnits === 0
+                    ? "border-border bg-muted/30"
+                    : isUnavailableScopeSelectionActive
+                      ? "border-action-workflow-border bg-action-workflow-soft"
+                      : "border-border bg-muted/30 hover:bg-muted"
+                }`}
+              >
+                <button
+                  aria-pressed={isUnavailableScopeSelectionActive}
+                  className="block w-full px-3 py-2 text-left disabled:cursor-default"
+                  disabled={inventoryState.unavailableUnits === 0}
+                  onClick={handleUnavailableMetricClick}
+                  type="button"
+                >
+                  <span className="block text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                    Unavailable
+                  </span>
+                  <span className="mt-1 block text-sm font-medium tabular-nums text-foreground">
+                    {formatInventoryNumber(inventoryState.unavailableUnits)}
+                  </span>
+                </button>
               </div>
-            </dl>
+            </div>
           </div>
 
           <Tabs
@@ -959,7 +1035,7 @@ export function StockAdjustmentWorkspaceContent({
           >
             <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {countScopeOptions.map((scope) => {
-                const isSelected = scope.key === selectedCountScope?.key;
+                const isSelected = selectedCountScopeKeySet.has(scope.key);
 
                 return (
                   <button
@@ -971,7 +1047,7 @@ export function StockAdjustmentWorkspaceContent({
                     }`}
                     key={scope.key}
                     onClick={() => {
-                      setSelectedCountScopeKey(scope.key);
+                      setSelectedCountScopeKeys([scope.key]);
                       setCycleCountSubmissionOutcome(null);
                       const firstScopedItem = rows.find(
                         (row) =>
@@ -1039,7 +1115,10 @@ export function StockAdjustmentWorkspaceContent({
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <Label className="sr-only" htmlFor="stock-adjustment-availability-filter">
+              <Label
+                className="sr-only"
+                htmlFor="stock-adjustment-availability-filter"
+              >
                 Filter by availability
               </Label>
               <Select
@@ -1111,7 +1190,7 @@ export function StockAdjustmentWorkspaceContent({
             }
             paginationRangeItemLabel="SKU"
             paginationRangeItemPluralLabel="SKUs"
-            tableId={`stock-adjustments-${adjustmentType}-${selectedCountScope?.key ?? "all"}-${filters.availability}-${normalizedFilterQuery || "all"}`}
+            tableId={`stock-adjustments-${adjustmentType}-${selectedCountScopeKeys.join("_") || "all"}-${filters.availability}-${normalizedFilterQuery || "all"}`}
           />
         </div>
       </section>
@@ -1185,47 +1264,15 @@ export function StockAdjustmentWorkspaceContent({
                   ? "Submitting this count will apply inventory movements immediately"
                   : "This batch can apply immediately and will still write inventory movements"}
             </div>
-            {adjustmentType === "cycle_count" &&
-            selectedCountScope &&
-            onDeleteSelectedScopeSkus ? (
-              <div className="space-y-layout-sm rounded-md border border-destructive/30 bg-destructive/5 px-layout-md py-layout-sm">
-                <div className="space-y-1">
-                  <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-destructive">
-                    Temporary cleanup
-                  </p>
-                  <p className="text-sm font-medium text-foreground">
-                    Delete selected scope SKUs
-                  </p>
-                  <p className="text-sm leading-6 text-muted-foreground">
-                    Deletes {selectedCountScope.itemCount}{" "}
-                    {selectedCountScope.itemCount === 1 ? "SKU" : "SKUs"} in{" "}
-                    {selectedCountScope.label} from the catalog.
-                  </p>
-                </div>
-                <LoadingButton
-                  className="w-full"
-                  disabled={
-                    isDeletingScopeSkus || selectedCountScope.itemCount === 0
-                  }
-                  isLoading={isDeletingScopeSkus}
-                  onClick={handleDeleteSelectedScopeSkus}
-                  size="sm"
-                  variant="destructive"
-                >
-                  <Trash2 className="h-4 w-4" />
-                  Delete scope SKUs
-                </LoadingButton>
-              </div>
-            ) : null}
           </div>
         </section>
 
-        <section className="space-y-layout-md rounded-lg border border-border bg-surface-raised px-layout-md py-layout-md shadow-surface">
+        <section className="space-y-layout-xl rounded-lg border border-border bg-surface-raised px-layout-md py-layout-md shadow-surface">
           <div className="space-y-layout-sm">
             <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
               SKU detail
             </p>
-            <div className="overflow-hidden rounded-md border border-none bg-muted/30">
+            <div className="overflow-hidden rounded-md bg-muted/30">
               {activeInventoryItem?.imageUrl ? (
                 <img
                   alt={getInventoryItemDisplayName(activeInventoryItem)}
@@ -1234,17 +1281,20 @@ export function StockAdjustmentWorkspaceContent({
                 />
               ) : (
                 <div className="flex aspect-square w-full items-center justify-center bg-muted">
-                  <Package className="h-8 w-8 text-muted-foreground" />
+                  <Package
+                    aria-label="SKU image unavailable"
+                    className="h-8 w-8 text-muted-foreground"
+                  />
                 </div>
               )}
             </div>
-            <div className="space-y-1">
+            <div className="space-y-4">
               <div className="flex items-start justify-between gap-3">
-                <p className="line-clamp-2 text-sm font-medium text-foreground">
-                  {activeInventoryItem
-                    ? getInventoryItemDisplayName(activeInventoryItem)
-                    : "No SKU selected"}
-                </p>
+                {activeInventoryItem ? (
+                  <p className="line-clamp-2 text-sm font-medium text-foreground">
+                    {getInventoryItemDisplayName(activeInventoryItem)}
+                  </p>
+                ) : null}
                 {activeInventoryItem?.productId ? (
                   <Link
                     aria-label={`View product detail for ${getInventoryItemDisplayName(
@@ -1268,10 +1318,19 @@ export function StockAdjustmentWorkspaceContent({
                   </Link>
                 ) : null}
               </div>
-              {activeInventoryItem?.sku ? (
-                <p className="text-xs text-muted-foreground">
-                  {activeInventoryItem.sku}
-                </p>
+              {activeInventoryItemDetails.length > 0 ? (
+                <dl className="grid grid-cols-2 gap-x-layout-md gap-y-layout-md pt-layout-xs text-xs">
+                  {activeInventoryItemDetails.map((entry) => (
+                    <div className="min-w-0" key={entry.label}>
+                      <dt className="font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                        {entry.label}
+                      </dt>
+                      <dd className="mt-0.5 truncate text-foreground capitalize">
+                        {entry.value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
               ) : null}
             </div>
           </div>
@@ -1311,7 +1370,7 @@ export function StockAdjustmentWorkspaceContent({
             <Textarea
               id="stock-adjustment-notes"
               onChange={(event) => setNotes(event.target.value)}
-              placeholder="Add operator notes, count context, or exception details."
+              placeholder="Add notes, count context, or exception details."
               value={notes}
             />
           </div>


### PR DESCRIPTION
## Summary
- Refines the stock adjustment workspace with richer SKU identifiers, multi-scope cycle-count filtering, and unavailable-inventory shortcuts.
- Removes the temporary stock-scope delete path from the operations queue integration.
- Stabilizes the empty-inventory cycle-count state and updates focused tests for the current operations mutation contract.
- Refreshes graphify artifacts for the changed code graph.

## Validation
- bun run --cwd packages/athena-webapp test src/components/operations/StockAdjustmentWorkspace.test.tsx
- bun run --cwd packages/athena-webapp test src/components/cash-controls/CashControlsDashboard.test.tsx
- bun run --cwd packages/athena-webapp test src/components/operations/OperationsQueueView.test.tsx
- bun run --cwd packages/athena-webapp typecheck
- bun run graphify:rebuild
- git push pre-push suite: graphify:check, harness:self-review, architecture:check, harness:review, changed Convex lint, TypeScript, build, full @athena/webapp:test, selected harness behavior scenarios, harness:inferential-review
