### PR TITLE
Improve stock count draft workflow

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4257 nodes · 3921 edges · 1501 communities detected
+- 4263 nodes · 3939 edges · 1501 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1575,64 +1575,64 @@ Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
 ### Community 9 - "Community 9"
+Cohesion: 0.25
+Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.16
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.18
 Nodes (15): createDefaultExpenseSessionCommandService(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindExpenseSessionToRegisterSessionCommand() (+7 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.11
 Nodes (2): isSkuReserved(), shouldDisable()
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.18
 Nodes (15): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+7 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.12
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.17
 Nodes (15): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), containsDisallowedRawNumericParse(), containsTerm(), isAllowedDisplayConversion() (+7 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.25
 Nodes (16): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+8 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.3
-Nodes (16): buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftWithCtx(), getCycleCountDraftLineWithCtx() (+8 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.12
@@ -1971,88 +1971,88 @@ Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
 ### Community 108 - "Community 108"
+Cohesion: 0.38
+Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
+
+### Community 109 - "Community 109"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 112 - "Community 112"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 113 - "Community 113"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 114 - "Community 114"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 115 - "Community 115"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 115 - "Community 115"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 116 - "Community 116"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 117 - "Community 117"
 Cohesion: 0.48
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 122 - "Community 122"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 123 - "Community 123"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 125 - "Community 125"
-Cohesion: 0.6
-Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
-
-### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 126 - "Community 126"
+Cohesion: 0.6
+Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
+
 ### Community 127 - "Community 127"
-Cohesion: 0.53
-Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 128 - "Community 128"
-Cohesion: 0.4
-Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
+Cohesion: 0.53
+Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
 ### Community 129 - "Community 129"
 Cohesion: 0.33
@@ -2063,12 +2063,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 131 - "Community 131"
-Cohesion: 0.4
-Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 132 - "Community 132"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 132 - "Community 132"
+Cohesion: 0.4
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 133 - "Community 133"
 Cohesion: 0.33
@@ -9679,9 +9679,9 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 6` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
-- **Should `Community 13` be split into smaller, more focused modules?**
+- **Should `Community 14` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 16` be split into smaller, more focused modules?**
-  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 17` be split into smaller, more focused modules?**
+  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
+- **Should `Community 18` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11,7 +11,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentsourceid",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L215",
+      "source_location": "L217",
       "target": "adjustments_applystockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -23,7 +23,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L306",
+      "source_location": "L308",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -35,7 +35,7 @@
       "relation": "calls",
       "source": "adjustments_buildresolvedstockadjustmentstatus",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L319",
+      "source_location": "L321",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -47,7 +47,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentdecisioneventtype",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L336",
+      "source_location": "L338",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -59,7 +59,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L349",
+      "source_location": "L351",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -71,7 +71,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L346",
+      "source_location": "L348",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -83,7 +83,7 @@
       "relation": "calls",
       "source": "adjustments_mapsubmitstockadjustmentbatcherror",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L786",
+      "source_location": "L795",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -95,7 +95,7 @@
       "relation": "calls",
       "source": "adjustments_submitstockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L784",
+      "source_location": "L793",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -107,7 +107,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L686",
+      "source_location": "L694",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -119,7 +119,7 @@
       "relation": "calls",
       "source": "adjustments_assertdistinctstockadjustmentlineitems",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L552",
+      "source_location": "L554",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -131,7 +131,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L642",
+      "source_location": "L650",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -143,7 +143,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L540",
+      "source_location": "L542",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -155,7 +155,7 @@
       "relation": "calls",
       "source": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L485",
+      "source_location": "L487",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -2279,7 +2279,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L164",
+      "source_location": "L209",
       "target": "cyclecountdrafts_createcyclecountdraftwithctx",
       "weight": 1
     },
@@ -2291,7 +2291,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L423",
+      "source_location": "L526",
       "target": "cyclecountdrafts_mapcyclecountdrafterror",
       "weight": 1
     },
@@ -2303,7 +2303,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_requirecyclecountdraftaccess",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L391",
+      "source_location": "L494",
       "target": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -2315,7 +2315,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_ensurecyclecountdraftwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L252",
+      "source_location": "L355",
       "target": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -2327,7 +2327,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_listcyclecountdraftlineswithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L260",
+      "source_location": "L363",
       "target": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -2339,7 +2339,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L263",
+      "source_location": "L366",
       "target": "cyclecountdrafts_mapcyclecountdrafterror",
       "weight": 1
     },
@@ -2351,7 +2351,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_createcyclecountdraftwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L210",
+      "source_location": "L255",
       "target": "cyclecountdrafts_ensurecyclecountdraftwithctx",
       "weight": 1
     },
@@ -2363,7 +2363,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_findopencyclecountdraftwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L202",
+      "source_location": "L247",
       "target": "cyclecountdrafts_ensurecyclecountdraftwithctx",
       "weight": 1
     },
@@ -2375,7 +2375,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_requirecyclecountdraftaccess",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L198",
+      "source_location": "L243",
       "target": "cyclecountdrafts_ensurecyclecountdraftwithctx",
       "weight": 1
     },
@@ -2387,8 +2387,32 @@
       "relation": "calls",
       "source": "cyclecountdrafts_trimrequiredscopekey",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L197",
+      "source_location": "L242",
       "target": "cyclecountdrafts_ensurecyclecountdraftwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "_tgt": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L296",
+      "target": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "_tgt": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L295",
+      "target": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
       "weight": 1
     },
     {
@@ -2399,7 +2423,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_findopencyclecountdraftwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L228",
+      "source_location": "L273",
       "target": "cyclecountdrafts_getactivecyclecountdraftwithctx",
       "weight": 1
     },
@@ -2411,7 +2435,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_listcyclecountdraftlineswithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L240",
+      "source_location": "L285",
       "target": "cyclecountdrafts_getactivecyclecountdraftwithctx",
       "weight": 1
     },
@@ -2423,7 +2447,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_requirecyclecountdraftaccess",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L227",
+      "source_location": "L272",
       "target": "cyclecountdrafts_getactivecyclecountdraftwithctx",
       "weight": 1
     },
@@ -2435,8 +2459,56 @@
       "relation": "calls",
       "source": "cyclecountdrafts_trimrequiredscopekey",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L226",
+      "source_location": "L271",
       "target": "cyclecountdrafts_getactivecyclecountdraftwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "_tgt": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L548",
+      "target": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "_tgt": "cyclecountdrafts_mapcyclecountdrafterror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L608",
+      "target": "cyclecountdrafts_mapcyclecountdrafterror",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "_tgt": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L579",
+      "target": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "_tgt": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L538",
+      "target": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
       "weight": 1
     },
     {
@@ -2447,7 +2519,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_listcyclecountdraftlineswithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L130",
+      "source_location": "L175",
       "target": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
       "weight": 1
     },
@@ -2459,7 +2531,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_getcyclecountdraftlinewithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L302",
+      "source_location": "L405",
       "target": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
       "weight": 1
     },
@@ -2471,7 +2543,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_listcyclecountdraftlineswithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L371",
+      "source_location": "L474",
       "target": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
       "weight": 1
     },
@@ -2483,7 +2555,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L374",
+      "source_location": "L477",
       "target": "cyclecountdrafts_mapcyclecountdrafterror",
       "weight": 1
     },
@@ -2495,7 +2567,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L344",
+      "source_location": "L447",
       "target": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
       "weight": 1
     },
@@ -2507,8 +2579,68 @@
       "relation": "calls",
       "source": "cyclecountdrafts_requirecyclecountdraftaccess",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L286",
+      "source_location": "L389",
       "target": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "_tgt": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L853",
+      "target": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "_tgt": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L788",
+      "target": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "_tgt": "cyclecountdrafts_liststalecyclecountdraftlines",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_liststalecyclecountdraftlines",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L807",
+      "target": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "_tgt": "cyclecountdrafts_mapcyclecountdrafterror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L900",
+      "target": "cyclecountdrafts_mapcyclecountdrafterror",
+      "weight": 1
+    },
+    {
+      "_src": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "_tgt": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L784",
+      "target": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
       "weight": 1
     },
     {
@@ -2519,7 +2651,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_listcyclecountdraftlineswithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L498",
+      "source_location": "L683",
       "target": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -2531,7 +2663,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_liststalecyclecountdraftlines",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L506",
+      "source_location": "L691",
       "target": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -2543,7 +2675,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L587",
+      "source_location": "L772",
       "target": "cyclecountdrafts_mapcyclecountdrafterror",
       "weight": 1
     },
@@ -2555,7 +2687,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L533",
+      "source_location": "L718",
       "target": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -2567,7 +2699,7 @@
       "relation": "calls",
       "source": "cyclecountdrafts_requirecyclecountdraftaccess",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L474",
+      "source_location": "L659",
       "target": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -8087,7 +8219,7 @@
       "relation": "calls",
       "source": "operationsqueueview_getapprovalrequestcopy",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L614",
+      "source_location": "L657",
       "target": "operationsqueueview_setdecisioningapprovalrequestid",
       "weight": 1
     },
@@ -15935,7 +16067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L31",
+      "source_location": "L32",
       "target": "adjustments_test_createapprovaldecisionmutationctx",
       "weight": 1
     },
@@ -15947,7 +16079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L176",
+      "source_location": "L177",
       "target": "adjustments_test_createsubmissionmutationctx",
       "weight": 1
     },
@@ -15959,7 +16091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L27",
+      "source_location": "L28",
       "target": "adjustments_test_getsource",
       "weight": 1
     },
@@ -15971,7 +16103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L202",
+      "source_location": "L204",
       "target": "adjustments_applystockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -15983,7 +16115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L126",
+      "source_location": "L128",
       "target": "adjustments_assertdistinctstockadjustmentlineitems",
       "weight": 1
     },
@@ -15995,7 +16127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L156",
+      "source_location": "L158",
       "target": "adjustments_assertnormalizedlineitem",
       "weight": 1
     },
@@ -16007,7 +16139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L260",
+      "source_location": "L262",
       "target": "adjustments_buildresolvedstockadjustmentstatus",
       "weight": 1
     },
@@ -16019,7 +16151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L250",
+      "source_location": "L252",
       "target": "adjustments_buildstockadjustmentdecisioneventtype",
       "weight": 1
     },
@@ -16031,7 +16163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L142",
+      "source_location": "L144",
       "target": "adjustments_buildstockadjustmentsourceid",
       "weight": 1
     },
@@ -16043,7 +16175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L146",
+      "source_location": "L148",
       "target": "adjustments_buildstockadjustmenttitle",
       "weight": 1
     },
@@ -16055,7 +16187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L69",
+      "source_location": "L71",
       "target": "adjustments_getstockadjustmentscopekey",
       "weight": 1
     },
@@ -16067,7 +16199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L73",
+      "source_location": "L75",
       "target": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "weight": 1
     },
@@ -16079,7 +16211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L726",
+      "source_location": "L735",
       "target": "adjustments_mapsubmitstockadjustmentbatcherror",
       "weight": 1
     },
@@ -16091,7 +16223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L266",
+      "source_location": "L268",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -16103,7 +16235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L779",
+      "source_location": "L788",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -16115,7 +16247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L536",
+      "source_location": "L538",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -16127,7 +16259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L455",
+      "source_location": "L457",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -16139,7 +16271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L64",
+      "source_location": "L66",
       "target": "adjustments_trimoptional",
       "weight": 1
     },
@@ -16151,8 +16283,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts",
-      "source_location": "L19",
+      "source_location": "L22",
       "target": "cyclecountdrafts_test_createcyclecountdraftctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "_tgt": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L90",
+      "target": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
       "weight": 1
     },
     {
@@ -16163,7 +16307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L64",
+      "source_location": "L75",
       "target": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
       "weight": 1
     },
@@ -16175,7 +16319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L145",
+      "source_location": "L190",
       "target": "cyclecountdrafts_createcyclecountdraftwithctx",
       "weight": 1
     },
@@ -16187,7 +16331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L378",
+      "source_location": "L481",
       "target": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -16199,7 +16343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L244",
+      "source_location": "L347",
       "target": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -16211,7 +16355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L190",
+      "source_location": "L235",
       "target": "cyclecountdrafts_ensurecyclecountdraftwithctx",
       "weight": 1
     },
@@ -16223,8 +16367,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L79",
+      "source_location": "L103",
       "target": "cyclecountdrafts_findopencyclecountdraftwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "_tgt": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L289",
+      "target": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
       "weight": 1
     },
     {
@@ -16235,7 +16391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L219",
+      "source_location": "L264",
       "target": "cyclecountdrafts_getactivecyclecountdraftwithctx",
       "weight": 1
     },
@@ -16247,7 +16403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L110",
+      "source_location": "L155",
       "target": "cyclecountdrafts_getcyclecountdraftlinewithctx",
       "weight": 1
     },
@@ -16259,8 +16415,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L99",
+      "source_location": "L144",
       "target": "cyclecountdrafts_listcyclecountdraftlineswithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "_tgt": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L123",
+      "target": "cyclecountdrafts_listopencyclecountdraftswithctx",
       "weight": 1
     },
     {
@@ -16271,7 +16439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L427",
+      "source_location": "L612",
       "target": "cyclecountdrafts_liststalecyclecountdraftlines",
       "weight": 1
     },
@@ -16283,8 +16451,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L591",
+      "source_location": "L904",
       "target": "cyclecountdrafts_mapcyclecountdrafterror",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "_tgt": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L530",
+      "target": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
       "weight": 1
     },
     {
@@ -16295,7 +16475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L125",
+      "source_location": "L170",
       "target": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
       "weight": 1
     },
@@ -16307,7 +16487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L32",
+      "source_location": "L43",
       "target": "cyclecountdrafts_requirecyclecountdraftaccess",
       "weight": 1
     },
@@ -16319,8 +16499,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L267",
+      "source_location": "L370",
       "target": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "_tgt": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L776",
+      "target": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
       "weight": 1
     },
     {
@@ -16331,7 +16523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L460",
+      "source_location": "L645",
       "target": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
       "weight": 1
     },
@@ -16343,7 +16535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L54",
+      "source_location": "L65",
       "target": "cyclecountdrafts_trimrequiredscopekey",
       "weight": 1
     },
@@ -18665,13 +18857,25 @@
     },
     {
       "_src": "packages_athena_webapp_shared_stockadjustment_ts",
-      "_tgt": "stockadjustment_requiresstockadjustmentapproval",
+      "_tgt": "stockadjustment_hashighstockadjustmentvariance",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_shared_stockadjustment_ts",
       "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L96",
+      "target": "stockadjustment_hashighstockadjustmentvariance",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_stockadjustment_ts",
+      "_tgt": "stockadjustment_requiresstockadjustmentapproval",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_stockadjustment_ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102",
       "target": "stockadjustment_requiresstockadjustmentapproval",
       "weight": 1
     },
@@ -21551,7 +21755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L62",
+      "source_location": "L63",
       "target": "operationsqueueview_getapprovalrequestcopy",
       "weight": 1
     },
@@ -21563,7 +21767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L53",
+      "source_location": "L54",
       "target": "operationsqueueview_getdefaultworkflow",
       "weight": 1
     },
@@ -21575,7 +21779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L557",
+      "source_location": "L616",
       "target": "operationsqueueview_if",
       "weight": 1
     },
@@ -21587,7 +21791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L595",
+      "source_location": "L638",
       "target": "operationsqueueview_setdecisioningapprovalrequestid",
       "weight": 1
     },
@@ -21611,7 +21815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L196",
+      "source_location": "L212",
       "target": "stockadjustmentworkspace_buildcyclecountdrafts",
       "weight": 1
     },
@@ -21623,7 +21827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L192",
+      "source_location": "L208",
       "target": "stockadjustmentworkspace_buildmanualdrafts",
       "weight": 1
     },
@@ -21635,7 +21839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L212",
+      "source_location": "L228",
       "target": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
       "weight": 1
     },
@@ -21647,7 +21851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L227",
+      "source_location": "L243",
       "target": "stockadjustmentworkspace_formatinventorynumber",
       "weight": 1
     },
@@ -21659,7 +21863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L184",
+      "source_location": "L200",
       "target": "stockadjustmentworkspace_getcountscopekey",
       "weight": 1
     },
@@ -21671,7 +21875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L188",
+      "source_location": "L204",
       "target": "stockadjustmentworkspace_getcountscopelabel",
       "weight": 1
     },
@@ -21683,7 +21887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L231",
+      "source_location": "L247",
       "target": "stockadjustmentworkspace_getinventoryitemdisplayname",
       "weight": 1
     },
@@ -21695,7 +21899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L235",
+      "source_location": "L251",
       "target": "stockadjustmentworkspace_getskudetailentries",
       "weight": 1
     },
@@ -21707,7 +21911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L874",
+      "source_location": "L929",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -21719,7 +21923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L252",
+      "source_location": "L268",
       "target": "stockadjustmentworkspace_normalizestockadjustmentsearch",
       "weight": 1
     },
@@ -21731,7 +21935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L256",
+      "source_location": "L272",
       "target": "stockadjustmentworkspace_parsecountscopekeys",
       "weight": 1
     },
@@ -21743,7 +21947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L223",
+      "source_location": "L239",
       "target": "stockadjustmentworkspace_pluralize",
       "weight": 1
     },
@@ -21755,7 +21959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L292",
+      "source_location": "L308",
       "target": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
       "weight": 1
     },
@@ -21767,7 +21971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L269",
+      "source_location": "L285",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -21779,7 +21983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L882",
+      "source_location": "L937",
       "target": "stockadjustmentworkspace_savecyclecountdraftvalue",
       "weight": 1
     },
@@ -21791,7 +21995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L265",
+      "source_location": "L281",
       "target": "stockadjustmentworkspace_serializecountscopekeys",
       "weight": 1
     },
@@ -21803,7 +22007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L864",
+      "source_location": "L919",
       "target": "stockadjustmentworkspace_setdraftvalue",
       "weight": 1
     },
@@ -21815,7 +22019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L218",
+      "source_location": "L234",
       "target": "stockadjustmentworkspace_trimoptional",
       "weight": 1
     },
@@ -44992,6 +45196,18 @@
       "weight": 1
     },
     {
+      "_src": "stockadjustment_requiresstockadjustmentapproval",
+      "_tgt": "stockadjustment_hashighstockadjustmentvariance",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "stockadjustment_hashighstockadjustmentvariance",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L107",
+      "target": "stockadjustment_requiresstockadjustmentapproval",
+      "weight": 1
+    },
+    {
       "_src": "stockadjustment_resolvestockadjustmentquantitydelta",
       "_tgt": "stockadjustment_calculatecyclecountquantitydelta",
       "confidence": "EXTRACTED",
@@ -45011,7 +45227,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_setdraftvalue",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L875",
+      "source_location": "L930",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -45023,7 +45239,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_getinventoryitemdisplayname",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L277",
+      "source_location": "L293",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -47898,200 +48114,200 @@
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_buildgitprocessenv",
-      "label": "buildGitProcessEnv()",
-      "norm_label": "buildgitprocessenv()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L419"
+      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_collectcommandsforchangedfiles",
-      "label": "collectCommandsForChangedFiles()",
-      "norm_label": "collectcommandsforchangedfiles()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L302"
+      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L93"
+      "id": "storeconfig_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L117"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_formatmissingpathprefixerror",
-      "label": "formatMissingPathPrefixError()",
-      "norm_label": "formatmissingpathprefixerror()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L83"
+      "id": "storeconfig_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L80"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_getchangedfilesforharnessreview",
-      "label": "getChangedFilesForHarnessReview()",
-      "norm_label": "getchangedfilesforharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L425"
+      "id": "storeconfig_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L114"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtarget",
-      "label": "loadReviewTarget()",
-      "norm_label": "loadreviewtarget()",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_loadreviewtargets",
-      "label": "loadReviewTargets()",
-      "norm_label": "loadreviewtargets()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L269"
+      "id": "storeconfig_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L103"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L57"
+      "id": "storeconfig_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L111"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L79"
+      "id": "storeconfig_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L143"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L53"
+      "id": "storeconfig_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L120"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L71"
+      "id": "storeconfig_getrawconfig",
+      "label": "getRawConfig()",
+      "norm_label": "getrawconfig()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L196"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_parseharnessreviewargs",
-      "label": "parseHarnessReviewArgs()",
-      "norm_label": "parseharnessreviewargs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L666"
+      "id": "storeconfig_getstoreconfigv2",
+      "label": "getStoreConfigV2()",
+      "norm_label": "getstoreconfigv2()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L208"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L122"
+      "id": "storeconfig_getstorefallbackimageurl",
+      "label": "getStoreFallbackImageUrl()",
+      "norm_label": "getstorefallbackimageurl()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L479"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_resolveharnessreviewshell",
-      "label": "resolveHarnessReviewShell()",
-      "norm_label": "resolveharnessreviewshell()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L533"
+      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L93"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_rungitcommand",
-      "label": "runGitCommand()",
-      "norm_label": "rungitcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L398"
+      "id": "storeconfig_isstoremaintenancemode",
+      "label": "isStoreMaintenanceMode()",
+      "norm_label": "isstoremaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L465"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L568"
+      "id": "storeconfig_isstorereadonlymode",
+      "label": "isStoreReadOnlyMode()",
+      "norm_label": "isstorereadonlymode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L461"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_runharnessreview",
-      "label": "runHarnessReview()",
-      "norm_label": "runharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L582"
+      "id": "storeconfig_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L106"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_runpackagescript",
-      "label": "runPackageScript()",
-      "norm_label": "runpackagescript()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L519"
+      "id": "storeconfig_mappromo",
+      "label": "mapPromo()",
+      "norm_label": "mappromo()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_runrawcommand",
-      "label": "runRawCommand()",
-      "norm_label": "runrawcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L554"
+      "id": "storeconfig_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "harness_review_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "scripts_harness_review_ts",
-      "label": "harness-review.ts",
-      "norm_label": "harness-review.ts",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L1"
+      "id": "storeconfig_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L177"
     },
     {
       "community": 100,
@@ -49320,65 +49536,65 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L404"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L181"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L231"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L275"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L259"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1080,
@@ -49473,65 +49689,65 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "posregisterview_cartcountsummary",
-      "label": "CartCountSummary()",
-      "norm_label": "cartcountsummary()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L152"
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "posregisterview_cashierauthworkspace",
-      "label": "CashierAuthWorkspace()",
-      "norm_label": "cashierauthworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L114"
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L181"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L431"
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L253"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L73"
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L231"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "posregisterview_registersetupresolvingworkspace",
-      "label": "RegisterSetupResolvingWorkspace()",
-      "norm_label": "registersetupresolvingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L146"
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L41"
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L259"
     },
     {
       "community": 1090,
@@ -49626,254 +49842,263 @@
     {
       "community": 11,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
-      "label": "sessionCommands.ts",
-      "norm_label": "sessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L1"
+      "id": "harness_review_buildgitprocessenv",
+      "label": "buildGitProcessEnv()",
+      "norm_label": "buildgitprocessenv()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L419"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "sessioncommands_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L754"
+      "id": "harness_review_collectcommandsforchangedfiles",
+      "label": "collectCommandsForChangedFiles()",
+      "norm_label": "collectcommandsforchangedfiles()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L302"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "sessioncommands_createdefaultsessioncommandservice",
-      "label": "createDefaultSessionCommandService()",
-      "norm_label": "createdefaultsessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L709"
+      "id": "harness_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L93"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "sessioncommands_createpossessioncommandservice",
-      "label": "createPosSessionCommandService()",
-      "norm_label": "createpossessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L139"
+      "id": "harness_review_formatmissingpathprefixerror",
+      "label": "formatMissingPathPrefixError()",
+      "norm_label": "formatmissingpathprefixerror()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L83"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "sessioncommands_failure",
-      "label": "failure()",
-      "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L947"
+      "id": "harness_review_getchangedfilesforharnessreview",
+      "label": "getChangedFilesForHarnessReview()",
+      "norm_label": "getchangedfilesforharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L425"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "sessioncommands_isactiveregistersession",
-      "label": "isActiveRegisterSession()",
-      "norm_label": "isactiveregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_issessionexpired",
-      "label": "isSessionExpired()",
-      "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L856"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_recordsessionlifecyclebesteffort",
-      "label": "recordSessionLifecycleBestEffort()",
-      "norm_label": "recordsessionlifecyclebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L721"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L771"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_resolveregistersessionbinding",
-      "label": "resolveRegisterSessionBinding()",
-      "norm_label": "resolveregistersessionbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L800"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_runbindsessiontoregistersessioncommand",
-      "label": "runBindSessionToRegisterSessionCommand()",
-      "norm_label": "runbindsessiontoregistersessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L686"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_runholdsessioncommand",
-      "label": "runHoldSessionCommand()",
-      "norm_label": "runholdsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L675"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_runremovesessionitemcommand",
-      "label": "runRemoveSessionItemCommand()",
-      "norm_label": "runremovesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L702"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_runresumesessioncommand",
-      "label": "runResumeSessionCommand()",
-      "norm_label": "runresumesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L679"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_runstartsessioncommand",
-      "label": "runStartSessionCommand()",
-      "norm_label": "runstartsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_runupsertsessionitemcommand",
-      "label": "runUpsertSessionItemCommand()",
-      "norm_label": "runupsertsessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L695"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L940"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesession",
-      "label": "validateActiveSession()",
-      "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L863"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesessionregisterbinding",
-      "label": "validateActiveSessionRegisterBinding()",
-      "norm_label": "validateactivesessionregisterbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L836"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "sessioncommands_validatemodifiablesession",
-      "label": "validateModifiableSession()",
-      "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L907"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "harness_review_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L102"
     },
     {
-      "community": 110,
+      "community": 11,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
+      "id": "harness_review_loadreviewtarget",
+      "label": "loadReviewTarget()",
+      "norm_label": "loadreviewtarget()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_loadreviewtargets",
+      "label": "loadReviewTargets()",
+      "norm_label": "loadreviewtargets()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L269"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_parseharnessreviewargs",
+      "label": "parseHarnessReviewArgs()",
+      "norm_label": "parseharnessreviewargs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L666"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_resolveharnessreviewshell",
+      "label": "resolveHarnessReviewShell()",
+      "norm_label": "resolveharnessreviewshell()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L533"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_rungitcommand",
+      "label": "runGitCommand()",
+      "norm_label": "rungitcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L398"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L568"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_runharnessreview",
+      "label": "runHarnessReview()",
+      "norm_label": "runharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L582"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_runpackagescript",
+      "label": "runPackageScript()",
+      "norm_label": "runpackagescript()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L519"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_runrawcommand",
+      "label": "runRawCommand()",
+      "norm_label": "runrawcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L554"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "harness_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "scripts_harness_review_ts",
+      "label": "harness-review.ts",
+      "norm_label": "harness-review.ts",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
+      "id": "posregisterview_cartcountsummary",
+      "label": "CartCountSummary()",
+      "norm_label": "cartcountsummary()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L152"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L431"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "posregisterview_registersetupresolvingworkspace",
+      "label": "RegisterSetupResolvingWorkspace()",
+      "norm_label": "registersetupresolvingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L146"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L41"
     },
     {
       "community": 1100,
@@ -49968,65 +50193,65 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 1110,
@@ -50121,65 +50346,65 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1120,
@@ -50274,65 +50499,65 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
     },
     {
       "community": 1130,
@@ -50427,65 +50652,65 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1140,
@@ -50580,65 +50805,65 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1150,
@@ -50733,65 +50958,65 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L13"
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createpackage",
-      "label": "createPackage()",
-      "norm_label": "createpackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
-      "label": "installFixtureToolchain()",
-      "norm_label": "installfixturetoolchain()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L63"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
-      "label": "linkWorkspacePackage()",
-      "norm_label": "linkworkspacepackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L32"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writefixturemanifests",
-      "label": "writeFixtureManifests()",
-      "norm_label": "writefixturemanifests()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L42"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writejson",
-      "label": "writeJson()",
-      "norm_label": "writejson()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L19"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "scripts_coverage_toolchain_parity_test_ts",
-      "label": "coverage-toolchain-parity.test.ts",
-      "norm_label": "coverage-toolchain-parity.test.ts",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L1"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1160,
@@ -50886,65 +51111,65 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "coverage_toolchain_parity_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_createpackage",
+      "label": "createPackage()",
+      "norm_label": "createpackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
+      "label": "installFixtureToolchain()",
+      "norm_label": "installfixturetoolchain()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
+      "label": "linkWorkspacePackage()",
+      "norm_label": "linkworkspacepackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writefixturemanifests",
+      "label": "writeFixtureManifests()",
+      "norm_label": "writefixturemanifests()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writejson",
+      "label": "writeJson()",
+      "norm_label": "writejson()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "scripts_coverage_toolchain_parity_test_ts",
+      "label": "coverage-toolchain-parity.test.ts",
+      "norm_label": "coverage-toolchain-parity.test.ts",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
     },
     {
       "community": 1170,
@@ -51039,65 +51264,65 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1180,
@@ -51192,64 +51417,64 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -51345,235 +51570,253 @@
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_buildnextsessionnumber",
+      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "label": "sessionCommands.ts",
+      "norm_label": "sessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "sessioncommands_buildnextsessionnumber",
       "label": "buildNextSessionNumber()",
       "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L656"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L754"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_createdefaultexpensesessioncommandservice",
-      "label": "createDefaultExpenseSessionCommandService()",
-      "norm_label": "createdefaultexpensesessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L644"
+      "id": "sessioncommands_createdefaultsessioncommandservice",
+      "label": "createDefaultSessionCommandService()",
+      "norm_label": "createdefaultsessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L709"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_createexpensesessioncommandservice",
-      "label": "createExpenseSessionCommandService()",
-      "norm_label": "createexpensesessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L136"
+      "id": "sessioncommands_createpossessioncommandservice",
+      "label": "createPosSessionCommandService()",
+      "norm_label": "createpossessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L139"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_failure",
+      "id": "sessioncommands_failure",
       "label": "failure()",
       "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L829"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L947"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_isactiveregistersession",
+      "id": "sessioncommands_isactiveregistersession",
       "label": "isActiveRegisterSession()",
       "norm_label": "isactiveregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L667"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L765"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_issessionexpired",
+      "id": "sessioncommands_issessionexpired",
       "label": "isSessionExpired()",
       "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L738"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L856"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_normalizeregisternumber",
+      "id": "sessioncommands_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
       "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L28"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L29"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_recordsessiontrace",
-      "label": "recordSessionTrace()",
-      "norm_label": "recordsessiontrace()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L550"
+      "id": "sessioncommands_recordsessionlifecyclebesteffort",
+      "label": "recordSessionLifecycleBestEffort()",
+      "norm_label": "recordsessionlifecyclebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L721"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_registersessionmatchesidentity",
+      "id": "sessioncommands_registersessionmatchesidentity",
       "label": "registerSessionMatchesIdentity()",
       "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L673"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L771"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_resolveregistersessionbinding",
+      "id": "sessioncommands_resolveregistersessionbinding",
       "label": "resolveRegisterSessionBinding()",
       "norm_label": "resolveregistersessionbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L800"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "sessioncommands_runbindsessiontoregistersessioncommand",
+      "label": "runBindSessionToRegisterSessionCommand()",
+      "norm_label": "runbindsessiontoregistersessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L686"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "sessioncommands_runholdsessioncommand",
+      "label": "runHoldSessionCommand()",
+      "norm_label": "runholdsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L675"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "sessioncommands_runremovesessionitemcommand",
+      "label": "runRemoveSessionItemCommand()",
+      "norm_label": "runremovesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
       "source_location": "L702"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
-      "label": "runBindExpenseSessionToRegisterSessionCommand()",
-      "norm_label": "runbindexpensesessiontoregistersessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L614"
+      "id": "sessioncommands_runresumesessioncommand",
+      "label": "runResumeSessionCommand()",
+      "norm_label": "runresumesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L679"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_runclearexpensesessionitemscommand",
-      "label": "runClearExpenseSessionItemsCommand()",
-      "norm_label": "runclearexpensesessionitemscommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L637"
+      "id": "sessioncommands_runstartsessioncommand",
+      "label": "runStartSessionCommand()",
+      "norm_label": "runstartsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L658"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_runremoveexpensesessionitemcommand",
-      "label": "runRemoveExpenseSessionItemCommand()",
-      "norm_label": "runremoveexpensesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L630"
+      "id": "sessioncommands_runupsertsessionitemcommand",
+      "label": "runUpsertSessionItemCommand()",
+      "norm_label": "runupsertsessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L695"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_runresumeexpensesessioncommand",
-      "label": "runResumeExpenseSessionCommand()",
-      "norm_label": "runresumeexpensesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L607"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "expensesessioncommands_runstartexpensesessioncommand",
-      "label": "runStartExpenseSessionCommand()",
-      "norm_label": "runstartexpensesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L588"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "expensesessioncommands_runupsertexpensesessionitemcommand",
-      "label": "runUpsertExpenseSessionItemCommand()",
-      "norm_label": "runupsertexpensesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L623"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "expensesessioncommands_success",
+      "id": "sessioncommands_success",
       "label": "success()",
       "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L822"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L940"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_validateactivesession",
+      "id": "sessioncommands_validateactivesession",
       "label": "validateActiveSession()",
       "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L745"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L863"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "expensesessioncommands_validatemodifiablesession",
+      "id": "sessioncommands_validateactivesessionregisterbinding",
+      "label": "validateActiveSessionRegisterBinding()",
+      "norm_label": "validateactivesessionregisterbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L836"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "sessioncommands_validatemodifiablesession",
       "label": "validateModifiableSession()",
       "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L789"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
-      "label": "expenseSessionCommands.ts",
-      "norm_label": "expensesessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L907"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -51669,56 +51912,56 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1210,
@@ -51813,56 +52056,56 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L42"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1220,
@@ -51957,56 +52200,56 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
     },
     {
       "community": 1230,
@@ -52101,56 +52344,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
     },
     {
       "community": 1240,
@@ -52245,55 +52488,55 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -52389,55 +52632,55 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -52533,56 +52776,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
     },
     {
       "community": 1270,
@@ -52677,56 +52920,56 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1280,
@@ -52965,182 +53208,182 @@
     {
       "community": 13,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productstock_tsx",
-      "label": "ProductStock.tsx",
-      "norm_label": "productstock.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "id": "expensesessioncommands_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L656"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_createdefaultexpensesessioncommandservice",
+      "label": "createDefaultExpenseSessionCommandService()",
+      "norm_label": "createdefaultexpensesessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L644"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_createexpensesessioncommandservice",
+      "label": "createExpenseSessionCommandService()",
+      "norm_label": "createexpensesessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_failure",
+      "label": "failure()",
+      "norm_label": "failure()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L829"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_isactiveregistersession",
+      "label": "isActiveRegisterSession()",
+      "norm_label": "isactiveregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L667"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_issessionexpired",
+      "label": "isSessionExpired()",
+      "norm_label": "issessionexpired()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L738"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_recordsessiontrace",
+      "label": "recordSessionTrace()",
+      "norm_label": "recordsessiontrace()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L550"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L673"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_resolveregistersessionbinding",
+      "label": "resolveRegisterSessionBinding()",
+      "norm_label": "resolveregistersessionbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L702"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
+      "label": "runBindExpenseSessionToRegisterSessionCommand()",
+      "norm_label": "runbindexpensesessiontoregistersessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L614"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_runclearexpensesessionitemscommand",
+      "label": "runClearExpenseSessionItemsCommand()",
+      "norm_label": "runclearexpensesessionitemscommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L637"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_runremoveexpensesessionitemcommand",
+      "label": "runRemoveExpenseSessionItemCommand()",
+      "norm_label": "runremoveexpensesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L630"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_runresumeexpensesessioncommand",
+      "label": "runResumeExpenseSessionCommand()",
+      "norm_label": "runresumeexpensesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L607"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_runstartexpensesessioncommand",
+      "label": "runStartExpenseSessionCommand()",
+      "norm_label": "runstartexpensesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L588"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_runupsertexpensesessionitemcommand",
+      "label": "runUpsertExpenseSessionItemCommand()",
+      "norm_label": "runupsertexpensesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L623"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L822"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_validateactivesession",
+      "label": "validateActiveSession()",
+      "norm_label": "validateactivesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L745"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "expensesessioncommands_validatemodifiablesession",
+      "label": "validateModifiableSession()",
+      "norm_label": "validatemodifiablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L789"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "label": "expenseSessionCommands.ts",
+      "norm_label": "expensesessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_addrow",
-      "label": "addRow()",
-      "norm_label": "addrow()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L437"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_getreservationtype",
-      "label": "getReservationType()",
-      "norm_label": "getreservationtype()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L180"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L391"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handleclearbarcodecancel",
-      "label": "handleClearBarcodeCancel()",
-      "norm_label": "handleclearbarcodecancel()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L386"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handleclearbarcodeclick",
-      "label": "handleClearBarcodeClick()",
-      "norm_label": "handleclearbarcodeclick()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L315"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handleclearbarcodeconfirm",
-      "label": "handleClearBarcodeConfirm()",
-      "norm_label": "handleclearbarcodeconfirm()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handledeleteaction",
-      "label": "handleDeleteAction()",
-      "norm_label": "handledeleteaction()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L452"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handlegeneratebarcode",
-      "label": "handleGenerateBarcode()",
-      "norm_label": "handlegeneratebarcode()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L242"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handlesavebarcode",
-      "label": "handleSaveBarcode()",
-      "norm_label": "handlesavebarcode()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L288"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_handleviewbarcode",
-      "label": "handleViewBarcode()",
-      "norm_label": "handleviewbarcode()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_haspriceerror",
-      "label": "hasPriceError()",
-      "norm_label": "haspriceerror()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L521"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_hasquantityerror",
-      "label": "hasQuantityError()",
-      "norm_label": "hasquantityerror()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L513"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_islastactivevariant",
-      "label": "isLastActiveVariant()",
-      "norm_label": "islastactivevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L493"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_islastvisiblevariant",
-      "label": "isLastVisibleVariant()",
-      "norm_label": "islastvisiblevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L499"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_isskureserved",
-      "label": "isSkuReserved()",
-      "norm_label": "isskureserved()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L176"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_restock",
-      "label": "restock()",
-      "norm_label": "restock()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_setoutofstock",
-      "label": "setOutOfStock()",
-      "norm_label": "setoutofstock()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L469"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_setvisibility",
-      "label": "setVisibility()",
-      "norm_label": "setvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L479"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "productstock_shoulddisable",
-      "label": "shouldDisable()",
-      "norm_label": "shoulddisable()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L505"
     },
     {
       "community": 130,
@@ -53289,56 +53532,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1310,
@@ -53433,56 +53676,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1320,
@@ -54585,182 +54828,182 @@
     {
       "community": 14,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productstock_tsx",
+      "label": "ProductStock.tsx",
+      "norm_label": "productstock.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L1"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L1"
+      "id": "productstock_addrow",
+      "label": "addRow()",
+      "norm_label": "addrow()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L437"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L1"
+      "id": "productstock_getreservationtype",
+      "label": "getReservationType()",
+      "norm_label": "getreservationtype()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L180"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L18"
+      "id": "productstock_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L391"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_capitalizewords",
-      "label": "capitalizeWords()",
-      "norm_label": "capitalizewords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L23"
+      "id": "productstock_handleclearbarcodecancel",
+      "label": "handleClearBarcodeCancel()",
+      "norm_label": "handleclearbarcodecancel()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L386"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L9"
+      "id": "productstock_handleclearbarcodeclick",
+      "label": "handleClearBarcodeClick()",
+      "norm_label": "handleclearbarcodeclick()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L315"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L39"
+      "id": "productstock_handleclearbarcodeconfirm",
+      "label": "handleClearBarcodeConfirm()",
+      "norm_label": "handleclearbarcodeconfirm()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L320"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_enablequery",
-      "label": "enableQuery()",
-      "norm_label": "enablequery()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L86"
+      "id": "productstock_handledeleteaction",
+      "label": "handleDeleteAction()",
+      "norm_label": "handledeleteaction()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L452"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_formatdate",
-      "label": "formatDate()",
-      "norm_label": "formatdate()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L70"
+      "id": "productstock_handlegeneratebarcode",
+      "label": "handleGenerateBarcode()",
+      "norm_label": "handlegeneratebarcode()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L242"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_formatuserid",
-      "label": "formatUserId()",
-      "norm_label": "formatuserid()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L87"
+      "id": "productstock_handlesavebarcode",
+      "label": "handleSaveBarcode()",
+      "norm_label": "handlesavebarcode()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L288"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L73"
+      "id": "productstock_handleviewbarcode",
+      "label": "handleViewBarcode()",
+      "norm_label": "handleviewbarcode()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L307"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_getaddressstring",
-      "label": "getAddressString()",
-      "norm_label": "getaddressstring()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L15"
+      "id": "productstock_haspriceerror",
+      "label": "hasPriceError()",
+      "norm_label": "haspriceerror()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L521"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_geterrorforfield",
-      "label": "getErrorForField()",
-      "norm_label": "geterrorforfield()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L14"
+      "id": "productstock_hasquantityerror",
+      "label": "hasQuantityError()",
+      "norm_label": "hasquantityerror()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L513"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L60"
+      "id": "productstock_islastactivevariant",
+      "label": "isLastActiveVariant()",
+      "norm_label": "islastactivevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L493"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_getrelativetime",
-      "label": "getRelativeTime()",
-      "norm_label": "getrelativetime()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L93"
+      "id": "productstock_islastvisiblevariant",
+      "label": "isLastVisibleVariant()",
+      "norm_label": "islastvisiblevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L499"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_getstoredetails",
-      "label": "getStoreDetails()",
-      "norm_label": "getstoredetails()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L79"
+      "id": "productstock_isskureserved",
+      "label": "isSkuReserved()",
+      "norm_label": "isskureserved()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L176"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_gettimeremaining",
-      "label": "getTimeRemaining()",
-      "norm_label": "gettimeremaining()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L67"
+      "id": "productstock_restock",
+      "label": "restock()",
+      "norm_label": "restock()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L109"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_slugtowords",
-      "label": "slugToWords()",
-      "norm_label": "slugtowords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L31"
+      "id": "productstock_setoutofstock",
+      "label": "setOutOfStock()",
+      "norm_label": "setoutofstock()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L469"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_snakecasetowords",
-      "label": "snakeCaseToWords()",
-      "norm_label": "snakecasetowords()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L46"
+      "id": "productstock_setvisibility",
+      "label": "setVisibility()",
+      "norm_label": "setvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L479"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "utils_toslug",
-      "label": "toSlug()",
-      "norm_label": "toslug()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L33"
+      "id": "productstock_shoulddisable",
+      "label": "shouldDisable()",
+      "norm_label": "shoulddisable()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L505"
     },
     {
       "community": 140,
@@ -56205,173 +56448,182 @@
     {
       "community": 15,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
-      "label": "registerSessions.ts",
-      "norm_label": "registersessions.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "id": "packages_athena_webapp_convex_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_assertregistersessionidentity",
-      "label": "assertRegisterSessionIdentity()",
-      "norm_label": "assertregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L61"
+      "id": "packages_athena_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_assertregistersessionmatchestransaction",
-      "label": "assertRegisterSessionMatchesTransaction()",
-      "norm_label": "assertregistersessionmatchestransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L71"
+      "id": "packages_storefront_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_assertvalidregistersessiontransition",
-      "label": "assertValidRegisterSessionTransition()",
-      "norm_label": "assertvalidregistersessiontransition()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L128"
+      "id": "utils_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L18"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildclosedregistersessionpatch",
-      "label": "buildClosedRegisterSessionPatch()",
-      "norm_label": "buildclosedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L297"
+      "id": "utils_capitalizewords",
+      "label": "capitalizeWords()",
+      "norm_label": "capitalizewords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L23"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "id": "utils_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_enablequery",
+      "label": "enableQuery()",
+      "norm_label": "enablequery()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_formatdate",
+      "label": "formatDate()",
+      "norm_label": "formatdate()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_formatuserid",
+      "label": "formatUserId()",
+      "norm_label": "formatuserid()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_getaddressstring",
+      "label": "getAddressString()",
+      "norm_label": "getaddressstring()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_geterrorforfield",
+      "label": "getErrorForField()",
+      "norm_label": "geterrorforfield()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "utils_getrelativetime",
+      "label": "getRelativeTime()",
+      "norm_label": "getrelativetime()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L93"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildregistersessioncloseoutpatch",
-      "label": "buildRegisterSessionCloseoutPatch()",
-      "norm_label": "buildregistersessioncloseoutpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L188"
+      "id": "utils_getstoredetails",
+      "label": "getStoreDetails()",
+      "norm_label": "getstoredetails()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L79"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiondepositpatch",
-      "label": "buildRegisterSessionDepositPatch()",
-      "norm_label": "buildregistersessiondepositpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L227"
+      "id": "utils_gettimeremaining",
+      "label": "getTimeRemaining()",
+      "norm_label": "gettimeremaining()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L67"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildregistersessionopeningfloatcorrectionpatch",
-      "label": "buildRegisterSessionOpeningFloatCorrectionPatch()",
-      "norm_label": "buildregistersessionopeningfloatcorrectionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L256"
+      "id": "utils_slugtowords",
+      "label": "slugToWords()",
+      "norm_label": "slugtowords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L31"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiontransactionpatch",
-      "label": "buildRegisterSessionTransactionPatch()",
-      "norm_label": "buildregistersessiontransactionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L147"
+      "id": "utils_snakecasetowords",
+      "label": "snakeCaseToWords()",
+      "norm_label": "snakecasetowords()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L46"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "registersessions_buildreopenedregistersessionpatch",
-      "label": "buildReopenedRegisterSessionPatch()",
-      "norm_label": "buildreopenedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_calculateregistersessioncashdelta",
-      "label": "calculateRegisterSessionCashDelta()",
-      "norm_label": "calculateregistersessioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_correctregistersessionopeningfloatwithctx",
-      "label": "correctRegisterSessionOpeningFloatWithCtx()",
-      "norm_label": "correctregistersessionopeningfloatwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L654"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_findconflictingregistersession",
-      "label": "findConflictingRegisterSession()",
-      "norm_label": "findconflictingregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L323"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_normalizeregistersessionidentity",
-      "label": "normalizeRegisterSessionIdentity()",
-      "norm_label": "normalizeregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_recordregistersessiondepositwithctx",
-      "label": "recordRegisterSessionDepositWithCtx()",
-      "norm_label": "recordregistersessiondepositwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L620"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_registersessionstatusset",
-      "label": "registerSessionStatusSet()",
-      "norm_label": "registersessionstatusset()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "registersessions_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L27"
+      "id": "utils_toslug",
+      "label": "toSlug()",
+      "norm_label": "toslug()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L33"
     },
     {
       "community": 150,
@@ -56925,173 +57177,173 @@
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
-      "label": "transactionRepository.ts",
-      "norm_label": "transactionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "label": "registerSessions.ts",
+      "norm_label": "registersessions.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_createpostransaction",
-      "label": "createPosTransaction()",
-      "norm_label": "createpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L152"
+      "id": "registersessions_assertregistersessionidentity",
+      "label": "assertRegisterSessionIdentity()",
+      "norm_label": "assertregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L61"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_createpostransactionitem",
-      "label": "createPosTransactionItem()",
-      "norm_label": "createpostransactionitem()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L159"
+      "id": "registersessions_assertregistersessionmatchestransaction",
+      "label": "assertRegisterSessionMatchesTransaction()",
+      "norm_label": "assertregistersessionmatchestransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L71"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getcashierbyid",
-      "label": "getCashierById()",
-      "norm_label": "getcashierbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L51"
+      "id": "registersessions_assertvalidregistersessiontransition",
+      "label": "assertValidRegisterSessionTransition()",
+      "norm_label": "assertvalidregistersessiontransition()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L128"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L58"
+      "id": "registersessions_buildclosedregistersessionpatch",
+      "label": "buildClosedRegisterSessionPatch()",
+      "norm_label": "buildclosedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L297"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getpossessionbyid",
-      "label": "getPosSessionById()",
-      "norm_label": "getpossessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L37"
+      "id": "registersessions_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L93"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getpostransactionbyid",
-      "label": "getPosTransactionById()",
-      "norm_label": "getpostransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L30"
+      "id": "registersessions_buildregistersessioncloseoutpatch",
+      "label": "buildRegisterSessionCloseoutPatch()",
+      "norm_label": "buildregistersessioncloseoutpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L188"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getproductskubyid",
-      "label": "getProductSkuById()",
-      "norm_label": "getproductskubyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L23"
+      "id": "registersessions_buildregistersessiondepositpatch",
+      "label": "buildRegisterSessionDepositPatch()",
+      "norm_label": "buildregistersessiondepositpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L227"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getregistersessionbyid",
-      "label": "getRegisterSessionById()",
-      "norm_label": "getregistersessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L44"
+      "id": "registersessions_buildregistersessionopeningfloatcorrectionpatch",
+      "label": "buildRegisterSessionOpeningFloatCorrectionPatch()",
+      "norm_label": "buildregistersessionopeningfloatcorrectionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L256"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_getstorebyid",
-      "label": "getStoreById()",
-      "norm_label": "getstorebyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L16"
+      "id": "registersessions_buildregistersessiontransactionpatch",
+      "label": "buildRegisterSessionTransactionPatch()",
+      "norm_label": "buildregistersessiontransactionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L147"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactions",
-      "label": "listCompletedTransactions()",
-      "norm_label": "listcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L101"
+      "id": "registersessions_buildreopenedregistersessionpatch",
+      "label": "buildReopenedRegisterSessionPatch()",
+      "norm_label": "buildreopenedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L214"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactionsforday",
-      "label": "listCompletedTransactionsForDay()",
-      "norm_label": "listcompletedtransactionsforday()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L131"
+      "id": "registersessions_calculateregistersessioncashdelta",
+      "label": "calculateRegisterSessionCashDelta()",
+      "norm_label": "calculateregistersessioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L115"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L76"
+      "id": "registersessions_correctregistersessionopeningfloatwithctx",
+      "label": "correctRegisterSessionOpeningFloatWithCtx()",
+      "norm_label": "correctregistersessionopeningfloatwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L654"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionitems",
-      "label": "listTransactionItems()",
-      "norm_label": "listtransactionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L65"
+      "id": "registersessions_findconflictingregistersession",
+      "label": "findConflictingRegisterSession()",
+      "norm_label": "findconflictingregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L323"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionsbystore",
-      "label": "listTransactionsByStore()",
-      "norm_label": "listtransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L87"
+      "id": "registersessions_normalizeregistersessionidentity",
+      "label": "normalizeRegisterSessionIdentity()",
+      "norm_label": "normalizeregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L54"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_patchpossession",
-      "label": "patchPosSession()",
-      "norm_label": "patchpossession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L182"
+      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_patchpostransaction",
-      "label": "patchPosTransaction()",
-      "norm_label": "patchpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L174"
+      "id": "registersessions_recordregistersessiondepositwithctx",
+      "label": "recordRegisterSessionDepositWithCtx()",
+      "norm_label": "recordregistersessiondepositwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L620"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_patchproductsku",
-      "label": "patchProductSku()",
-      "norm_label": "patchproductsku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L166"
+      "id": "registersessions_registersessionstatusset",
+      "label": "registerSessionStatusSet()",
+      "norm_label": "registersessionstatusset()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L11"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "transactionrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L6"
+      "id": "registersessions_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L27"
     },
     {
       "community": 160,
@@ -57555,173 +57807,173 @@
     {
       "community": 17,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
+      "label": "transactionRepository.ts",
+      "norm_label": "transactionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
       "source_location": "L1"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L196"
+      "id": "transactionrepository_createpostransaction",
+      "label": "createPosTransaction()",
+      "norm_label": "createpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L152"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L192"
+      "id": "transactionrepository_createpostransactionitem",
+      "label": "createPosTransactionItem()",
+      "norm_label": "createpostransactionitem()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L159"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L212"
+      "id": "transactionrepository_getcashierbyid",
+      "label": "getCashierById()",
+      "norm_label": "getcashierbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L51"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L227"
+      "id": "transactionrepository_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L58"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopekey",
-      "label": "getCountScopeKey()",
-      "norm_label": "getcountscopekey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L184"
+      "id": "transactionrepository_getpossessionbyid",
+      "label": "getPosSessionById()",
+      "norm_label": "getpossessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L37"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L188"
+      "id": "transactionrepository_getpostransactionbyid",
+      "label": "getPosTransactionById()",
+      "norm_label": "getpostransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L30"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L231"
+      "id": "transactionrepository_getproductskubyid",
+      "label": "getProductSkuById()",
+      "norm_label": "getproductskubyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L23"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getskudetailentries",
-      "label": "getSkuDetailEntries()",
-      "norm_label": "getskudetailentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L235"
+      "id": "transactionrepository_getregistersessionbyid",
+      "label": "getRegisterSessionById()",
+      "norm_label": "getregistersessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L44"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L874"
+      "id": "transactionrepository_getstorebyid",
+      "label": "getStoreById()",
+      "norm_label": "getstorebyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L16"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
-      "label": "normalizeStockAdjustmentSearch()",
-      "norm_label": "normalizestockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L252"
+      "id": "transactionrepository_listcompletedtransactions",
+      "label": "listCompletedTransactions()",
+      "norm_label": "listcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L101"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_parsecountscopekeys",
-      "label": "parseCountScopeKeys()",
-      "norm_label": "parsecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L256"
+      "id": "transactionrepository_listcompletedtransactionsforday",
+      "label": "listCompletedTransactionsForDay()",
+      "norm_label": "listcompletedtransactionsforday()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L131"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L223"
+      "id": "transactionrepository_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L76"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L292"
+      "id": "transactionrepository_listtransactionitems",
+      "label": "listTransactionItems()",
+      "norm_label": "listtransactionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L65"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "label": "rowMatchesStockAdjustmentSearch()",
-      "norm_label": "rowmatchesstockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L269"
+      "id": "transactionrepository_listtransactionsbystore",
+      "label": "listTransactionsByStore()",
+      "norm_label": "listtransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L87"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_savecyclecountdraftvalue",
-      "label": "saveCycleCountDraftValue()",
-      "norm_label": "savecyclecountdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L882"
+      "id": "transactionrepository_patchpossession",
+      "label": "patchPosSession()",
+      "norm_label": "patchpossession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L182"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_serializecountscopekeys",
-      "label": "serializeCountScopeKeys()",
-      "norm_label": "serializecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L265"
+      "id": "transactionrepository_patchpostransaction",
+      "label": "patchPosTransaction()",
+      "norm_label": "patchpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L174"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L864"
+      "id": "transactionrepository_patchproductsku",
+      "label": "patchProductSku()",
+      "norm_label": "patchproductsku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L166"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L218"
+      "id": "transactionrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L6"
     },
     {
       "community": 170,
@@ -58176,173 +58428,173 @@
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_ancestorchain",
-      "label": "ancestorChain()",
-      "norm_label": "ancestorchain()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L197"
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparses",
-      "label": "collectRawMoneyParses()",
-      "norm_label": "collectrawmoneyparses()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L394"
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L212"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
-      "label": "collectRawMoneyParsesFromSource()",
-      "norm_label": "collectrawmoneyparsesfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L321"
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L208"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
-      "label": "collectRawNumericHelperNames()",
-      "norm_label": "collectrawnumerichelpernames()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L295"
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L228"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L105"
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L243"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
-      "label": "containsDisallowedRawNumericParse()",
-      "norm_label": "containsdisallowedrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L260"
+      "id": "stockadjustmentworkspace_getcountscopekey",
+      "label": "getCountScopeKey()",
+      "norm_label": "getcountscopekey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L200"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsterm",
-      "label": "containsTerm()",
-      "norm_label": "containsterm()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L149"
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L204"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isalloweddisplayconversion",
-      "label": "isAllowedDisplayConversion()",
-      "norm_label": "isalloweddisplayconversion()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L247"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L251"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L929"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "label": "normalizeStockAdjustmentSearch()",
+      "norm_label": "normalizestockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L268"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_parsecountscopekeys",
+      "label": "parseCountScopeKeys()",
+      "norm_label": "parsecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L272"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L239"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowednumericrounding",
-      "label": "isAllowedNumericRounding()",
-      "norm_label": "isallowednumericrounding()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L249"
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L308"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowedpercentagebranch",
-      "label": "isAllowedPercentageBranch()",
-      "norm_label": "isallowedpercentagebranch()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L225"
+      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "label": "rowMatchesStockAdjustmentSearch()",
+      "norm_label": "rowmatchesstockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L285"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_israwnumericparse",
-      "label": "isRawNumericParse()",
-      "norm_label": "israwnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L128"
+      "id": "stockadjustmentworkspace_savecyclecountdraftvalue",
+      "label": "saveCycleCountDraftValue()",
+      "norm_label": "savecyclecountdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L937"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_nearestcontextnode",
-      "label": "nearestContextNode()",
-      "norm_label": "nearestcontextnode()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L209"
+      "id": "stockadjustmentworkspace_serializecountscopekeys",
+      "label": "serializeCountScopeKeys()",
+      "norm_label": "serializecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L281"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_nodeline",
-      "label": "nodeLine()",
-      "norm_label": "nodeline()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L186"
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L919"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_readwebappfile",
-      "label": "readWebappFile()",
-      "norm_label": "readwebappfile()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_referencesmoney",
-      "label": "referencesMoney()",
-      "norm_label": "referencesmoney()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
-      "label": "referencesOnlyNonMoneyNumericContext()",
-      "norm_label": "referencesonlynonmoneynumericcontext()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_returnsrawnumericparse",
-      "label": "returnsRawNumericParse()",
-      "norm_label": "returnsrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_reviewedreason",
-      "label": "reviewedReason()",
-      "norm_label": "reviewedreason()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
-      "label": "moneyEntryAudit.test.ts",
-      "norm_label": "moneyentryaudit.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L1"
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L234"
     },
     {
       "community": 180,
@@ -58396,7 +58648,7 @@
       "label": "getApprovalRequestCopy()",
       "norm_label": "getapprovalrequestcopy()",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L62"
+      "source_location": "L63"
     },
     {
       "community": 181,
@@ -58405,7 +58657,7 @@
       "label": "getDefaultWorkflow()",
       "norm_label": "getdefaultworkflow()",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L53"
+      "source_location": "L54"
     },
     {
       "community": 181,
@@ -58414,7 +58666,7 @@
       "label": "if()",
       "norm_label": "if()",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L557"
+      "source_location": "L579"
     },
     {
       "community": 181,
@@ -58423,7 +58675,7 @@
       "label": "setDecisioningApprovalRequestId()",
       "norm_label": "setdecisioningapprovalrequestid()",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L595"
+      "source_location": "L638"
     },
     {
       "community": 181,
@@ -58797,164 +59049,173 @@
     {
       "community": 19,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
-      "label": "staffCredentials.ts",
-      "norm_label": "staffcredentials.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "id": "moneyentryaudit_test_ancestorchain",
+      "label": "ancestorChain()",
+      "norm_label": "ancestorchain()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparses",
+      "label": "collectRawMoneyParses()",
+      "norm_label": "collectrawmoneyparses()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
+      "label": "collectRawMoneyParsesFromSource()",
+      "norm_label": "collectrawmoneyparsesfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L321"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
+      "label": "collectRawNumericHelperNames()",
+      "norm_label": "collectrawnumerichelpernames()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
+      "label": "containsDisallowedRawNumericParse()",
+      "norm_label": "containsdisallowedrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsterm",
+      "label": "containsTerm()",
+      "norm_label": "containsterm()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isalloweddisplayconversion",
+      "label": "isAllowedDisplayConversion()",
+      "norm_label": "isalloweddisplayconversion()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowednumericrounding",
+      "label": "isAllowedNumericRounding()",
+      "norm_label": "isallowednumericrounding()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowedpercentagebranch",
+      "label": "isAllowedPercentageBranch()",
+      "norm_label": "isallowedpercentagebranch()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_israwnumericparse",
+      "label": "isRawNumericParse()",
+      "norm_label": "israwnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nearestcontextnode",
+      "label": "nearestContextNode()",
+      "norm_label": "nearestcontextnode()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nodeline",
+      "label": "nodeLine()",
+      "norm_label": "nodeline()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_readwebappfile",
+      "label": "readWebappFile()",
+      "norm_label": "readwebappfile()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesmoney",
+      "label": "referencesMoney()",
+      "norm_label": "referencesmoney()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
+      "label": "referencesOnlyNonMoneyNumericContext()",
+      "norm_label": "referencesonlynonmoneynumericcontext()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_returnsrawnumericparse",
+      "label": "returnsRawNumericParse()",
+      "norm_label": "returnsrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_reviewedreason",
+      "label": "reviewedReason()",
+      "norm_label": "reviewedreason()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
+      "label": "moneyEntryAudit.test.ts",
+      "norm_label": "moneyentryaudit.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_assertstaffprofilereadyforcredential",
-      "label": "assertStaffProfileReadyForCredential()",
-      "norm_label": "assertstaffprofilereadyforcredential()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
-      "label": "authenticateStaffCredentialForApprovalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L566"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
-      "label": "authenticateStaffCredentialForTerminalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L505"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialwithctx",
-      "label": "authenticateStaffCredentialWithCtx()",
-      "norm_label": "authenticatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_createstaffcredentialwithctx",
-      "label": "createStaffCredentialWithCtx()",
-      "norm_label": "createstaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getactiverolesforstaffprofile",
-      "label": "getActiveRolesForStaffProfile()",
-      "norm_label": "getactiverolesforstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyid",
-      "label": "getCredentialById()",
-      "norm_label": "getcredentialbyid()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyusername",
-      "label": "getCredentialByUsername()",
-      "norm_label": "getcredentialbyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
-      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
-      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
-      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
-      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_invalidstaffcredentialsresult",
-      "label": "invalidStaffCredentialsResult()",
-      "norm_label": "invalidstaffcredentialsresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
-      "label": "listStaffCredentialsByStoreWithCtx()",
-      "norm_label": "liststaffcredentialsbystorewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_normalizeusername",
-      "label": "normalizeUsername()",
-      "norm_label": "normalizeusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_requirenonemptyusername",
-      "label": "requireNonEmptyUsername()",
-      "norm_label": "requirenonemptyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_staffauthorizationfailedresult",
-      "label": "staffAuthorizationFailedResult()",
-      "norm_label": "staffauthorizationfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_staffpreconditionfailedresult",
-      "label": "staffPreconditionFailedResult()",
-      "norm_label": "staffpreconditionfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_updatestaffcredentialwithctx",
-      "label": "updateStaffCredentialWithCtx()",
-      "norm_label": "updatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L319"
     },
     {
       "community": 190,
@@ -59706,164 +59967,164 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "customerrepository_createposcustomer",
-      "label": "createPosCustomer()",
-      "norm_label": "createposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_ensurecustomerprofilefromsources",
-      "label": "ensureCustomerProfileFromSources()",
-      "norm_label": "ensurecustomerprofilefromsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findcustomerbyemail",
-      "label": "findCustomerByEmail()",
-      "norm_label": "findcustomerbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findcustomerbyphone",
-      "label": "findCustomerByPhone()",
-      "norm_label": "findcustomerbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findguestbyemail",
-      "label": "findGuestByEmail()",
-      "norm_label": "findguestbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findguestbyphone",
-      "label": "findGuestByPhone()",
-      "norm_label": "findguestbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findposcustomerbyguest",
-      "label": "findPosCustomerByGuest()",
-      "norm_label": "findposcustomerbyguest()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findposcustomerbystorefrontuser",
-      "label": "findPosCustomerByStoreFrontUser()",
-      "norm_label": "findposcustomerbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyemail",
-      "label": "findStoreFrontUserByEmail()",
-      "norm_label": "findstorefrontuserbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyphone",
-      "label": "findStoreFrontUserByPhone()",
-      "norm_label": "findstorefrontuserbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_getguestbyid",
-      "label": "getGuestById()",
-      "norm_label": "getguestbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_getposcustomerbyid",
-      "label": "getPosCustomerById()",
-      "norm_label": "getposcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_getstorefrontuserbyid",
-      "label": "getStoreFrontUserById()",
-      "norm_label": "getstorefrontuserbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_listactivecustomersforstore",
-      "label": "listActiveCustomersForStore()",
-      "norm_label": "listactivecustomersforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_listcompletedtransactionsforcustomer",
-      "label": "listCompletedTransactionsForCustomer()",
-      "norm_label": "listcompletedtransactionsforcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_patchposcustomer",
-      "label": "patchPosCustomer()",
-      "norm_label": "patchposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
-      "label": "customerRepository.ts",
-      "norm_label": "customerrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
+      "label": "staffCredentials.ts",
+      "norm_label": "staffcredentials.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_assertstaffprofilereadyforcredential",
+      "label": "assertStaffProfileReadyForCredential()",
+      "norm_label": "assertstaffprofilereadyforcredential()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
+      "label": "authenticateStaffCredentialForApprovalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L566"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
+      "label": "authenticateStaffCredentialForTerminalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L505"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialwithctx",
+      "label": "authenticateStaffCredentialWithCtx()",
+      "norm_label": "authenticatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L415"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_createstaffcredentialwithctx",
+      "label": "createStaffCredentialWithCtx()",
+      "norm_label": "createstaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getactiverolesforstaffprofile",
+      "label": "getActiveRolesForStaffProfile()",
+      "norm_label": "getactiverolesforstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyid",
+      "label": "getCredentialById()",
+      "norm_label": "getcredentialbyid()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyusername",
+      "label": "getCredentialByUsername()",
+      "norm_label": "getcredentialbyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
+      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
+      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
+      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
+      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_invalidstaffcredentialsresult",
+      "label": "invalidStaffCredentialsResult()",
+      "norm_label": "invalidstaffcredentialsresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
+      "label": "listStaffCredentialsByStoreWithCtx()",
+      "norm_label": "liststaffcredentialsbystorewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_normalizeusername",
+      "label": "normalizeUsername()",
+      "norm_label": "normalizeusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_requirenonemptyusername",
+      "label": "requireNonEmptyUsername()",
+      "norm_label": "requirenonemptyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_staffauthorizationfailedresult",
+      "label": "staffAuthorizationFailedResult()",
+      "norm_label": "staffauthorizationfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_staffpreconditionfailedresult",
+      "label": "staffPreconditionFailedResult()",
+      "norm_label": "staffpreconditionfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_updatestaffcredentialwithctx",
+      "label": "updateStaffCredentialWithCtx()",
+      "norm_label": "updatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L319"
     },
     {
       "community": 200,
@@ -60318,163 +60579,163 @@
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_calculatepromocodevalue",
-      "label": "calculatePromoCodeValue()",
-      "norm_label": "calculatepromocodevalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447"
+      "id": "customerrepository_createposcustomer",
+      "label": "createPosCustomer()",
+      "norm_label": "createposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L57"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_checkadjustedavailability",
-      "label": "checkAdjustedAvailability()",
-      "norm_label": "checkadjustedavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990"
+      "id": "customerrepository_ensurecustomerprofilefromsources",
+      "label": "ensureCustomerProfileFromSources()",
+      "norm_label": "ensurecustomerprofilefromsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L240"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_checkifitemshavechanged",
-      "label": "checkIfItemsHaveChanged()",
-      "norm_label": "checkifitemshavechanged()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L50"
+      "id": "customerrepository_findcustomerbyemail",
+      "label": "findCustomerByEmail()",
+      "norm_label": "findcustomerbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L27"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_createonlineorder",
-      "label": "createOnlineOrder()",
-      "norm_label": "createonlineorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765"
+      "id": "customerrepository_findcustomerbyphone",
+      "label": "findCustomerByPhone()",
+      "norm_label": "findcustomerbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L42"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_createpatchobject",
-      "label": "createPatchObject()",
-      "norm_label": "createpatchobject()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651"
+      "id": "customerrepository_findguestbyemail",
+      "label": "findGuestByEmail()",
+      "norm_label": "findguestbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L186"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_createsessionitems",
-      "label": "createSessionItems()",
-      "norm_label": "createsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102"
+      "id": "customerrepository_findguestbyphone",
+      "label": "findGuestByPhone()",
+      "norm_label": "findguestbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L222"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_fetchproductskus",
-      "label": "fetchProductSkus()",
-      "norm_label": "fetchproductskus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979"
+      "id": "customerrepository_findposcustomerbyguest",
+      "label": "findPosCustomerByGuest()",
+      "norm_label": "findposcustomerbyguest()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L154"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_findbestvaluepromocode",
-      "label": "findBestValuePromoCode()",
-      "norm_label": "findbestvaluepromocode()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495"
+      "id": "customerrepository_findposcustomerbystorefrontuser",
+      "label": "findPosCustomerByStoreFrontUser()",
+      "norm_label": "findposcustomerbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L142"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_handleexistingsession",
-      "label": "handleExistingSession()",
-      "norm_label": "handleexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161"
+      "id": "customerrepository_findstorefrontuserbyemail",
+      "label": "findStoreFrontUserByEmail()",
+      "norm_label": "findstorefrontuserbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L168"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_handleordercreation",
-      "label": "handleOrderCreation()",
-      "norm_label": "handleordercreation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734"
+      "id": "customerrepository_findstorefrontuserbyphone",
+      "label": "findStoreFrontUserByPhone()",
+      "norm_label": "findstorefrontuserbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L204"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_handleplaceorder",
-      "label": "handlePlaceOrder()",
-      "norm_label": "handleplaceorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698"
+      "id": "customerrepository_getguestbyid",
+      "label": "getGuestById()",
+      "norm_label": "getguestbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L135"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L40"
+      "id": "customerrepository_getposcustomerbyid",
+      "label": "getPosCustomerById()",
+      "norm_label": "getposcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L20"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_retrieveactivecheckoutsession",
-      "label": "retrieveActiveCheckoutSession()",
-      "norm_label": "retrieveactivecheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951"
+      "id": "customerrepository_getstorefrontuserbyid",
+      "label": "getStoreFrontUserById()",
+      "norm_label": "getstorefrontuserbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L128"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_updateavailability",
-      "label": "updateAvailability()",
-      "norm_label": "updateavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140"
+      "id": "customerrepository_listactivecustomersforstore",
+      "label": "listActiveCustomersForStore()",
+      "norm_label": "listactivecustomersforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L8"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_updateexistingsession",
-      "label": "updateExistingSession()",
-      "norm_label": "updateexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020"
+      "id": "customerrepository_listcompletedtransactionsforcustomer",
+      "label": "listCompletedTransactionsForCustomer()",
+      "norm_label": "listcompletedtransactionsforcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L94"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_updateproductavailability",
-      "label": "updateProductAvailability()",
-      "norm_label": "updateproductavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123"
+      "id": "customerrepository_patchposcustomer",
+      "label": "patchPosCustomer()",
+      "norm_label": "patchposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L64"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_validateexistingdiscount",
-      "label": "validateExistingDiscount()",
-      "norm_label": "validateexistingdiscount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321"
+      "id": "customerrepository_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L72"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
+      "label": "customerRepository.ts",
+      "norm_label": "customerrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
       "source_location": "L1"
     },
     {
@@ -60876,163 +61137,163 @@
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
+      "id": "checkoutsession_calculatepromocodevalue",
+      "label": "calculatePromoCodeValue()",
+      "norm_label": "calculatepromocodevalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1447"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
+      "id": "checkoutsession_checkadjustedavailability",
+      "label": "checkAdjustedAvailability()",
+      "norm_label": "checkadjustedavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L990"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
+      "id": "checkoutsession_checkifitemshavechanged",
+      "label": "checkIfItemsHaveChanged()",
+      "norm_label": "checkifitemshavechanged()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L50"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
+      "id": "checkoutsession_createonlineorder",
+      "label": "createOnlineOrder()",
+      "norm_label": "createonlineorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L765"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
+      "id": "checkoutsession_createpatchobject",
+      "label": "createPatchObject()",
+      "norm_label": "createpatchobject()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L651"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
+      "id": "checkoutsession_createsessionitems",
+      "label": "createSessionItems()",
+      "norm_label": "createsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1102"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
+      "id": "checkoutsession_fetchproductskus",
+      "label": "fetchProductSkus()",
+      "norm_label": "fetchproductskus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L979"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
+      "id": "checkoutsession_findbestvaluepromocode",
+      "label": "findBestValuePromoCode()",
+      "norm_label": "findbestvaluepromocode()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1495"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
+      "id": "checkoutsession_handleexistingsession",
+      "label": "handleExistingSession()",
+      "norm_label": "handleexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1161"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
+      "id": "checkoutsession_handleordercreation",
+      "label": "handleOrderCreation()",
+      "norm_label": "handleordercreation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L734"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
+      "id": "checkoutsession_handleplaceorder",
+      "label": "handlePlaceOrder()",
+      "norm_label": "handleplaceorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L698"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
+      "id": "checkoutsession_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L40"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
+      "id": "checkoutsession_retrieveactivecheckoutsession",
+      "label": "retrieveActiveCheckoutSession()",
+      "norm_label": "retrieveactivecheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L951"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
+      "id": "checkoutsession_updateavailability",
+      "label": "updateAvailability()",
+      "norm_label": "updateavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1140"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
+      "id": "checkoutsession_updateexistingsession",
+      "label": "updateExistingSession()",
+      "norm_label": "updateexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1020"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
+      "id": "checkoutsession_updateproductavailability",
+      "label": "updateProductAvailability()",
+      "norm_label": "updateproductavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1123"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
+      "id": "checkoutsession_validateexistingdiscount",
+      "label": "validateExistingDiscount()",
+      "norm_label": "validateexistingdiscount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1321"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -61398,154 +61659,163 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
-      "label": "buildCycleCountDraftSubmissionKey()",
-      "norm_label": "buildcyclecountdraftsubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L64"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
-      "label": "createCycleCountDraftWithCtx()",
-      "norm_label": "createcyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
-      "label": "discardCycleCountDraftCommandWithCtx()",
-      "norm_label": "discardcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
-      "label": "ensureCycleCountDraftCommandWithCtx()",
-      "norm_label": "ensurecyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
-      "label": "ensureCycleCountDraftWithCtx()",
-      "norm_label": "ensurecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L190"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
-      "label": "findOpenCycleCountDraftWithCtx()",
-      "norm_label": "findopencyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L79"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
-      "label": "getActiveCycleCountDraftWithCtx()",
-      "norm_label": "getactivecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L219"
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
-      "label": "getCycleCountDraftLineWithCtx()",
-      "norm_label": "getcyclecountdraftlinewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L110"
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
-      "label": "listCycleCountDraftLinesWithCtx()",
-      "norm_label": "listcyclecountdraftlineswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L99"
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
-      "label": "listStaleCycleCountDraftLines()",
-      "norm_label": "liststalecyclecountdraftlines()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L427"
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_mapcyclecountdrafterror",
-      "label": "mapCycleCountDraftError()",
-      "norm_label": "mapcyclecountdrafterror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L591"
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
-      "label": "refreshCycleCountDraftSummaryWithCtx()",
-      "norm_label": "refreshcyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L125"
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
-      "label": "requireCycleCountDraftAccess()",
-      "norm_label": "requirecyclecountdraftaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L32"
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
-      "label": "saveCycleCountDraftLineCommandWithCtx()",
-      "norm_label": "savecyclecountdraftlinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L267"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
-      "label": "submitCycleCountDraftCommandWithCtx()",
-      "norm_label": "submitcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L460"
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "cyclecountdrafts_trimrequiredscopekey",
-      "label": "trimRequiredScopeKey()",
-      "norm_label": "trimrequiredscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
-      "label": "cycleCountDrafts.ts",
-      "norm_label": "cyclecountdrafts.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
     },
     {
@@ -61771,7 +62041,7 @@
       "label": "createApprovalDecisionMutationCtx()",
       "norm_label": "createapprovaldecisionmutationctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L31"
+      "source_location": "L32"
     },
     {
       "community": 236,
@@ -61780,7 +62050,7 @@
       "label": "createSubmissionMutationCtx()",
       "norm_label": "createsubmissionmutationctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L176"
+      "source_location": "L177"
     },
     {
       "community": 236,
@@ -61789,7 +62059,7 @@
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L27"
+      "source_location": "L28"
     },
     {
       "community": 236,
@@ -64462,7 +64732,7 @@
       "label": "applyStockAdjustmentBatchWithCtx()",
       "norm_label": "applystockadjustmentbatchwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L202"
+      "source_location": "L204"
     },
     {
       "community": 29,
@@ -64471,7 +64741,7 @@
       "label": "assertDistinctStockAdjustmentLineItems()",
       "norm_label": "assertdistinctstockadjustmentlineitems()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L126"
+      "source_location": "L128"
     },
     {
       "community": 29,
@@ -64480,7 +64750,7 @@
       "label": "assertNormalizedLineItem()",
       "norm_label": "assertnormalizedlineitem()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L156"
+      "source_location": "L158"
     },
     {
       "community": 29,
@@ -64489,7 +64759,7 @@
       "label": "buildResolvedStockAdjustmentStatus()",
       "norm_label": "buildresolvedstockadjustmentstatus()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L260"
+      "source_location": "L262"
     },
     {
       "community": 29,
@@ -64498,7 +64768,7 @@
       "label": "buildStockAdjustmentDecisionEventType()",
       "norm_label": "buildstockadjustmentdecisioneventtype()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L250"
+      "source_location": "L252"
     },
     {
       "community": 29,
@@ -64507,7 +64777,7 @@
       "label": "buildStockAdjustmentSourceId()",
       "norm_label": "buildstockadjustmentsourceid()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L142"
+      "source_location": "L144"
     },
     {
       "community": 29,
@@ -64516,7 +64786,7 @@
       "label": "buildStockAdjustmentTitle()",
       "norm_label": "buildstockadjustmenttitle()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L146"
+      "source_location": "L148"
     },
     {
       "community": 29,
@@ -64525,7 +64795,7 @@
       "label": "getStockAdjustmentScopeKey()",
       "norm_label": "getstockadjustmentscopekey()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L69"
+      "source_location": "L71"
     },
     {
       "community": 29,
@@ -64534,7 +64804,7 @@
       "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
       "norm_label": "listproductskusforstockadjustmentscopewithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L73"
+      "source_location": "L75"
     },
     {
       "community": 29,
@@ -64543,7 +64813,7 @@
       "label": "mapSubmitStockAdjustmentBatchError()",
       "norm_label": "mapsubmitstockadjustmentbatcherror()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L726"
+      "source_location": "L735"
     },
     {
       "community": 29,
@@ -64552,7 +64822,7 @@
       "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
       "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L266"
+      "source_location": "L268"
     },
     {
       "community": 29,
@@ -64561,7 +64831,7 @@
       "label": "submitStockAdjustmentBatchCommandWithCtx()",
       "norm_label": "submitstockadjustmentbatchcommandwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L779"
+      "source_location": "L788"
     },
     {
       "community": 29,
@@ -64570,7 +64840,7 @@
       "label": "submitStockAdjustmentBatchWithCtx()",
       "norm_label": "submitstockadjustmentbatchwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L536"
+      "source_location": "L538"
     },
     {
       "community": 29,
@@ -64579,7 +64849,7 @@
       "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
       "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L455"
+      "source_location": "L457"
     },
     {
       "community": 29,
@@ -64588,7 +64858,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L64"
+      "source_location": "L66"
     },
     {
       "community": 29,
@@ -72364,7 +72634,7 @@
       "label": "createCycleCountDraftCtx()",
       "norm_label": "createcyclecountdraftctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts",
-      "source_location": "L19"
+      "source_location": "L22"
     },
     {
       "community": 480,
@@ -83610,200 +83880,200 @@
     {
       "community": 9,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "label": "buildActiveCycleCountDraftsSubmissionKey()",
+      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L90"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
+      "label": "buildCycleCountDraftSubmissionKey()",
+      "norm_label": "buildcyclecountdraftsubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L75"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L117"
+      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
+      "label": "createCycleCountDraftWithCtx()",
+      "norm_label": "createcyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L190"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L80"
+      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
+      "label": "discardCycleCountDraftCommandWithCtx()",
+      "norm_label": "discardcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L481"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L114"
+      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
+      "label": "ensureCycleCountDraftCommandWithCtx()",
+      "norm_label": "ensurecyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L347"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L132"
+      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
+      "label": "ensureCycleCountDraftWithCtx()",
+      "norm_label": "ensurecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L235"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
+      "label": "findOpenCycleCountDraftWithCtx()",
+      "norm_label": "findopencyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L103"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L111"
+      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "label": "getActiveCycleCountDraftSummaryWithCtx()",
+      "norm_label": "getactivecyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L289"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L143"
+      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
+      "label": "getActiveCycleCountDraftWithCtx()",
+      "norm_label": "getactivecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L264"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_getrawconfig",
-      "label": "getRawConfig()",
-      "norm_label": "getrawconfig()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_getstoreconfigv2",
-      "label": "getStoreConfigV2()",
-      "norm_label": "getstoreconfigv2()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_getstorefallbackimageurl",
-      "label": "getStoreFallbackImageUrl()",
-      "norm_label": "getstorefallbackimageurl()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L479"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_isstoremaintenancemode",
-      "label": "isStoreMaintenanceMode()",
-      "norm_label": "isstoremaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_isstorereadonlymode",
-      "label": "isStoreReadOnlyMode()",
-      "norm_label": "isstorereadonlymode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L461"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_mappromo",
-      "label": "mapPromo()",
-      "norm_label": "mappromo()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "storeconfig_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
+      "label": "getCycleCountDraftLineWithCtx()",
+      "norm_label": "getcyclecountdraftlinewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L155"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L126"
+      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
+      "label": "listCycleCountDraftLinesWithCtx()",
+      "norm_label": "listcyclecountdraftlineswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L144"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "storeconfig_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L177"
+      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "label": "listOpenCycleCountDraftsWithCtx()",
+      "norm_label": "listopencyclecountdraftswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
+      "label": "listStaleCycleCountDraftLines()",
+      "norm_label": "liststalecyclecountdraftlines()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_mapcyclecountdrafterror",
+      "label": "mapCycleCountDraftError()",
+      "norm_label": "mapcyclecountdrafterror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L904"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
+      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L530"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
+      "label": "refreshCycleCountDraftSummaryWithCtx()",
+      "norm_label": "refreshcyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "label": "requireCycleCountDraftAccess()",
+      "norm_label": "requirecyclecountdraftaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
+      "label": "saveCycleCountDraftLineCommandWithCtx()",
+      "norm_label": "savecyclecountdraftlinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
+      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L776"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
+      "label": "submitCycleCountDraftCommandWithCtx()",
+      "norm_label": "submitcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "cyclecountdrafts_trimrequiredscopekey",
+      "label": "trimRequiredScopeKey()",
+      "norm_label": "trimrequiredscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "label": "cycleCountDrafts.ts",
+      "norm_label": "cyclecountdrafts.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L1"
     },
     {
       "community": 90,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1573
-- Graph nodes: 4257
-- Graph edges: 3921
+- Graph nodes: 4263
+- Graph edges: 3939
 - Communities: 1501
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `RegisterSessionView.tsx` (27 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storeConfigV2.ts` (27 edges, Community 5) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `sessionCommands.ts` (20 edges, Community 11) - [`packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts)
-- `expenseSessionCommands.ts` (19 edges, Community 12) - [`packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts)
-- `ProductStock.tsx` (19 edges, Community 13) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
+- `cycleCountDrafts.ts` (21 edges, Community 9) - [`packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts`](../../../packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts)
+- `sessionCommands.ts` (20 edges, Community 12) - [`packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts)
+- `expenseSessionCommands.ts` (19 edges, Community 13) - [`packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 9) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 10) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 31) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 9) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 10) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts
+++ b/packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts
@@ -15,6 +15,8 @@ export const stockAdjustmentBatchSchema = v.object({
   lineItemCount: v.number(),
   netQuantityDelta: v.number(),
   largestAbsoluteDelta: v.number(),
+  highVarianceFlag: v.optional(v.boolean()),
+  varianceThreshold: v.optional(v.number()),
   approvalRequired: v.boolean(),
   createdByUserId: v.optional(v.id("athenaUser")),
   operationalWorkItemId: v.optional(v.id("operationalWorkItem")),

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -16,6 +16,7 @@ import {
   assertDistinctStockAdjustmentLineItems,
   assertStockAdjustmentReasonCode,
   calculateCycleCountQuantityDelta,
+  hasHighStockAdjustmentVariance,
   requiresStockAdjustmentApproval,
   resolveStockAdjustmentApprovalDecisionWithCtx,
   resolveStockAdjustmentQuantityDelta,
@@ -426,7 +427,7 @@ describe("stock ops adjustments", () => {
     ).toThrow("Cycle counts must reconcile with the cycle-count reason code.");
   });
 
-  it("requires approval when a batch crosses the variance threshold", () => {
+  it("requires manual adjustment approval when a batch crosses the variance threshold", () => {
     const belowThreshold = summarizeStockAdjustmentLineItems([
       { quantityDelta: STOCK_ADJUSTMENT_APPROVAL_THRESHOLD - 1 },
       { quantityDelta: -1 },
@@ -435,8 +436,26 @@ describe("stock ops adjustments", () => {
       { quantityDelta: STOCK_ADJUSTMENT_APPROVAL_THRESHOLD },
     ]);
 
-    expect(requiresStockAdjustmentApproval(belowThreshold)).toBe(false);
-    expect(requiresStockAdjustmentApproval(atThreshold)).toBe(true);
+    expect(hasHighStockAdjustmentVariance(belowThreshold)).toBe(false);
+    expect(hasHighStockAdjustmentVariance(atThreshold)).toBe(true);
+    expect(
+      requiresStockAdjustmentApproval({
+        adjustmentType: "manual",
+        largestAbsoluteDelta: belowThreshold.largestAbsoluteDelta,
+      })
+    ).toBe(false);
+    expect(
+      requiresStockAdjustmentApproval({
+        adjustmentType: "manual",
+        largestAbsoluteDelta: atThreshold.largestAbsoluteDelta,
+      })
+    ).toBe(true);
+    expect(
+      requiresStockAdjustmentApproval({
+        adjustmentType: "cycle_count",
+        largestAbsoluteDelta: atThreshold.largestAbsoluteDelta,
+      })
+    ).toBe(false);
   });
 
   it("requires typed quantities that match the adjustment mode", () => {
@@ -662,6 +681,54 @@ describe("stock ops adjustments", () => {
       expect.objectContaining({
         actorUserId: "operator-1",
         quantityDelta: -2,
+      }),
+    ]);
+  });
+
+  it("applies high-variance cycle counts immediately and flags the batch", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "pos_only",
+    });
+
+    await submitStockAdjustmentBatchWithCtx(ctx, {
+      adjustmentType: "cycle_count",
+      lineItems: [
+        {
+          countedQuantity: 14,
+          productSkuId: "sku-1" as Id<"productSku">,
+        },
+      ],
+      reasonCode: "cycle_count_reconciliation",
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "submission-cycle-count-high-variance",
+    });
+
+    expect(Array.from(tables.stockAdjustmentBatch.values())).toEqual([
+      expect.objectContaining({
+        adjustmentType: "cycle_count",
+        approvalRequired: false,
+        highVarianceFlag: true,
+        largestAbsoluteDelta: 6,
+        status: "applied",
+        varianceThreshold: STOCK_ADJUSTMENT_APPROVAL_THRESHOLD,
+      }),
+    ]);
+    expect(tables.approvalRequest.size).toBe(0);
+    expect(tables.operationalWorkItem.size).toBe(0);
+    expect(Array.from(tables.inventoryMovement.values())).toEqual([
+      expect.objectContaining({
+        quantityDelta: 6,
+        reasonCode: "cycle_count_reconciliation",
+      }),
+    ]);
+    expect(Array.from(tables.operationalEvent.values())).toEqual([
+      expect.objectContaining({
+        eventType: "stock_adjustment_applied",
+        metadata: expect.objectContaining({
+          highVarianceFlag: true,
+          largestAbsoluteDelta: 6,
+        }),
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -18,6 +18,7 @@ import {
   STOCK_ADJUSTMENT_APPROVAL_THRESHOLD,
   assertStockAdjustmentReasonCode,
   calculateCycleCountQuantityDelta,
+  hasHighStockAdjustmentVariance,
   requiresStockAdjustmentApproval,
   resolveStockAdjustmentQuantityDelta,
   summarizeStockAdjustmentLineItems,
@@ -31,6 +32,7 @@ export {
   STOCK_ADJUSTMENT_APPROVAL_THRESHOLD,
   assertStockAdjustmentReasonCode,
   calculateCycleCountQuantityDelta,
+  hasHighStockAdjustmentVariance,
   requiresStockAdjustmentApproval,
   resolveStockAdjustmentQuantityDelta,
   summarizeStockAdjustmentLineItems,
@@ -597,7 +599,11 @@ export async function submitStockAdjustmentBatchWithCtx(
   );
 
   const summary = summarizeStockAdjustmentLineItems(normalizedLineItems);
-  const approvalRequired = requiresStockAdjustmentApproval(summary);
+  const highVarianceFlag = hasHighStockAdjustmentVariance(summary);
+  const approvalRequired = requiresStockAdjustmentApproval({
+    adjustmentType: args.adjustmentType,
+    largestAbsoluteDelta: summary.largestAbsoluteDelta,
+  });
   const now = Date.now();
   const notes = trimOptional(args.notes);
 
@@ -609,6 +615,7 @@ export async function submitStockAdjustmentBatchWithCtx(
     lineItemCount: summary.lineItemCount,
     lineItems: normalizedLineItems,
     largestAbsoluteDelta: summary.largestAbsoluteDelta,
+    highVarianceFlag,
     netQuantityDelta: summary.netQuantityDelta,
     notes,
     organizationId: store.organizationId,
@@ -616,6 +623,7 @@ export async function submitStockAdjustmentBatchWithCtx(
     status: approvalRequired ? "pending_approval" : "applied",
     storeId: args.storeId,
     submissionKey,
+    varianceThreshold: STOCK_ADJUSTMENT_APPROVAL_THRESHOLD,
     ...(approvalRequired ? null : { appliedAt: now }),
   });
 
@@ -703,6 +711,7 @@ export async function submitStockAdjustmentBatchWithCtx(
     metadata: {
       adjustmentType: args.adjustmentType,
       approvalRequired,
+      highVarianceFlag,
       largestAbsoluteDelta: summary.largestAbsoluteDelta,
       lineItemCount: summary.lineItemCount,
       netQuantityDelta: summary.netQuantityDelta,

--- a/packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts
+++ b/packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts
@@ -4,8 +4,11 @@ import type { Id } from "../_generated/dataModel";
 import {
   discardCycleCountDraftCommandWithCtx,
   ensureCycleCountDraftCommandWithCtx,
+  getActiveCycleCountDraftSummaryWithCtx,
+  refreshCycleCountDraftLineBaselineCommandWithCtx,
   saveCycleCountDraftLineCommandWithCtx,
   submitCycleCountDraftCommandWithCtx,
+  submitActiveCycleCountDraftsCommandWithCtx,
 } from "./cycleCountDrafts";
 
 const mockedAuthServer = vi.hoisted(() => ({
@@ -227,6 +230,140 @@ describe("cycle count drafts", () => {
       baselineInventoryCount: 8,
       countedQuantity: 5,
       staleStatus: "stale",
+    });
+  });
+
+  it("refreshes a stale draft line baseline to the current stock count", async () => {
+    const { ctx, tables } = createCycleCountDraftCtx();
+    const ensured = await ensureCycleCountDraftCommandWithCtx(ctx, {
+      scopeKey: "Hair",
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(ensured.kind).toBe("ok");
+    if (ensured.kind !== "ok") return;
+
+    await saveCycleCountDraftLineCommandWithCtx(ctx, {
+      countedQuantity: 5,
+      draftId: ensured.data.draft._id,
+      productSkuId: "sku-1" as Id<"productSku">,
+    });
+    await ctx.db.patch("productSku", "sku-1" as Id<"productSku">, {
+      inventoryCount: 9,
+      quantityAvailable: 7,
+    });
+
+    const refreshed = await refreshCycleCountDraftLineBaselineCommandWithCtx(ctx, {
+      productSkuId: "sku-1" as Id<"productSku">,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(refreshed.kind).toBe("ok");
+    expect(Array.from(tables.cycleCountDraftLine.values())[0]).toMatchObject({
+      baselineAvailableCount: 7,
+      baselineInventoryCount: 9,
+      countedQuantity: 9,
+      isDirty: false,
+      staleStatus: "current",
+    });
+    expect(tables.cycleCountDraft.get(String(ensured.data.draft._id))).toMatchObject({
+      changedLineCount: 0,
+      staleLineCount: 0,
+    });
+  });
+
+  it("summarizes changed open drafts across scopes for the operator", async () => {
+    const { ctx } = createCycleCountDraftCtx();
+    const hairDraft = await ensureCycleCountDraftCommandWithCtx(ctx, {
+      scopeKey: "Hair",
+      storeId: "store-1" as Id<"store">,
+    });
+    const beveragesDraft = await ensureCycleCountDraftCommandWithCtx(ctx, {
+      scopeKey: "Beverages",
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(hairDraft.kind).toBe("ok");
+    expect(beveragesDraft.kind).toBe("ok");
+    if (hairDraft.kind !== "ok" || beveragesDraft.kind !== "ok") return;
+
+    await saveCycleCountDraftLineCommandWithCtx(ctx, {
+      countedQuantity: 5,
+      draftId: hairDraft.data.draft._id,
+      productSkuId: "sku-1" as Id<"productSku">,
+    });
+    await saveCycleCountDraftLineCommandWithCtx(ctx, {
+      countedQuantity: 6,
+      draftId: beveragesDraft.data.draft._id,
+      productSkuId: "sku-1" as Id<"productSku">,
+    });
+
+    const summary = await getActiveCycleCountDraftSummaryWithCtx(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(summary).toMatchObject({
+      changedLineCount: 2,
+      draftCount: 2,
+      largestAbsoluteDelta: 3,
+      netQuantityDelta: -5,
+      scopeKeys: ["Beverages", "Hair"],
+      scopeCount: 2,
+      staleLineCount: 0,
+    });
+    expect(summary.lastSavedAt).toEqual(expect.any(Number));
+  });
+
+  it("submits changed drafts across scopes for the active store", async () => {
+    const { ctx, tables } = createCycleCountDraftCtx();
+    tables.productSku.set("sku-2", {
+      _id: "sku-2",
+      inventoryCount: 12,
+      productId: "product-2",
+      productName: "Body wave bundle",
+      quantityAvailable: 12,
+      sku: "BW-24",
+      storeId: "store-1",
+    });
+    const hairDraft = await ensureCycleCountDraftCommandWithCtx(ctx, {
+      scopeKey: "Hair",
+      storeId: "store-1" as Id<"store">,
+    });
+    const beveragesDraft = await ensureCycleCountDraftCommandWithCtx(ctx, {
+      scopeKey: "Beverages",
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(hairDraft.kind).toBe("ok");
+    expect(beveragesDraft.kind).toBe("ok");
+    if (hairDraft.kind !== "ok" || beveragesDraft.kind !== "ok") return;
+
+    await saveCycleCountDraftLineCommandWithCtx(ctx, {
+      countedQuantity: 5,
+      draftId: hairDraft.data.draft._id,
+      productSkuId: "sku-1" as Id<"productSku">,
+    });
+    await saveCycleCountDraftLineCommandWithCtx(ctx, {
+      countedQuantity: 10,
+      draftId: beveragesDraft.data.draft._id,
+      productSkuId: "sku-2" as Id<"productSku">,
+    });
+
+    const submitted = await submitActiveCycleCountDraftsCommandWithCtx(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(submitted.kind).toBe("ok");
+    expect(Array.from(tables.stockAdjustmentBatch.values())[0]).toMatchObject({
+      adjustmentType: "cycle_count",
+      lineItemCount: 2,
+      status: "applied",
+    });
+    expect(tables.cycleCountDraft.get(String(hairDraft.data.draft._id))).toMatchObject({
+      status: "submitted",
+    });
+    expect(tables.cycleCountDraft.get(String(beveragesDraft.data.draft._id))).toMatchObject({
+      status: "submitted",
     });
   });
 

--- a/packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts
+++ b/packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts
@@ -19,6 +19,17 @@ type CycleCountDraftWithLines = {
   lines: Doc<"cycleCountDraftLine">[];
 };
 
+type ActiveCycleCountDraftSummary = {
+  changedLineCount: number;
+  draftCount: number;
+  largestAbsoluteDelta: number;
+  lastSavedAt?: number;
+  netQuantityDelta: number;
+  scopeKeys: string[];
+  scopeCount: number;
+  staleLineCount: number;
+};
+
 type StaleCycleCountDraftLine = {
   productSkuId: Id<"productSku">;
   sku?: string | null;
@@ -76,6 +87,19 @@ function buildCycleCountDraftSubmissionKey(args: {
   ].join(":");
 }
 
+function buildActiveCycleCountDraftsSubmissionKey(args: {
+  draftIds: Id<"cycleCountDraft">[];
+  ownerUserId: Id<"athenaUser">;
+  storeId: Id<"store">;
+}) {
+  return [
+    "cycle-count-drafts",
+    String(args.storeId),
+    String(args.ownerUserId),
+    ...args.draftIds.map(String).sort(),
+  ].join(":");
+}
+
 async function findOpenCycleCountDraftWithCtx(
   ctx: CycleCountDraftAccessCtx,
   args: {
@@ -94,6 +118,27 @@ async function findOpenCycleCountDraftWithCtx(
         .eq("ownerUserId", args.ownerUserId),
     )
     .first();
+}
+
+async function listOpenCycleCountDraftsWithCtx(
+  ctx: CycleCountDraftAccessCtx,
+  args: {
+    ownerUserId: Id<"athenaUser">;
+    storeId: Id<"store">;
+  },
+) {
+  // eslint-disable-next-line @convex-dev/no-collect-in-query -- Operators need a small store-wide summary of their open count drafts across scopes.
+  return ctx.db
+    .query("cycleCountDraft")
+    .withIndex("by_storeId_status_scope_owner", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "open"),
+    )
+    .collect()
+    .then((drafts) =>
+      drafts.filter((draft) => draft.ownerUserId === args.ownerUserId),
+    );
 }
 
 async function listCycleCountDraftLinesWithCtx(
@@ -238,6 +283,64 @@ export async function getActiveCycleCountDraftWithCtx(
   return {
     draft,
     lines: await listCycleCountDraftLinesWithCtx(ctx, draft._id),
+  };
+}
+
+export async function getActiveCycleCountDraftSummaryWithCtx(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+  },
+): Promise<ActiveCycleCountDraftSummary> {
+  const { actorUser } = await requireCycleCountDraftAccess(ctx, args.storeId);
+  const drafts = await listOpenCycleCountDraftsWithCtx(ctx, {
+    ownerUserId: actorUser._id,
+    storeId: args.storeId,
+  });
+  const changedDrafts = drafts.filter((draft) => draft.changedLineCount > 0);
+  const scopeKeys = Array.from(
+    new Set(changedDrafts.map((draft) => draft.scopeKey)),
+  ).sort((left, right) => left.localeCompare(right));
+  const changedDraftLines = (
+    await Promise.all(
+      changedDrafts.map((draft) => listCycleCountDraftLinesWithCtx(ctx, draft._id)),
+    )
+  )
+    .flat()
+    .filter((line) => line.isDirty);
+  const lastSavedAt = changedDrafts.reduce<number | undefined>(
+    (latestSavedAt, draft) =>
+      latestSavedAt === undefined || draft.updatedAt > latestSavedAt
+        ? draft.updatedAt
+        : latestSavedAt,
+    undefined,
+  );
+
+  return {
+    changedLineCount: changedDrafts.reduce(
+      (total, draft) => total + draft.changedLineCount,
+      0,
+    ),
+    draftCount: drafts.length,
+    largestAbsoluteDelta: changedDraftLines.reduce(
+      (largestDelta, line) =>
+        Math.max(
+          largestDelta,
+          Math.abs(line.countedQuantity - line.baselineInventoryCount),
+        ),
+      0,
+    ),
+    lastSavedAt,
+    netQuantityDelta: changedDraftLines.reduce(
+      (total, line) => total + line.countedQuantity - line.baselineInventoryCount,
+      0,
+    ),
+    scopeKeys,
+    scopeCount: scopeKeys.length,
+    staleLineCount: changedDrafts.reduce(
+      (total, draft) => total + draft.staleLineCount,
+      0,
+    ),
   };
 }
 
@@ -424,6 +527,88 @@ export async function discardCycleCountDraftCommandWithCtx(
   }
 }
 
+export async function refreshCycleCountDraftLineBaselineCommandWithCtx(
+  ctx: MutationCtx,
+  args: {
+    productSkuId: Id<"productSku">;
+    storeId: Id<"store">;
+  },
+): Promise<CommandResult<any>> {
+  try {
+    const { actorUser, store } = await requireCycleCountDraftAccess(
+      ctx,
+      args.storeId,
+    );
+    const productSku = await ctx.db.get("productSku", args.productSkuId);
+
+    if (!productSku || productSku.storeId !== args.storeId) {
+      throw new Error("Selected SKU could not be found for this store.");
+    }
+
+    const drafts = await listOpenCycleCountDraftsWithCtx(ctx, {
+      ownerUserId: actorUser._id,
+      storeId: args.storeId,
+    });
+    const draftLineEntries = await Promise.all(
+      drafts.map(async (draft) => ({
+        draft,
+        line: await getCycleCountDraftLineWithCtx(ctx, {
+          draftId: draft._id,
+          productSkuId: args.productSkuId,
+        }),
+      })),
+    );
+    const draftLineEntry = draftLineEntries.find((entry) => entry.line);
+
+    if (!draftLineEntry?.line) {
+      throw new Error("Cycle count draft line not found.");
+    }
+
+    const now = Date.now();
+
+    await ctx.db.patch("cycleCountDraftLine", draftLineEntry.line._id, {
+      baselineAvailableCount: productSku.quantityAvailable,
+      baselineInventoryCount: productSku.inventoryCount,
+      countedQuantity: productSku.inventoryCount,
+      currentAvailableCount: productSku.quantityAvailable,
+      currentInventoryCount: productSku.inventoryCount,
+      isDirty: false,
+      staleStatus: "current",
+      updatedAt: now,
+    });
+    const summary = await refreshCycleCountDraftSummaryWithCtx(
+      ctx,
+      draftLineEntry.draft._id,
+      now,
+    );
+    await ctx.db.patch("cycleCountDraft", draftLineEntry.draft._id, {
+      lastSavedAt: now,
+      ...summary,
+    });
+    await recordOperationalEventWithCtx(ctx, {
+      actorUserId: actorUser._id,
+      eventType: "cycle_count_draft_baseline_refreshed",
+      message: "Cycle count draft baseline refreshed.",
+      metadata: {
+        productSkuId: String(args.productSkuId),
+        scopeKey: draftLineEntry.draft.scopeKey,
+      },
+      organizationId: store.organizationId,
+      storeId: args.storeId,
+      subjectId: String(draftLineEntry.draft._id),
+      subjectLabel: "Cycle count draft",
+      subjectType: "cycle_count_draft",
+    });
+
+    return ok({
+      draft: await ctx.db.get("cycleCountDraft", draftLineEntry.draft._id),
+      line: await ctx.db.get("cycleCountDraftLine", draftLineEntry.line._id),
+    });
+  } catch (error) {
+    return mapCycleCountDraftError(error);
+  }
+}
+
 async function listStaleCycleCountDraftLines(
   ctx: MutationCtx,
   lines: Doc<"cycleCountDraftLine">[],
@@ -588,6 +773,134 @@ export async function submitCycleCountDraftCommandWithCtx(
   }
 }
 
+export async function submitActiveCycleCountDraftsCommandWithCtx(
+  ctx: MutationCtx,
+  args: {
+    notes?: string;
+    storeId: Id<"store">;
+  },
+): Promise<CommandResult<any>> {
+  try {
+    const { actorUser, store } = await requireCycleCountDraftAccess(
+      ctx,
+      args.storeId,
+    );
+    const drafts = await listOpenCycleCountDraftsWithCtx(ctx, {
+      ownerUserId: actorUser._id,
+      storeId: args.storeId,
+    });
+    const changedDrafts = drafts.filter((draft) => draft.changedLineCount > 0);
+    const draftLines = await Promise.all(
+      changedDrafts.map(async (draft) => ({
+        draft,
+        lines: (await listCycleCountDraftLinesWithCtx(ctx, draft._id)).filter(
+          (line) => line.isDirty,
+        ),
+      })),
+    );
+    const lines = draftLines.flatMap((entry) => entry.lines);
+
+    if (lines.length === 0) {
+      throw new Error("Change at least one count before submitting.");
+    }
+
+    const staleLines = await listStaleCycleCountDraftLines(ctx, lines);
+
+    if (staleLines.length > 0) {
+      const now = Date.now();
+
+      await Promise.all(
+        staleLines.map((line) => {
+          const draftLine = lines.find(
+            (candidateLine) => candidateLine.productSkuId === line.productSkuId,
+          );
+
+          return draftLine
+            ? ctx.db.patch("cycleCountDraftLine", draftLine._id, {
+                currentAvailableCount: line.currentAvailableCount,
+                currentInventoryCount: line.currentInventoryCount,
+                staleStatus: "stale",
+                updatedAt: now,
+              })
+            : null;
+        }),
+      );
+      await Promise.all(
+        changedDrafts.map((draft) =>
+          refreshCycleCountDraftSummaryWithCtx(ctx, draft._id, now),
+        ),
+      );
+
+      return userError({
+        code: "precondition_failed",
+        message: "Inventory changed since this count started. Review the affected SKUs before submitting.",
+        metadata: {
+          staleLines,
+        },
+        title: "Review changed inventory",
+      });
+    }
+
+    const batch = await submitStockAdjustmentBatchWithCtx(ctx, {
+      adjustmentType: "cycle_count",
+      lineItems: lines.map((line) => ({
+        countedQuantity: line.countedQuantity,
+        productSkuId: line.productSkuId,
+      })),
+      notes: args.notes,
+      reasonCode: CYCLE_COUNT_REASON_CODE,
+      storeId: args.storeId,
+      submissionKey: buildActiveCycleCountDraftsSubmissionKey({
+        draftIds: changedDrafts.map((draft) => draft._id),
+        ownerUserId: actorUser._id,
+        storeId: args.storeId,
+      }),
+    });
+    const now = Date.now();
+
+    await Promise.all(
+      changedDrafts.map((draft) =>
+        ctx.db.patch("cycleCountDraft", draft._id, {
+          notes: args.notes?.trim() || undefined,
+          status: "submitted",
+          submittedAt: now,
+          submittedStockAdjustmentBatchId: batch?._id,
+          updatedAt: now,
+        }),
+      ),
+    );
+    await Promise.all(
+      changedDrafts.map((draft) =>
+        recordOperationalEventWithCtx(ctx, {
+          actorUserId: actorUser._id,
+          eventType: "cycle_count_draft_submitted",
+          message: "Cycle count draft submitted.",
+          metadata: {
+            lineItemCount:
+              draftLines.find((entry) => entry.draft._id === draft._id)?.lines
+                .length ?? 0,
+            scopeKey: draft.scopeKey,
+            stockAdjustmentBatchId: batch?._id ? String(batch._id) : undefined,
+          },
+          organizationId: store.organizationId,
+          storeId: draft.storeId,
+          subjectId: String(draft._id),
+          subjectLabel: "Cycle count draft",
+          subjectType: "cycle_count_draft",
+        }),
+      ),
+    );
+
+    return ok({
+      batch,
+      draftCount: changedDrafts.length,
+      status: "submitted",
+    });
+  } catch (error) {
+    return mapCycleCountDraftError(error);
+  }
+}
+
 function mapCycleCountDraftError(error: unknown): CommandResult<never> {
   const message = error instanceof Error ? error.message : "";
 
@@ -602,7 +915,8 @@ function mapCycleCountDraftError(error: unknown): CommandResult<never> {
   if (
     message === "Store not found." ||
     message === "Selected SKU could not be found for this store." ||
-    message === "Cycle count draft not found."
+    message === "Cycle count draft not found." ||
+    message === "Cycle count draft line not found."
   ) {
     return userError({ code: "not_found", message });
   }
@@ -625,6 +939,13 @@ export const getActiveCycleCountDraft = query({
     storeId: v.id("store"),
   },
   handler: getActiveCycleCountDraftWithCtx,
+});
+
+export const getActiveCycleCountDraftSummary = query({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: getActiveCycleCountDraftSummaryWithCtx,
 });
 
 export const ensureCycleCountDraft = mutation({
@@ -654,6 +975,15 @@ export const discardCycleCountDraft = mutation({
   handler: discardCycleCountDraftCommandWithCtx,
 });
 
+export const refreshCycleCountDraftLineBaseline = mutation({
+  args: {
+    productSkuId: v.id("productSku"),
+    storeId: v.id("store"),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: refreshCycleCountDraftLineBaselineCommandWithCtx,
+});
+
 export const submitCycleCountDraft = mutation({
   args: {
     draftId: v.id("cycleCountDraft"),
@@ -661,4 +991,13 @@ export const submitCycleCountDraft = mutation({
   },
   returns: commandResultValidator(v.any()),
   handler: submitCycleCountDraftCommandWithCtx,
+});
+
+export const submitActiveCycleCountDrafts = mutation({
+  args: {
+    notes: v.optional(v.string()),
+    storeId: v.id("store"),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: submitActiveCycleCountDraftsCommandWithCtx,
 });

--- a/packages/athena-webapp/shared/stockAdjustment.ts
+++ b/packages/athena-webapp/shared/stockAdjustment.ts
@@ -93,8 +93,17 @@ export function summarizeStockAdjustmentLineItems(
   );
 }
 
-export function requiresStockAdjustmentApproval(args: {
+export function hasHighStockAdjustmentVariance(args: {
   largestAbsoluteDelta: number;
 }) {
   return args.largestAbsoluteDelta >= STOCK_ADJUSTMENT_APPROVAL_THRESHOLD;
+}
+
+export function requiresStockAdjustmentApproval(args: {
+  adjustmentType: StockAdjustmentType;
+  largestAbsoluteDelta: number;
+}) {
+  return (
+    args.adjustmentType === "manual" && hasHighStockAdjustmentVariance(args)
+  );
 }

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx
@@ -55,6 +55,7 @@ describe("OperationsQueueView auth readiness", () => {
       "skip",
       "skip",
       "skip",
+      "skip",
     ]);
   });
 
@@ -72,6 +73,7 @@ describe("OperationsQueueView auth readiness", () => {
       "skip",
       "skip",
       "skip",
+      "skip",
     ]);
   });
 
@@ -86,6 +88,7 @@ describe("OperationsQueueView auth readiness", () => {
       { storeId: "store-1" },
       { storeId: "store-1" },
       "skip",
+      { storeId: "store-1" },
     ]);
   });
 });

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -332,6 +332,9 @@ describe("OperationsQueueViewContent", () => {
       scopeKey: "Hair",
       storeId: "store-1",
     });
+    expect(mockedHooks.useQuery.mock.calls[3]?.[1]).toEqual({
+      storeId: "store-1",
+    });
     await waitFor(() =>
       expect(ensureCycleCountDraft).toHaveBeenCalledWith({
         scopeKey: "Hair",
@@ -362,6 +365,9 @@ describe("OperationsQueueViewContent", () => {
     );
 
     expect(mockedHooks.useQuery.mock.calls[2]?.[1]).toBe("skip");
+    expect(mockedHooks.useQuery.mock.calls[3]?.[1]).toEqual({
+      storeId: "store-1",
+    });
   });
 
   it("collapses unexpected approval failures to the shared fallback toast", async () => {

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -17,6 +17,7 @@ import {
   StockAdjustmentWorkspaceContent,
 } from "./StockAdjustmentWorkspace";
 import type {
+  CycleCountDraftSummary,
   CycleCountDraftState,
   InventorySnapshotItem,
   StockAdjustmentSearchPatch,
@@ -171,6 +172,7 @@ type OperationsQueueViewContentProps = {
   activeWorkflow?: OperationsWorkflow;
   approvalRequests: QueueApprovalRequest[];
   cycleCountDraft?: CycleCountDraftState | null;
+  cycleCountDraftSummary?: CycleCountDraftSummary | null;
   hasFullAdminAccess: boolean;
   inventoryItems: InventorySnapshotItem[];
   isCycleCountDraftSaving?: boolean;
@@ -183,6 +185,9 @@ type OperationsQueueViewContentProps = {
     decision: "approved" | "rejected";
   }) => Promise<void>;
   onDiscardCycleCountDraft?: () => Promise<NormalizedCommandResult<unknown>>;
+  onRefreshCycleCountDraftLineBaseline?: (args: {
+    productSkuId: Id<"productSku">;
+  }) => Promise<NormalizedCommandResult<unknown>>;
   onSaveCycleCountDraftLine?: (args: {
     countedQuantity: number;
     productSkuId: Id<"productSku">;
@@ -203,6 +208,7 @@ export function OperationsQueueViewContent({
   activeWorkflow,
   approvalRequests,
   cycleCountDraft,
+  cycleCountDraftSummary,
   hasFullAdminAccess,
   inventoryItems,
   isCycleCountDraftSaving,
@@ -212,6 +218,7 @@ export function OperationsQueueViewContent({
   isSubmittingStockBatch,
   onDecideApprovalRequest,
   onDiscardCycleCountDraft,
+  onRefreshCycleCountDraftLineBaseline,
   onSaveCycleCountDraftLine,
   onSubmitStockBatch,
   onSubmitCycleCountDraft,
@@ -252,10 +259,14 @@ export function OperationsQueueViewContent({
         {resolvedWorkflow === "stock" ? (
           <StockAdjustmentWorkspaceContent
             cycleCountDraft={cycleCountDraft}
+            cycleCountDraftSummary={cycleCountDraftSummary}
             inventoryItems={inventoryItems}
             isCycleCountDraftSaving={isCycleCountDraftSaving}
             isSubmitting={isSubmittingStockBatch}
             onDiscardCycleCountDraft={onDiscardCycleCountDraft}
+            onRefreshCycleCountDraftLineBaseline={
+              onRefreshCycleCountDraftLineBaseline
+            }
             onSearchStateChange={onStockAdjustmentSearchChange}
             onSaveCycleCountDraftLine={onSaveCycleCountDraftLine}
             onSubmitBatch={onSubmitStockBatch}
@@ -463,6 +474,14 @@ export function OperationsQueueView({
       }
     | null
     | undefined;
+  const activeCycleCountDraftSummary = useQuery(
+    stockOpsApi.cycleCountDrafts.getActiveCycleCountDraftSummary,
+    canQueryProtectedData && activeStore?._id
+      ? {
+          storeId: activeStore._id,
+        }
+      : "skip",
+  ) as CycleCountDraftSummary | undefined;
   const submitStockAdjustmentBatch = useMutation(
     stockOpsApi.adjustments.submitStockAdjustmentBatch,
   );
@@ -478,8 +497,11 @@ export function OperationsQueueView({
   const discardCycleCountDraft = useMutation(
     stockOpsApi.cycleCountDrafts.discardCycleCountDraft,
   );
+  const refreshCycleCountDraftLineBaseline = useMutation(
+    stockOpsApi.cycleCountDrafts.refreshCycleCountDraftLineBaseline,
+  );
   const submitCycleCountDraft = useMutation(
-    stockOpsApi.cycleCountDrafts.submitCycleCountDraft,
+    stockOpsApi.cycleCountDrafts.submitActiveCycleCountDrafts,
   );
   const cycleCountDraft = useMemo<CycleCountDraftState | null>(() => {
     if (!activeCycleCountDraft?.draft) return null;
@@ -570,8 +592,8 @@ export function OperationsQueueView({
   };
 
   const handleSubmitCycleCountDraft = async (args: { notes?: string }) => {
-    if (!cycleCountDraft) {
-      return buildMissingDraftResult("Select a count scope before submitting a count.");
+    if (!activeStore?._id) {
+      return buildMissingDraftResult("Select a store before submitting a count.");
     }
 
     setIsSubmittingStockBatch(true);
@@ -579,12 +601,33 @@ export function OperationsQueueView({
     try {
       return await runCommand(() =>
         submitCycleCountDraft({
-          draftId: cycleCountDraft._id,
           notes: args.notes,
+          storeId: activeStore._id,
         }),
       );
     } finally {
       setIsSubmittingStockBatch(false);
+    }
+  };
+
+  const handleRefreshCycleCountDraftLineBaseline = async (args: {
+    productSkuId: Id<"productSku">;
+  }) => {
+    if (!activeStore?._id) {
+      return buildMissingDraftResult("Select a store before refreshing stock.");
+    }
+
+    setIsSavingCycleCountDraft(true);
+
+    try {
+      return await runCommand(() =>
+        refreshCycleCountDraftLineBaseline({
+          productSkuId: args.productSkuId,
+          storeId: activeStore._id,
+        }),
+      );
+    } finally {
+      setIsSavingCycleCountDraft(false);
     }
   };
 
@@ -654,6 +697,7 @@ export function OperationsQueueView({
       activeWorkflow={activeWorkflow}
       approvalRequests={queue?.approvalRequests ?? []}
       cycleCountDraft={cycleCountDraft}
+      cycleCountDraftSummary={activeCycleCountDraftSummary ?? null}
       hasFullAdminAccess={hasFullAdminAccess}
       inventoryItems={inventoryItems ?? []}
       isCycleCountDraftSaving={isSavingCycleCountDraft}
@@ -662,6 +706,9 @@ export function OperationsQueueView({
       isLoadingQueue={queue === undefined || inventoryItems === undefined}
       onDiscardCycleCountDraft={handleDiscardCycleCountDraft}
       onDecideApprovalRequest={handleDecideApprovalRequest}
+      onRefreshCycleCountDraftLineBaseline={
+        handleRefreshCycleCountDraftLineBaseline
+      }
       onSaveCycleCountDraftLine={handleSaveCycleCountDraftLine}
       isSubmittingStockBatch={isSubmittingStockBatch}
       onSubmitStockBatch={handleSubmitStockBatch}

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -218,7 +218,155 @@ describe("StockAdjustmentWorkspaceContent", () => {
     });
 
     expect(screen.getByLabelText(/counted quantity for .*closure wig/i)).toHaveValue(5);
-    expect(screen.getByText(/1 row saved in this draft/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/overall draft: 1 SKU saved across 1 scope/i),
+    ).toBeInTheDocument();
+  });
+
+  it("hides discard when the active count has no saved SKU changes", () => {
+    renderStockAdjustmentWorkspace({
+      cycleCountDraft: {
+        _id: "draft-1" as Id<"cycleCountDraft">,
+        changedLineCount: 0,
+        lines: [],
+        scopeKey: "Hair",
+        staleLineCount: 0,
+        status: "open",
+      },
+      onDiscardCycleCountDraft: vi.fn().mockResolvedValue(ok({})),
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /discard draft/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides discard after a cycle count is applied", async () => {
+    const user = userEvent.setup();
+    const onSubmitCycleCountDraft = vi.fn().mockResolvedValue(ok({}));
+
+    renderStockAdjustmentWorkspace({
+      cycleCountDraft: {
+        _id: "draft-1" as Id<"cycleCountDraft">,
+        changedLineCount: 1,
+        lines: [
+          {
+            baselineAvailableCount: 6,
+            baselineInventoryCount: 8,
+            countedQuantity: 5,
+            isDirty: true,
+            productSkuId: "sku-1" as Id<"productSku">,
+          },
+        ],
+        scopeKey: "Hair",
+        staleLineCount: 0,
+        status: "open",
+      },
+      onDiscardCycleCountDraft: vi.fn().mockResolvedValue(ok({})),
+      onSubmitCycleCountDraft,
+    });
+
+    expect(
+      screen.getByRole("button", { name: /discard draft/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /submit count/i }));
+
+    await waitFor(() =>
+      expect(mockedToast.success).toHaveBeenCalledWith("Count applied"),
+    );
+    expect(
+      screen.queryByRole("button", { name: /discard draft/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("summarizes saved draft rows across all scopes in the batch rail", () => {
+    renderStockAdjustmentWorkspace({
+      cycleCountDraft: {
+        _id: "draft-1" as Id<"cycleCountDraft">,
+        changedLineCount: 2,
+        lastSavedAt: 1000,
+        lines: [
+          {
+            baselineAvailableCount: 6,
+            baselineInventoryCount: 8,
+            countedQuantity: 5,
+            isDirty: true,
+            productSkuId: "sku-1" as Id<"productSku">,
+          },
+          {
+            baselineAvailableCount: 3,
+            baselineInventoryCount: 3,
+            countedQuantity: 7,
+            isDirty: true,
+            productSkuId: "sku-2" as Id<"productSku">,
+          },
+        ],
+        scopeKey: "Hair",
+        staleLineCount: 0,
+        status: "open",
+      },
+      cycleCountDraftSummary: {
+        changedLineCount: 5,
+        draftCount: 3,
+        largestAbsoluteDelta: 4,
+        lastSavedAt: 2000,
+        netQuantityDelta: -9,
+        scopeKeys: ["Beverages", "Hair"],
+        scopeCount: 3,
+        staleLineCount: 0,
+      },
+    });
+
+    expect(
+      screen.getByText(/overall draft: 5 SKUs saved across 3 scopes/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/current: hair, 2 SKUs/i)).toBeInTheDocument();
+    expect(screen.getByText(/scopes: beverages, hair/i)).toBeInTheDocument();
+    expect(screen.getByText("Count metrics")).toBeInTheDocument();
+    expect(screen.getByText("Overall draft")).toBeInTheDocument();
+    expect(screen.getByText("Current scope")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("-9")).toBeInTheDocument();
+    expect(screen.getAllByText("SKUs").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Net").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Variance").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("4").length).toBeGreaterThan(0);
+  });
+
+  it("submits the overall cycle count draft when the current scope has no changes", async () => {
+    const user = userEvent.setup();
+    const onSubmitCycleCountDraft = vi.fn().mockResolvedValue(ok({}));
+
+    renderStockAdjustmentWorkspace({
+      cycleCountDraft: {
+        _id: "draft-1" as Id<"cycleCountDraft">,
+        changedLineCount: 0,
+        lines: [],
+        scopeKey: "Hair",
+        staleLineCount: 0,
+        status: "open",
+      },
+      cycleCountDraftSummary: {
+        changedLineCount: 5,
+        draftCount: 2,
+        largestAbsoluteDelta: 4,
+        netQuantityDelta: 23,
+        scopeKeys: ["Beverages", "Hair Tools"],
+        scopeCount: 2,
+        staleLineCount: 0,
+      },
+      onSubmitCycleCountDraft,
+    });
+
+    await user.click(screen.getByRole("button", { name: /submit count/i }));
+
+    await waitFor(() =>
+      expect(onSubmitCycleCountDraft).toHaveBeenCalledWith({ notes: undefined }),
+    );
+    expect(mockedToast.error).not.toHaveBeenCalledWith(
+      "Enter at least one counted SKU that differs from the system stock",
+    );
   });
 
   it("saves cycle count edits on blur without using the URL", async () => {
@@ -352,6 +500,63 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(mockedToast.success).not.toHaveBeenCalledWith("Count applied");
   });
 
+  it("refreshes a stale SKU baseline from the stale state", async () => {
+    const user = userEvent.setup();
+    const onRefreshCycleCountDraftLineBaseline = vi.fn().mockResolvedValue(ok({}));
+    const onSubmitCycleCountDraft = vi.fn().mockResolvedValue(
+      userError({
+        code: "precondition_failed",
+        message:
+          "Inventory changed since this count started. Review the affected SKUs before submitting.",
+        metadata: {
+          staleLines: [
+            {
+              baselineInventoryCount: 8,
+              currentInventoryCount: 9,
+              productName: "Closure wig",
+              productSkuId: "sku-1",
+              sku: "CW-18",
+            },
+          ],
+        },
+      }),
+    );
+
+    renderStockAdjustmentWorkspace({
+      cycleCountDraft: {
+        _id: "draft-1" as Id<"cycleCountDraft">,
+        changedLineCount: 1,
+        lines: [
+          {
+            baselineAvailableCount: 6,
+            baselineInventoryCount: 8,
+            countedQuantity: 5,
+            isDirty: true,
+            productSkuId: "sku-1" as Id<"productSku">,
+          },
+        ],
+        scopeKey: "Hair",
+        staleLineCount: 0,
+        status: "open",
+      },
+      onRefreshCycleCountDraftLineBaseline,
+      onSubmitCycleCountDraft,
+    });
+
+    await user.click(screen.getByRole("button", { name: /submit count/i }));
+    await user.click(await screen.findByRole("button", { name: /use latest stock/i }));
+
+    await waitFor(() =>
+      expect(onRefreshCycleCountDraftLineBaseline).toHaveBeenCalledWith({
+        productSkuId: "sku-1",
+      }),
+    );
+    expect(mockedToast.success).toHaveBeenCalledWith("Baseline refreshed");
+    expect(
+      screen.queryByText("Inventory changed since this count started."),
+    ).not.toBeInTheDocument();
+  });
+
   it("resets an edited cycle count field to the original system count", async () => {
     const user = userEvent.setup();
 
@@ -377,7 +582,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(resetButton).toBeDisabled();
   });
 
-  it("orients cycle counts around a selected category scope", async () => {
+	  it("orients cycle counts around a selected category scope", async () => {
     const user = userEvent.setup();
 
     renderStockAdjustmentWorkspace({
@@ -423,6 +628,55 @@ describe("StockAdjustmentWorkspaceContent", () => {
     );
     expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
     expect(within(table).queryByText("Ai Engineering")).not.toBeInTheDocument();
+  });
+
+  it("shows stock scopes in manual adjustment mode", async () => {
+    const user = userEvent.setup();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-1" as Id<"productSku">,
+          inventoryCount: 8,
+          productCategory: "Hair",
+          productName: "closure wig",
+          quantityAvailable: 6,
+          sku: "CW-18",
+        },
+        {
+          _id: "sku-2" as Id<"productSku">,
+          inventoryCount: 3,
+          productCategory: "Books",
+          productName: "ai engineering",
+          quantityAvailable: 3,
+          sku: "BOOK-1",
+        },
+      ],
+      searchState: {
+        mode: "manual",
+      },
+    });
+
+    expect(
+      screen.getByRole("button", { name: /books 1 sku/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /hair 1 sku/i }),
+    ).toBeInTheDocument();
+
+    const table = screen.getByRole("table");
+
+    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /books 1 sku/i }));
+
+    expect(screen.getByRole("button", { name: /books 1 sku/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
+    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
   });
 
   it("leads with the current inventory availability state", () => {
@@ -916,12 +1170,12 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     await user.click(screen.getByRole("tab", { name: /manual adjustment/i }));
 
-    expect(onSearchStateChange).toHaveBeenCalledWith({
-      mode: "manual",
-      page: 1,
-      scope: undefined,
-      sku: "sku-1",
-    });
+	    expect(onSearchStateChange).toHaveBeenCalledWith({
+	      mode: "manual",
+	      page: 1,
+	      scope: "Hair",
+	      sku: "sku-1",
+	    });
   });
 
   it("shows the active SKU detail image in the right rail", async () => {

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -15,6 +15,7 @@ import {
   CYCLE_COUNT_REASON_CODE,
   MANUAL_STOCK_ADJUSTMENT_REASON_CODES,
   STOCK_ADJUSTMENT_APPROVAL_THRESHOLD,
+  hasHighStockAdjustmentVariance,
   requiresStockAdjustmentApproval,
   summarizeStockAdjustmentLineItems,
 } from "~/shared/stockAdjustment";
@@ -111,6 +112,17 @@ export type CycleCountDraftState = {
   lines: CycleCountDraftLine[];
 };
 
+export type CycleCountDraftSummary = {
+  changedLineCount: number;
+  draftCount: number;
+  largestAbsoluteDelta: number;
+  lastSavedAt?: number;
+  netQuantityDelta: number;
+  scopeKeys: string[];
+  scopeCount: number;
+  staleLineCount: number;
+};
+
 type SaveCycleCountDraftLineArgs = {
   countedQuantity: number;
   productSkuId: Id<"productSku">;
@@ -118,6 +130,7 @@ type SaveCycleCountDraftLineArgs = {
 
 type StockAdjustmentWorkspaceContentProps = {
   cycleCountDraft?: CycleCountDraftState | null;
+  cycleCountDraftSummary?: CycleCountDraftSummary | null;
   inventoryItems: InventorySnapshotItem[];
   isCycleCountDraftSaving?: boolean;
   isSubmitting: boolean;
@@ -126,6 +139,9 @@ type StockAdjustmentWorkspaceContentProps = {
   onSaveCycleCountDraftLine?: (
     args: SaveCycleCountDraftLineArgs,
   ) => Promise<NormalizedCommandResult<unknown>>;
+  onRefreshCycleCountDraftLineBaseline?: (args: {
+    productSkuId: Id<"productSku">;
+  }) => Promise<NormalizedCommandResult<unknown>>;
   onSubmitBatch: (
     args: SubmitStockAdjustmentArgs,
   ) => Promise<NormalizedCommandResult<unknown>>;
@@ -177,7 +193,7 @@ const STOCK_ADJUSTMENT_AVAILABILITY_FILTER_LABELS: Record<
 > = {
   all: "All SKUs",
   all_available: "All available",
-  changed: "Changed rows",
+  changed: "Changed SKUs",
   unavailable: "Unavailable",
 };
 
@@ -304,10 +320,12 @@ function rowMatchesAvailabilityFilter(
 
 export function StockAdjustmentWorkspaceContent({
   cycleCountDraft,
+  cycleCountDraftSummary,
   inventoryItems,
   isCycleCountDraftSaving = false,
   isSubmitting,
   onDiscardCycleCountDraft,
+  onRefreshCycleCountDraftLineBaseline,
   onSearchStateChange,
   onSaveCycleCountDraftLine,
   onSubmitBatch,
@@ -539,12 +557,12 @@ export function StockAdjustmentWorkspaceContent({
   );
   const scopedRows = useMemo(
     () =>
-      adjustmentType === "cycle_count" && selectedCountScopeKeys.length > 0
+      selectedCountScopeKeys.length > 0
         ? rows.filter((row) =>
             selectedCountScopeKeySet.has(getCountScopeKey(row.inventoryItem)),
           )
         : rows,
-    [adjustmentType, rows, selectedCountScopeKeySet, selectedCountScopeKeys],
+    [rows, selectedCountScopeKeySet, selectedCountScopeKeys],
   );
   const normalizedFilterQuery = normalizeStockAdjustmentSearch(filters.query);
   const filteredRows = useMemo(
@@ -584,8 +602,24 @@ export function StockAdjustmentWorkspaceContent({
       quantityDelta: row.quantityDelta,
     })),
   );
+  const overallSummary =
+    adjustmentType === "cycle_count" && cycleCountDraftSummary
+      ? {
+          largestAbsoluteDelta: cycleCountDraftSummary.largestAbsoluteDelta,
+          lineItemCount: cycleCountDraftSummary.changedLineCount,
+          netQuantityDelta: cycleCountDraftSummary.netQuantityDelta,
+        }
+      : summary;
+  const highVarianceFlag =
+    overallSummary.lineItemCount > 0 &&
+    hasHighStockAdjustmentVariance(overallSummary);
   const approvalRequired =
-    changedRows.length > 0 && requiresStockAdjustmentApproval(summary);
+    adjustmentType === "manual" &&
+    changedRows.length > 0 &&
+    requiresStockAdjustmentApproval({
+      adjustmentType,
+      largestAbsoluteDelta: summary.largestAbsoluteDelta,
+    });
   const displayedReasonCode =
     adjustmentType === "manual" ? reasonCode : CYCLE_COUNT_REASON_CODE;
   const activeInventoryItem =
@@ -647,6 +681,15 @@ export function StockAdjustmentWorkspaceContent({
             : "All inventory is available.",
     };
   }, [inventoryItems]);
+  const totalDraftChangedLineCount =
+    cycleCountDraftSummary?.changedLineCount ?? cycleCountDraft?.changedLineCount ?? 0;
+  const totalDraftScopeCount = cycleCountDraftSummary?.scopeCount ?? 0;
+  const draftScopeNames = cycleCountDraftSummary?.scopeKeys ?? [];
+  const scopeDraftChangedLineCount = cycleCountDraft?.changedLineCount ?? 0;
+  const currentScopeLabel =
+    cycleCountDraft?.scopeKey ??
+    selectedCountScope?.label ??
+    (selectedCountScopeKeys[0] ? getCountScopeLabel(selectedCountScopeKeys[0]) : null);
   const cycleCountStatus = cycleCountSubmissionOutcome
     ? cycleCountSubmissionOutcome === "review_required"
       ? {
@@ -663,12 +706,15 @@ export function StockAdjustmentWorkspaceContent({
         }
     : {
         description:
-          cycleCountDraft && cycleCountDraft.changedLineCount > 0
-            ? `${cycleCountDraft.changedLineCount} ${pluralize(
-                cycleCountDraft.changedLineCount,
-                "row",
-              )} saved in this draft.`
-            : "Submit the selected category count when the physical counts are recorded.",
+          totalDraftChangedLineCount > 0
+            ? `Overall draft: ${totalDraftChangedLineCount} ${pluralize(
+                totalDraftChangedLineCount,
+                "SKU",
+              )} saved across ${totalDraftScopeCount || 1} ${pluralize(
+                totalDraftScopeCount || 1,
+                "scope",
+              )}.`
+            : "Overall draft: no saved SKUs yet.",
         label:
           isCycleCountDraftSaving
             ? "Saving draft"
@@ -677,12 +723,21 @@ export function StockAdjustmentWorkspaceContent({
               : "Count in progress",
         tone: "border-border bg-muted/40 text-foreground" as const,
       };
-  const draftLastSavedLabel = cycleCountDraft?.lastSavedAt
+  const draftLastSavedAt =
+    cycleCountDraftSummary?.lastSavedAt ?? cycleCountDraft?.lastSavedAt;
+  const draftLastSavedLabel = draftLastSavedAt
     ? new Intl.DateTimeFormat("en-US", {
         hour: "numeric",
         minute: "2-digit",
-      }).format(new Date(cycleCountDraft.lastSavedAt))
+      }).format(new Date(draftLastSavedAt))
     : null;
+  const showDraftSavedTimestamp =
+    cycleCountStatus.label === "Draft saved" && Boolean(draftLastSavedLabel);
+  const canDiscardCycleCountDraft =
+    !cycleCountSubmissionOutcome &&
+    cycleCountDraft?.status === "open" &&
+    totalDraftChangedLineCount > 0 &&
+    Boolean(onDiscardCycleCountDraft);
 
   useEffect(() => {
     if (adjustmentType !== "cycle_count") return;
@@ -1005,12 +1060,9 @@ export function StockAdjustmentWorkspaceContent({
         : countScopeOptions[0]?.key
           ? [countScopeOptions[0].key]
           : [];
-    const nextScope =
-      nextType === "cycle_count"
-        ? serializeCountScopeKeys(currentScopeKeys)
-        : undefined;
+    const nextScope = serializeCountScopeKeys(currentScopeKeys);
     const nextActiveItem =
-      nextType === "cycle_count" && currentScopeKeys.length > 0
+      currentScopeKeys.length > 0
         ? rows.find((row) =>
             currentScopeKeys.includes(getCountScopeKey(row.inventoryItem)),
           )?.inventoryItem
@@ -1129,11 +1181,15 @@ export function StockAdjustmentWorkspaceContent({
       await awaitPendingCycleCountSaves();
     }
 
-    if (changedRows.length === 0) {
+    if (
+      adjustmentType === "manual"
+        ? changedRows.length === 0
+        : overallSummary.lineItemCount === 0
+    ) {
       toast.error(
         adjustmentType === "manual"
           ? "Add at least one non-zero stock delta"
-          : "Enter at least one counted quantity that differs from the system stock",
+          : "Enter at least one counted SKU that differs from the system stock",
       );
       return;
     }
@@ -1173,9 +1229,7 @@ export function StockAdjustmentWorkspaceContent({
 
     toast.success(
       approvalRequired
-        ? adjustmentType === "cycle_count"
-          ? "Count submitted for review"
-          : "Stock batch submitted for review"
+        ? "Stock batch submitted for review"
         : adjustmentType === "manual"
           ? "Stock adjustment applied"
           : "Count applied",
@@ -1268,69 +1322,101 @@ export function StockAdjustmentWorkspaceContent({
           </Tabs>
         </div>
 
-        {adjustmentType === "cycle_count" ? (
-          <section
-            aria-labelledby="count-scope-heading"
-            className="space-y-layout-md"
-          >
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {countScopeOptions.map((scope) => {
-                const isSelected = selectedCountScopeKeySet.has(scope.key);
-
-                return (
-                  <button
-                    aria-pressed={isSelected}
-                    className={`rounded-md border px-layout-md py-layout-sm text-left transition-colors ${
-                      isSelected
-                        ? "border-action-workflow-border bg-action-workflow-soft text-foreground"
-                        : "border-border bg-background hover:bg-muted"
-                    }`}
-                    key={scope.key}
-                    onClick={() => {
-                      setSelectedCountScopeKeys([scope.key]);
-                      setCycleCountSubmissionOutcome(null);
-                      const firstScopedItem = rows.find(
-                        (row) =>
-                          getCountScopeKey(row.inventoryItem) === scope.key,
-                      )?.inventoryItem;
-
-                      setActiveInventoryItemId(firstScopedItem?._id ?? null);
-                      onSearchStateChange?.({
-                        page: 1,
-                        scope: scope.key,
-                        sku: firstScopedItem?._id,
-                      });
-                    }}
-                    type="button"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium">
-                          {scope.label}
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {scope.itemCount}{" "}
-                          {scope.itemCount === 1 ? "SKU" : "SKUs"}
-                        </p>
-                      </div>
-                      {isSelected ? (
-                        <CheckCircle2 className="h-4 w-4 shrink-0 text-action-commit" />
-                      ) : null}
-                    </div>
-                    <div className="mt-layout-sm flex items-center gap-2 text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground">
-                        {scope.changedCount}
-                      </span>
-                      <span>
-                        {scope.changedCount === 1 ? "variance" : "variances"}
-                      </span>
-                    </div>
-                  </button>
-                );
-              })}
+        <section
+          aria-labelledby="count-scope-heading"
+          className="space-y-layout-md"
+        >
+          <h2 className="sr-only" id="count-scope-heading">
+            Stock scopes
+          </h2>
+          {adjustmentType === "manual" && selectedCountScopeKeys.length > 0 ? (
+            <div className="flex justify-end">
+              <Button
+                className="h-8 px-2 text-xs"
+                onClick={() => {
+                  setSelectedCountScopeKeys([]);
+                  onSearchStateChange?.({
+                    page: 1,
+                    scope: undefined,
+                    sku: rows[0]?.inventoryItem._id,
+                  });
+                }}
+                type="button"
+                variant="outline"
+              >
+                Show all scopes
+              </Button>
             </div>
-          </section>
-        ) : null}
+          ) : null}
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {countScopeOptions.map((scope) => {
+              const isSelected = selectedCountScopeKeySet.has(scope.key);
+
+              return (
+                <button
+                  aria-pressed={isSelected}
+                  className={`rounded-md border px-layout-md py-layout-sm text-left transition-colors ${
+                    isSelected
+                      ? "border-action-workflow-border bg-action-workflow-soft text-foreground"
+                      : "border-border bg-background hover:bg-muted"
+                  }`}
+                  key={scope.key}
+                  onClick={() => {
+                    const nextScopeKeys =
+                      adjustmentType === "cycle_count"
+                        ? [scope.key]
+                        : isSelected
+                          ? selectedCountScopeKeys.filter(
+                              (selectedKey) => selectedKey !== scope.key,
+                            )
+                          : [...selectedCountScopeKeys, scope.key];
+                    const firstScopedItem =
+                      nextScopeKeys.length > 0
+                        ? rows.find((row) =>
+                            nextScopeKeys.includes(
+                              getCountScopeKey(row.inventoryItem),
+                            ),
+                          )?.inventoryItem
+                        : rows[0]?.inventoryItem;
+
+                    setSelectedCountScopeKeys(nextScopeKeys);
+                    setCycleCountSubmissionOutcome(null);
+                    setActiveInventoryItemId(firstScopedItem?._id ?? null);
+                    onSearchStateChange?.({
+                      page: 1,
+                      scope: serializeCountScopeKeys(nextScopeKeys),
+                      sku: firstScopedItem?._id,
+                    });
+                  }}
+                  type="button"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {scope.label}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {scope.itemCount}{" "}
+                        {scope.itemCount === 1 ? "SKU" : "SKUs"}
+                      </p>
+                    </div>
+                    {isSelected ? (
+                      <CheckCircle2 className="h-4 w-4 shrink-0 text-action-commit" />
+                    ) : null}
+                  </div>
+                  <div className="mt-layout-sm flex items-center gap-2 text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      {scope.changedCount}
+                    </span>
+                    <span>
+                      {scope.changedCount === 1 ? "variance" : "variances"}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </section>
 
         <section
           aria-label="SKU search and filters"
@@ -1444,26 +1530,49 @@ export function StockAdjustmentWorkspaceContent({
             {adjustmentType === "cycle_count" ? (
               <div className="space-y-3">
                 <div
-                  className={`space-y-2 rounded-md border px-layout-md py-layout-sm ${cycleCountStatus.tone}`}
+                  className={`space-y-layout-md rounded-md border px-layout-md py-layout-md ${cycleCountStatus.tone}`}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <p className="text-xs font-medium text-muted-foreground">
                       Count status
                     </p>
                     <Badge
-                      className="rounded-md border-border bg-background text-foreground"
+                      className="inline-flex items-center gap-1.5 rounded-md border-border bg-background text-foreground"
                       variant="outline"
                     >
-                      {cycleCountStatus.label}
+                      <span>{cycleCountStatus.label}</span>
+                      {showDraftSavedTimestamp ? (
+                        <>
+                          <span
+                            aria-hidden="true"
+                            className="h-3 w-px bg-border"
+                          />
+                          <span>{draftLastSavedLabel}</span>
+                        </>
+                      ) : null}
                     </Badge>
                   </div>
                   <p className="text-sm leading-6">
                     {cycleCountStatus.description}
-                    {draftLastSavedLabel ? ` Last saved ${draftLastSavedLabel}.` : ""}
                   </p>
-                  {cycleCountDraft && onDiscardCycleCountDraft ? (
+                  <div className="space-y-1.5">
+                    {cycleCountDraft && totalDraftChangedLineCount > 0 ? (
+                      <p className="text-xs leading-5 text-muted-foreground">
+                        Current:{" "}
+                        {currentScopeLabel ? `${currentScopeLabel}, ` : ""}
+                        {scopeDraftChangedLineCount}{" "}
+                        {pluralize(scopeDraftChangedLineCount, "SKU")}.
+                      </p>
+                    ) : null}
+                    {draftScopeNames.length > 0 ? (
+                      <p className="text-xs leading-5 text-muted-foreground">
+                        Scopes: {draftScopeNames.join(", ")}.
+                      </p>
+                    ) : null}
+                  </div>
+                  {canDiscardCycleCountDraft && onDiscardCycleCountDraft ? (
                     <Button
-                      className="h-8 px-2 text-xs"
+                      className="mt-layout-xs h-8 px-2 text-xs"
                       disabled={isCycleCountDraftSaving || isSubmitting}
                       onClick={async () => {
                         await awaitPendingCycleCountSaves();
@@ -1493,10 +1602,51 @@ export function StockAdjustmentWorkspaceContent({
                     </p>
                     <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
                       {staleDraftLines.map((line) => (
-                        <li key={line.productSkuId}>
-                          {line.productName ?? line.sku ?? line.productSkuId}:{" "}
-                          {line.baselineInventoryCount} to{" "}
-                          {line.currentInventoryCount} on hand.
+                        <li
+                          className="flex items-center justify-between gap-2"
+                          key={line.productSkuId}
+                        >
+                          <span>
+                            {line.productName ?? line.sku ?? line.productSkuId}:{" "}
+                            {line.baselineInventoryCount} to{" "}
+                            {line.currentInventoryCount} on hand.
+                          </span>
+                          {onRefreshCycleCountDraftLineBaseline ? (
+                            <Button
+                              className="h-7 shrink-0 px-2 text-[11px]"
+                              disabled={isCycleCountDraftSaving || isSubmitting}
+                              onClick={async () => {
+                                await awaitPendingCycleCountSaves();
+                                const result =
+                                  await onRefreshCycleCountDraftLineBaseline({
+                                    productSkuId: line.productSkuId,
+                                  });
+
+                                if (result.kind !== "ok") {
+                                  presentCommandToast(result);
+                                  return;
+                                }
+
+                                setStaleDraftLines((currentLines) =>
+                                  currentLines.filter(
+                                    (currentLine) =>
+                                      currentLine.productSkuId !== line.productSkuId,
+                                  ),
+                                );
+                                setCycleCounts((currentCounts) => ({
+                                  ...currentCounts,
+                                  [line.productSkuId]: String(
+                                    line.currentInventoryCount,
+                                  ),
+                                }));
+                                toast.success("Baseline refreshed");
+                              }}
+                              type="button"
+                              variant="outline"
+                            >
+                              Use latest stock
+                            </Button>
+                          ) : null}
                         </li>
                       ))}
                     </ul>
@@ -1504,45 +1654,125 @@ export function StockAdjustmentWorkspaceContent({
                 ) : null}
               </div>
             ) : null}
-            <div className="grid grid-cols-2 gap-layout-md">
-              <div className="space-y-1">
+            {adjustmentType === "cycle_count" ? (
+              <div className="space-y-3 border-t border-border pt-layout-md">
                 <p className="text-xs font-medium text-muted-foreground">
-                  Changed rows
+                  Count metrics
                 </p>
-                <p className="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground">
-                  {summary.lineItemCount}
-                </p>
+                <div className="grid gap-2">
+                  <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+                    <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                      Overall draft
+                    </p>
+                    <div className="mt-2 grid grid-cols-3 gap-2">
+                      <div>
+                        <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                          {overallSummary.lineItemCount}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          SKUs
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                          {overallSummary.netQuantityDelta > 0
+                            ? `+${overallSummary.netQuantityDelta}`
+                            : overallSummary.netQuantityDelta}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          Net
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                          {overallSummary.largestAbsoluteDelta}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          Variance
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="rounded-md border border-border px-3 py-3">
+                    <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                      Current scope
+                    </p>
+                    <div className="mt-2 grid grid-cols-3 gap-2">
+                      <div>
+                        <p className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
+                          {summary.lineItemCount}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          SKUs
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
+                          {summary.netQuantityDelta > 0
+                            ? `+${summary.netQuantityDelta}`
+                            : summary.netQuantityDelta}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          Net
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
+                          {summary.largestAbsoluteDelta}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          Variance
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div className="space-y-1">
-                <p className="text-xs font-medium text-muted-foreground">
-                  Net delta
-                </p>
-                <p className="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground">
-                  {summary.netQuantityDelta > 0
-                    ? `+${summary.netQuantityDelta}`
-                    : summary.netQuantityDelta}
-                </p>
-              </div>
-            </div>
-            <div className="space-y-1 border-t border-border pt-layout-md">
-              <p className="text-xs font-medium text-muted-foreground">
-                Largest variance
-              </p>
-              <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
-                {summary.largestAbsoluteDelta} units
-              </p>
-            </div>
+            ) : (
+              <>
+                <div className="grid grid-cols-2 gap-layout-md">
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Changed SKUs
+                    </p>
+                    <p className="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground">
+                      {summary.lineItemCount}
+                    </p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Net delta
+                    </p>
+                    <p className="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground">
+                      {summary.netQuantityDelta > 0
+                        ? `+${summary.netQuantityDelta}`
+                        : summary.netQuantityDelta}
+                    </p>
+                  </div>
+                </div>
+                <div className="space-y-1 border-t border-border pt-layout-md">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Largest variance
+                  </p>
+                  <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                    {summary.largestAbsoluteDelta} units
+                  </p>
+                </div>
+              </>
+            )}
             <div
               className={`rounded-md border px-layout-md py-layout-sm text-sm leading-6 ${
                 approvalRequired
                   ? "border-warning/30 bg-warning/10 text-foreground"
+                  : adjustmentType === "cycle_count" && highVarianceFlag
+                    ? "border-warning/30 bg-warning/10 text-foreground"
                   : "border-success/30 bg-success/10 text-foreground"
               }`}
             >
               {approvalRequired
-                ? adjustmentType === "cycle_count"
-                  ? "Submitting this count will open a review before inventory changes apply"
-                  : "This batch will open an approval request before inventory changes are applied"
+                ? "This batch will open an approval request before inventory changes are applied"
+                : adjustmentType === "cycle_count" && highVarianceFlag
+                  ? "Submitting this count will apply inventory movements immediately and flag the high variance"
                 : adjustmentType === "cycle_count"
                   ? "Submitting this count will apply inventory movements immediately"
                   : "This batch can apply immediately and will still write inventory movements"}
@@ -1660,8 +1890,10 @@ export function StockAdjustmentWorkspaceContent({
 
           <div className="space-y-layout-sm text-sm text-muted-foreground">
             <p>
-              Variances of {STOCK_ADJUSTMENT_APPROVAL_THRESHOLD}+ units go to
-              review.
+              Variances of {STOCK_ADJUSTMENT_APPROVAL_THRESHOLD}+ units{" "}
+              {adjustmentType === "cycle_count"
+                ? "are flagged after submission."
+                : "go to review."}
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- add durable cycle-count draft summaries across scopes with clearer batch status and metrics
- submit all active cycle-count draft scopes together and apply high-variance cycle counts immediately while flagging them for audit
- add stale-baseline recovery, manual scope filtering, and status-card UX refinements

## Validation
- bun run pr:athena
- pre-push validation suite