### PR TITLE
feat(athena): refine stock adjustment workflow

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4263 nodes · 3939 edges · 1501 communities detected
+- 4262 nodes · 3938 edges · 1501 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1611,24 +1611,24 @@ Cohesion: 0.12
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
 ### Community 18 - "Community 18"
-Cohesion: 0.12
-Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
-
-### Community 19 - "Community 19"
 Cohesion: 0.17
 Nodes (15): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), containsDisallowedRawNumericParse(), containsTerm(), isAllowedDisplayConversion() (+7 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.25
 Nodes (16): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+8 more)
 
-### Community 21 - "Community 21"
+### Community 20 - "Community 20"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 22 - "Community 22"
+### Community 21 - "Community 21"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
+
+### Community 22 - "Community 22"
+Cohesion: 0.12
+Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
 ### Community 23 - "Community 23"
 Cohesion: 0.22
@@ -1852,35 +1852,35 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 78 - "Community 78"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 79 - "Community 79"
-Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 80 - "Community 80"
+### Community 79 - "Community 79"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 81 - "Community 81"
+### Community 80 - "Community 80"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
+
+### Community 83 - "Community 83"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 84 - "Community 84"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 85 - "Community 85"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 86 - "Community 86"
 Cohesion: 0.36
@@ -2248,7 +2248,7 @@ Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.4
@@ -2259,16 +2259,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 180 - "Community 180"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 182 - "Community 182"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.4
@@ -2280,7 +2280,7 @@ Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 186 - "Community 186"
 Cohesion: 0.5
@@ -9683,5 +9683,5 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 17` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 18` be split into smaller, more focused modules?**
-  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
+- **Should `Community 20` be split into smaller, more focused modules?**
+  _Cohesion score 0.11 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -21911,7 +21911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L929",
+      "source_location": "L958",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -21959,7 +21959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L308",
+      "source_location": "L309",
       "target": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
       "weight": 1
     },
@@ -21973,18 +21973,6 @@
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L285",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "_tgt": "stockadjustmentworkspace_savecyclecountdraftvalue",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L937",
-      "target": "stockadjustmentworkspace_savecyclecountdraftvalue",
       "weight": 1
     },
     {
@@ -22007,7 +21995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L919",
+      "source_location": "L948",
       "target": "stockadjustmentworkspace_setdraftvalue",
       "weight": 1
     },
@@ -45227,7 +45215,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_setdraftvalue",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L930",
+      "source_location": "L959",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -58293,537 +58281,6 @@
     {
       "community": 177,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L212"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopekey",
-      "label": "getCountScopeKey()",
-      "norm_label": "getcountscopekey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L200"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L204"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L247"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getskudetailentries",
-      "label": "getSkuDetailEntries()",
-      "norm_label": "getskudetailentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L251"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L929"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
-      "label": "normalizeStockAdjustmentSearch()",
-      "norm_label": "normalizestockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L268"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_parsecountscopekeys",
-      "label": "parseCountScopeKeys()",
-      "norm_label": "parsecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L272"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L239"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L308"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "label": "rowMatchesStockAdjustmentSearch()",
-      "norm_label": "rowmatchesstockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L285"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_savecyclecountdraftvalue",
-      "label": "saveCycleCountDraftValue()",
-      "norm_label": "savecyclecountdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L937"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_serializecountscopekeys",
-      "label": "serializeCountScopeKeys()",
-      "norm_label": "serializecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L281"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L919"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L234"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "operationsqueueview_getapprovalrequestcopy",
-      "label": "getApprovalRequestCopy()",
-      "norm_label": "getapprovalrequestcopy()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "operationsqueueview_getdefaultworkflow",
-      "label": "getDefaultWorkflow()",
-      "norm_label": "getdefaultworkflow()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "operationsqueueview_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L579"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "operationsqueueview_setdecisioningapprovalrequestid",
-      "label": "setDecisioningApprovalRequestId()",
-      "norm_label": "setdecisioningapprovalrequestid()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L638"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -58831,7 +58288,7 @@
       "source_location": "L30"
     },
     {
-      "community": 185,
+      "community": 177,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -58840,7 +58297,7 @@
       "source_location": "L43"
     },
     {
-      "community": 185,
+      "community": 177,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -58849,7 +58306,7 @@
       "source_location": "L106"
     },
     {
-      "community": 185,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -58858,12 +58315,543 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_ancestorchain",
+      "label": "ancestorChain()",
+      "norm_label": "ancestorchain()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparses",
+      "label": "collectRawMoneyParses()",
+      "norm_label": "collectrawmoneyparses()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
+      "label": "collectRawMoneyParsesFromSource()",
+      "norm_label": "collectrawmoneyparsesfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L321"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
+      "label": "collectRawNumericHelperNames()",
+      "norm_label": "collectrawnumerichelpernames()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
+      "label": "containsDisallowedRawNumericParse()",
+      "norm_label": "containsdisallowedrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsterm",
+      "label": "containsTerm()",
+      "norm_label": "containsterm()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isalloweddisplayconversion",
+      "label": "isAllowedDisplayConversion()",
+      "norm_label": "isalloweddisplayconversion()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowednumericrounding",
+      "label": "isAllowedNumericRounding()",
+      "norm_label": "isallowednumericrounding()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowedpercentagebranch",
+      "label": "isAllowedPercentageBranch()",
+      "norm_label": "isallowedpercentagebranch()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_israwnumericparse",
+      "label": "isRawNumericParse()",
+      "norm_label": "israwnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nearestcontextnode",
+      "label": "nearestContextNode()",
+      "norm_label": "nearestcontextnode()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nodeline",
+      "label": "nodeLine()",
+      "norm_label": "nodeline()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_readwebappfile",
+      "label": "readWebappFile()",
+      "norm_label": "readwebappfile()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesmoney",
+      "label": "referencesMoney()",
+      "norm_label": "referencesmoney()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
+      "label": "referencesOnlyNonMoneyNumericContext()",
+      "norm_label": "referencesonlynonmoneynumericcontext()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_returnsrawnumericparse",
+      "label": "returnsRawNumericParse()",
+      "norm_label": "returnsrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_reviewedreason",
+      "label": "reviewedReason()",
+      "norm_label": "reviewedreason()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
+      "label": "moneyEntryAudit.test.ts",
+      "norm_label": "moneyentryaudit.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "operationsqueueview_getapprovalrequestcopy",
+      "label": "getApprovalRequestCopy()",
+      "norm_label": "getapprovalrequestcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "operationsqueueview_getdefaultworkflow",
+      "label": "getDefaultWorkflow()",
+      "norm_label": "getdefaultworkflow()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "operationsqueueview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L579"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "operationsqueueview_setdecisioningapprovalrequestid",
+      "label": "setDecisioningApprovalRequestId()",
+      "norm_label": "setdecisioningapprovalrequestid()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L638"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -59049,173 +59037,164 @@
     {
       "community": 19,
       "file_type": "code",
-      "id": "moneyentryaudit_test_ancestorchain",
-      "label": "ancestorChain()",
-      "norm_label": "ancestorchain()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparses",
-      "label": "collectRawMoneyParses()",
-      "norm_label": "collectrawmoneyparses()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L394"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
-      "label": "collectRawMoneyParsesFromSource()",
-      "norm_label": "collectrawmoneyparsesfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L321"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
-      "label": "collectRawNumericHelperNames()",
-      "norm_label": "collectrawnumerichelpernames()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
-      "label": "containsDisallowedRawNumericParse()",
-      "norm_label": "containsdisallowedrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_containsterm",
-      "label": "containsTerm()",
-      "norm_label": "containsterm()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_isalloweddisplayconversion",
-      "label": "isAllowedDisplayConversion()",
-      "norm_label": "isalloweddisplayconversion()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_isallowednumericrounding",
-      "label": "isAllowedNumericRounding()",
-      "norm_label": "isallowednumericrounding()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_isallowedpercentagebranch",
-      "label": "isAllowedPercentageBranch()",
-      "norm_label": "isallowedpercentagebranch()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_israwnumericparse",
-      "label": "isRawNumericParse()",
-      "norm_label": "israwnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_nearestcontextnode",
-      "label": "nearestContextNode()",
-      "norm_label": "nearestcontextnode()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_nodeline",
-      "label": "nodeLine()",
-      "norm_label": "nodeline()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_readwebappfile",
-      "label": "readWebappFile()",
-      "norm_label": "readwebappfile()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_referencesmoney",
-      "label": "referencesMoney()",
-      "norm_label": "referencesmoney()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
-      "label": "referencesOnlyNonMoneyNumericContext()",
-      "norm_label": "referencesonlynonmoneynumericcontext()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_returnsrawnumericparse",
-      "label": "returnsRawNumericParse()",
-      "norm_label": "returnsrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_reviewedreason",
-      "label": "reviewedReason()",
-      "norm_label": "reviewedreason()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
-      "label": "moneyEntryAudit.test.ts",
-      "norm_label": "moneyentryaudit.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
+      "label": "staffCredentials.ts",
+      "norm_label": "staffcredentials.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_assertstaffprofilereadyforcredential",
+      "label": "assertStaffProfileReadyForCredential()",
+      "norm_label": "assertstaffprofilereadyforcredential()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
+      "label": "authenticateStaffCredentialForApprovalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L566"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
+      "label": "authenticateStaffCredentialForTerminalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L505"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialwithctx",
+      "label": "authenticateStaffCredentialWithCtx()",
+      "norm_label": "authenticatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L415"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_createstaffcredentialwithctx",
+      "label": "createStaffCredentialWithCtx()",
+      "norm_label": "createstaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_getactiverolesforstaffprofile",
+      "label": "getActiveRolesForStaffProfile()",
+      "norm_label": "getactiverolesforstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyid",
+      "label": "getCredentialById()",
+      "norm_label": "getcredentialbyid()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyusername",
+      "label": "getCredentialByUsername()",
+      "norm_label": "getcredentialbyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
+      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
+      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
+      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
+      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_invalidstaffcredentialsresult",
+      "label": "invalidStaffCredentialsResult()",
+      "norm_label": "invalidstaffcredentialsresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
+      "label": "listStaffCredentialsByStoreWithCtx()",
+      "norm_label": "liststaffcredentialsbystorewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_normalizeusername",
+      "label": "normalizeUsername()",
+      "norm_label": "normalizeusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_requirenonemptyusername",
+      "label": "requireNonEmptyUsername()",
+      "norm_label": "requirenonemptyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_staffauthorizationfailedresult",
+      "label": "staffAuthorizationFailedResult()",
+      "norm_label": "staffauthorizationfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_staffpreconditionfailedresult",
+      "label": "staffPreconditionFailedResult()",
+      "norm_label": "staffpreconditionfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "staffcredentials_updatestaffcredentialwithctx",
+      "label": "updateStaffCredentialWithCtx()",
+      "norm_label": "updatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L319"
     },
     {
       "community": 190,
@@ -59967,164 +59946,164 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
-      "label": "staffCredentials.ts",
-      "norm_label": "staffcredentials.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "id": "customerrepository_createposcustomer",
+      "label": "createPosCustomer()",
+      "norm_label": "createposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_ensurecustomerprofilefromsources",
+      "label": "ensureCustomerProfileFromSources()",
+      "norm_label": "ensurecustomerprofilefromsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findcustomerbyemail",
+      "label": "findCustomerByEmail()",
+      "norm_label": "findcustomerbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findcustomerbyphone",
+      "label": "findCustomerByPhone()",
+      "norm_label": "findcustomerbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findguestbyemail",
+      "label": "findGuestByEmail()",
+      "norm_label": "findguestbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findguestbyphone",
+      "label": "findGuestByPhone()",
+      "norm_label": "findguestbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findposcustomerbyguest",
+      "label": "findPosCustomerByGuest()",
+      "norm_label": "findposcustomerbyguest()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findposcustomerbystorefrontuser",
+      "label": "findPosCustomerByStoreFrontUser()",
+      "norm_label": "findposcustomerbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findstorefrontuserbyemail",
+      "label": "findStoreFrontUserByEmail()",
+      "norm_label": "findstorefrontuserbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_findstorefrontuserbyphone",
+      "label": "findStoreFrontUserByPhone()",
+      "norm_label": "findstorefrontuserbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_getguestbyid",
+      "label": "getGuestById()",
+      "norm_label": "getguestbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_getposcustomerbyid",
+      "label": "getPosCustomerById()",
+      "norm_label": "getposcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_getstorefrontuserbyid",
+      "label": "getStoreFrontUserById()",
+      "norm_label": "getstorefrontuserbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_listactivecustomersforstore",
+      "label": "listActiveCustomersForStore()",
+      "norm_label": "listactivecustomersforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_listcompletedtransactionsforcustomer",
+      "label": "listCompletedTransactionsForCustomer()",
+      "norm_label": "listcompletedtransactionsforcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_patchposcustomer",
+      "label": "patchPosCustomer()",
+      "norm_label": "patchposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "customerrepository_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
+      "label": "customerRepository.ts",
+      "norm_label": "customerrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_assertstaffprofilereadyforcredential",
-      "label": "assertStaffProfileReadyForCredential()",
-      "norm_label": "assertstaffprofilereadyforcredential()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
-      "label": "authenticateStaffCredentialForApprovalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L566"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
-      "label": "authenticateStaffCredentialForTerminalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L505"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialwithctx",
-      "label": "authenticateStaffCredentialWithCtx()",
-      "norm_label": "authenticatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_createstaffcredentialwithctx",
-      "label": "createStaffCredentialWithCtx()",
-      "norm_label": "createstaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_getactiverolesforstaffprofile",
-      "label": "getActiveRolesForStaffProfile()",
-      "norm_label": "getactiverolesforstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyid",
-      "label": "getCredentialById()",
-      "norm_label": "getcredentialbyid()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyusername",
-      "label": "getCredentialByUsername()",
-      "norm_label": "getcredentialbyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
-      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
-      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
-      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
-      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_invalidstaffcredentialsresult",
-      "label": "invalidStaffCredentialsResult()",
-      "norm_label": "invalidstaffcredentialsresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
-      "label": "listStaffCredentialsByStoreWithCtx()",
-      "norm_label": "liststaffcredentialsbystorewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_normalizeusername",
-      "label": "normalizeUsername()",
-      "norm_label": "normalizeusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_requirenonemptyusername",
-      "label": "requireNonEmptyUsername()",
-      "norm_label": "requirenonemptyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_staffauthorizationfailedresult",
-      "label": "staffAuthorizationFailedResult()",
-      "norm_label": "staffauthorizationfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_staffpreconditionfailedresult",
-      "label": "staffPreconditionFailedResult()",
-      "norm_label": "staffpreconditionfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "staffcredentials_updatestaffcredentialwithctx",
-      "label": "updateStaffCredentialWithCtx()",
-      "norm_label": "updatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L319"
     },
     {
       "community": 200,
@@ -60579,163 +60558,163 @@
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_createposcustomer",
-      "label": "createPosCustomer()",
-      "norm_label": "createposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L57"
+      "id": "checkoutsession_calculatepromocodevalue",
+      "label": "calculatePromoCodeValue()",
+      "norm_label": "calculatepromocodevalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1447"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_ensurecustomerprofilefromsources",
-      "label": "ensureCustomerProfileFromSources()",
-      "norm_label": "ensurecustomerprofilefromsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L240"
+      "id": "checkoutsession_checkadjustedavailability",
+      "label": "checkAdjustedAvailability()",
+      "norm_label": "checkadjustedavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L990"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyemail",
-      "label": "findCustomerByEmail()",
-      "norm_label": "findcustomerbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L27"
+      "id": "checkoutsession_checkifitemshavechanged",
+      "label": "checkIfItemsHaveChanged()",
+      "norm_label": "checkifitemshavechanged()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L50"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyphone",
-      "label": "findCustomerByPhone()",
-      "norm_label": "findcustomerbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L42"
+      "id": "checkoutsession_createonlineorder",
+      "label": "createOnlineOrder()",
+      "norm_label": "createonlineorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L765"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findguestbyemail",
-      "label": "findGuestByEmail()",
-      "norm_label": "findguestbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L186"
+      "id": "checkoutsession_createpatchobject",
+      "label": "createPatchObject()",
+      "norm_label": "createpatchobject()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L651"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findguestbyphone",
-      "label": "findGuestByPhone()",
-      "norm_label": "findguestbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L222"
+      "id": "checkoutsession_createsessionitems",
+      "label": "createSessionItems()",
+      "norm_label": "createsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1102"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbyguest",
-      "label": "findPosCustomerByGuest()",
-      "norm_label": "findposcustomerbyguest()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L154"
+      "id": "checkoutsession_fetchproductskus",
+      "label": "fetchProductSkus()",
+      "norm_label": "fetchproductskus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L979"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbystorefrontuser",
-      "label": "findPosCustomerByStoreFrontUser()",
-      "norm_label": "findposcustomerbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L142"
+      "id": "checkoutsession_findbestvaluepromocode",
+      "label": "findBestValuePromoCode()",
+      "norm_label": "findbestvaluepromocode()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1495"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyemail",
-      "label": "findStoreFrontUserByEmail()",
-      "norm_label": "findstorefrontuserbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L168"
+      "id": "checkoutsession_handleexistingsession",
+      "label": "handleExistingSession()",
+      "norm_label": "handleexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1161"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyphone",
-      "label": "findStoreFrontUserByPhone()",
-      "norm_label": "findstorefrontuserbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L204"
+      "id": "checkoutsession_handleordercreation",
+      "label": "handleOrderCreation()",
+      "norm_label": "handleordercreation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L734"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_getguestbyid",
-      "label": "getGuestById()",
-      "norm_label": "getguestbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L135"
+      "id": "checkoutsession_handleplaceorder",
+      "label": "handlePlaceOrder()",
+      "norm_label": "handleplaceorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L698"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_getposcustomerbyid",
-      "label": "getPosCustomerById()",
-      "norm_label": "getposcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L20"
+      "id": "checkoutsession_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L40"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_getstorefrontuserbyid",
-      "label": "getStoreFrontUserById()",
-      "norm_label": "getstorefrontuserbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L128"
+      "id": "checkoutsession_retrieveactivecheckoutsession",
+      "label": "retrieveActiveCheckoutSession()",
+      "norm_label": "retrieveactivecheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L951"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_listactivecustomersforstore",
-      "label": "listActiveCustomersForStore()",
-      "norm_label": "listactivecustomersforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L8"
+      "id": "checkoutsession_updateavailability",
+      "label": "updateAvailability()",
+      "norm_label": "updateavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1140"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_listcompletedtransactionsforcustomer",
-      "label": "listCompletedTransactionsForCustomer()",
-      "norm_label": "listcompletedtransactionsforcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L94"
+      "id": "checkoutsession_updateexistingsession",
+      "label": "updateExistingSession()",
+      "norm_label": "updateexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1020"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_patchposcustomer",
-      "label": "patchPosCustomer()",
-      "norm_label": "patchposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L64"
+      "id": "checkoutsession_updateproductavailability",
+      "label": "updateProductAvailability()",
+      "norm_label": "updateproductavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1123"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "customerrepository_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L72"
+      "id": "checkoutsession_validateexistingdiscount",
+      "label": "validateExistingDiscount()",
+      "norm_label": "validateexistingdiscount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1321"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
-      "label": "customerRepository.ts",
-      "norm_label": "customerrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -61137,164 +61116,164 @@
     {
       "community": 22,
       "file_type": "code",
-      "id": "checkoutsession_calculatepromocodevalue",
-      "label": "calculatePromoCodeValue()",
-      "norm_label": "calculatepromocodevalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_checkadjustedavailability",
-      "label": "checkAdjustedAvailability()",
-      "norm_label": "checkadjustedavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_checkifitemshavechanged",
-      "label": "checkIfItemsHaveChanged()",
-      "norm_label": "checkifitemshavechanged()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_createonlineorder",
-      "label": "createOnlineOrder()",
-      "norm_label": "createonlineorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_createpatchobject",
-      "label": "createPatchObject()",
-      "norm_label": "createpatchobject()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_createsessionitems",
-      "label": "createSessionItems()",
-      "norm_label": "createsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_fetchproductskus",
-      "label": "fetchProductSkus()",
-      "norm_label": "fetchproductskus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_findbestvaluepromocode",
-      "label": "findBestValuePromoCode()",
-      "norm_label": "findbestvaluepromocode()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_handleexistingsession",
-      "label": "handleExistingSession()",
-      "norm_label": "handleexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_handleordercreation",
-      "label": "handleOrderCreation()",
-      "norm_label": "handleordercreation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_handleplaceorder",
-      "label": "handlePlaceOrder()",
-      "norm_label": "handleplaceorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_retrieveactivecheckoutsession",
-      "label": "retrieveActiveCheckoutSession()",
-      "norm_label": "retrieveactivecheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_updateavailability",
-      "label": "updateAvailability()",
-      "norm_label": "updateavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_updateexistingsession",
-      "label": "updateExistingSession()",
-      "norm_label": "updateexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_updateproductavailability",
-      "label": "updateProductAvailability()",
-      "norm_label": "updateproductavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "checkoutsession_validateexistingdiscount",
-      "label": "validateExistingDiscount()",
-      "norm_label": "validateexistingdiscount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L212"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L208"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopekey",
+      "label": "getCountScopeKey()",
+      "norm_label": "getcountscopekey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L200"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L204"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L247"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L251"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L958"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "label": "normalizeStockAdjustmentSearch()",
+      "norm_label": "normalizestockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L268"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_parsecountscopekeys",
+      "label": "parseCountScopeKeys()",
+      "norm_label": "parsecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L272"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L239"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L309"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "label": "rowMatchesStockAdjustmentSearch()",
+      "norm_label": "rowmatchesstockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L285"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_serializecountscopekeys",
+      "label": "serializeCountScopeKeys()",
+      "norm_label": "serializecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L281"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L948"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L234"
     },
     {
       "community": 220,
@@ -81351,73 +81330,73 @@
     {
       "community": 78,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 78,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 78,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 78,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 78,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -81603,73 +81582,73 @@
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L67"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -82080,74 +82059,74 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 800,
@@ -82332,74 +82311,74 @@
     {
       "community": 81,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 810,
@@ -82584,74 +82563,74 @@
     {
       "community": 82,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 820,
@@ -82746,74 +82725,74 @@
     {
       "community": 83,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
     },
     {
       "community": 830,
@@ -82908,74 +82887,74 @@
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2359"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
+      "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2353"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
+      "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2349"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
+      "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2369"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
+      "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2115"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
+      "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2205"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
+      "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2097"
     },
     {
       "community": 840,
@@ -83070,74 +83049,74 @@
     {
       "community": 85,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 85,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2359"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2353"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2349"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2369"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2115"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2205"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2097"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 850,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1573
-- Graph nodes: 4263
-- Graph edges: 3939
+- Graph nodes: 4262
+- Graph edges: 3938
 - Communities: 1501
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -219,7 +219,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     expect(screen.getByLabelText(/counted quantity for .*closure wig/i)).toHaveValue(5);
     expect(
-      screen.getByText(/overall draft: 1 SKU saved across 1 scope/i),
+      screen.getByText(/saved count: 1 SKU across 1 scope/i),
     ).toBeInTheDocument();
   });
 
@@ -280,7 +280,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("summarizes saved draft rows across all scopes in the batch rail", () => {
+  it("summarizes saved draft SKUs across all scopes in the batch rail", () => {
     renderStockAdjustmentWorkspace({
       cycleCountDraft: {
         _id: "draft-1" as Id<"cycleCountDraft">,
@@ -319,13 +319,13 @@ describe("StockAdjustmentWorkspaceContent", () => {
     });
 
     expect(
-      screen.getByText(/overall draft: 5 SKUs saved across 3 scopes/i),
+      screen.getByText(/saved count: 5 SKUs across 3 scopes/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/current: hair, 2 SKUs/i)).toBeInTheDocument();
     expect(screen.getByText(/scopes: beverages, hair/i)).toBeInTheDocument();
     expect(screen.getByText("Count metrics")).toBeInTheDocument();
-    expect(screen.getByText("Overall draft")).toBeInTheDocument();
-    expect(screen.getByText("Current scope")).toBeInTheDocument();
+    expect(screen.getByText("All saved counts")).toBeInTheDocument();
+    expect(screen.getByText("Selected scope")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("-9")).toBeInTheDocument();
     expect(screen.getAllByText("SKUs").length).toBeGreaterThan(0);
@@ -399,6 +399,52 @@ describe("StockAdjustmentWorkspaceContent", () => {
     );
     expect(onSearchStateChange).not.toHaveBeenCalledWith(
       expect.objectContaining({ countedQuantity: 5 }),
+    );
+  });
+
+  it("flushes the focused cycle count edit before submitting", async () => {
+    const user = userEvent.setup();
+    const onSaveCycleCountDraftLine = vi.fn().mockResolvedValue(ok({}));
+    const onSubmitCycleCountDraft = vi.fn().mockResolvedValue(ok({}));
+
+    renderStockAdjustmentWorkspace({
+      cycleCountDraft: {
+        _id: "draft-1" as Id<"cycleCountDraft">,
+        changedLineCount: 0,
+        lines: [],
+        scopeKey: "Hair",
+        staleLineCount: 0,
+        status: "open",
+      },
+      cycleCountDraftSummary: {
+        changedLineCount: 0,
+        draftCount: 0,
+        largestAbsoluteDelta: 0,
+        netQuantityDelta: 0,
+        scopeKeys: [],
+        scopeCount: 0,
+        staleLineCount: 0,
+      },
+      onSaveCycleCountDraftLine,
+      onSubmitCycleCountDraft,
+    });
+
+    const input = screen.getByLabelText(/counted quantity for .*closure wig/i);
+
+    await user.clear(input);
+    await user.type(input, "5");
+    await user.click(screen.getByRole("button", { name: /submit count/i }));
+
+    await waitFor(() =>
+      expect(onSaveCycleCountDraftLine).toHaveBeenCalledWith({
+        countedQuantity: 5,
+        productSkuId: "sku-1",
+      }),
+    );
+    await waitFor(() =>
+      expect(onSubmitCycleCountDraft).toHaveBeenCalledWith({
+        notes: undefined,
+      }),
     );
   });
 
@@ -582,7 +628,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(resetButton).toBeDisabled();
   });
 
-	  it("orients cycle counts around a selected category scope", async () => {
+  it("orients cycle counts around a selected category scope", async () => {
     const user = userEvent.setup();
 
     renderStockAdjustmentWorkspace({
@@ -614,11 +660,14 @@ describe("StockAdjustmentWorkspaceContent", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /books 1 sku/i }),
-    ).toHaveAttribute("aria-pressed", "true");
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: /show all scopes/i }),
+    ).toBeDisabled();
     const table = screen.getByRole("table");
 
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
-    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /hair 1 sku/i }));
 
@@ -626,8 +675,23 @@ describe("StockAdjustmentWorkspaceContent", () => {
       "aria-pressed",
       "true",
     );
+    expect(
+      screen.getByRole("button", { name: /show all scopes/i }),
+    ).toBeEnabled();
     expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
     expect(within(table).queryByText("Ai Engineering")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /hair 1 sku/i }));
+
+    expect(screen.getByRole("button", { name: /hair 1 sku/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(
+      screen.getByRole("button", { name: /show all scopes/i }),
+    ).toBeDisabled();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
+    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
   });
 
   it("shows stock scopes in manual adjustment mode", async () => {
@@ -736,7 +800,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(within(table).getByText("Body Wave Bundle")).toBeInTheDocument();
 
     await user.type(
-      screen.getByRole("textbox", { name: /search product skus/i }),
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
       "body",
     );
 
@@ -746,13 +812,38 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(within(table).getByText("Body Wave Bundle")).toBeInTheDocument();
 
     await user.clear(
-      screen.getByRole("textbox", { name: /search product skus/i }),
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
     );
     await user.click(
       screen.getByRole("combobox", { name: /filter by availability/i }),
     );
     await user.click(
       await screen.findByRole("option", { name: "Unavailable" }),
+    );
+
+    expect(
+      within(table).getByText('18" Natural Black Closure Wig'),
+    ).toBeInTheDocument();
+    expect(
+      within(table).queryByText("Body Wave Bundle"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 SKUs.")).toBeInTheDocument();
+  });
+
+  it("filters stock rows by barcode", async () => {
+    const user = userEvent.setup();
+
+    renderStockAdjustmentWorkspace();
+
+    const table = screen.getByRole("table");
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "1234567890123",
     );
 
     expect(
@@ -852,7 +943,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     const table = screen.getByRole("table");
 
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
-    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /unavailable 4/i }));
 
@@ -884,7 +975,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
       screen.getByRole("button", { name: /unavailable 4/i }),
     ).toHaveAttribute("aria-pressed", "false");
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
-    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
   });
 
   it("reports stock filter changes for route search", async () => {
@@ -894,7 +985,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     renderStockAdjustmentWorkspace({ onSearchStateChange });
 
     await user.type(
-      screen.getByRole("textbox", { name: /search product skus/i }),
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
       "CW",
     );
 

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -292,6 +292,7 @@ function rowMatchesStockAdjustmentSearch(
   const searchableText = [
     getInventoryItemDisplayName(item),
     item.sku,
+    item.barcode,
     item.colorName,
     item.productCategory,
     item.length === null || item.length === undefined
@@ -367,7 +368,7 @@ export function StockAdjustmentWorkspaceContent({
   const [pendingCycleCountSaveCount, setPendingCycleCountSaveCount] =
     useState(0);
   const pendingCycleCountSavePromisesRef = useRef<Promise<void>[]>([]);
-  const locallyEditedCycleCountItemIdsRef = useRef(new Set<string>());
+  const locallyEditedCycleCountItemIdsRef = useRef(new Set<Id<"productSku">>());
   const [staleDraftLines, setStaleDraftLines] = useState<
     Array<{
       productSkuId: Id<"productSku">;
@@ -459,6 +460,51 @@ export function StockAdjustmentWorkspaceContent({
         ]),
       ),
     [cycleCountDraft?.lines],
+  );
+  const saveCycleCountDraftValue = useCallback(
+    async (productSkuId: Id<"productSku">, value: string) => {
+      if (adjustmentType !== "cycle_count" || !onSaveCycleCountDraftLine) {
+        return;
+      }
+
+      const parsedCount = value.trim() === "" ? Number.NaN : Number(value);
+      if (!Number.isInteger(parsedCount) || parsedCount < 0) {
+        return;
+      }
+
+      const savePromise = onSaveCycleCountDraftLine({
+        countedQuantity: parsedCount,
+        productSkuId,
+      })
+        .then((result) => {
+          if (result.kind !== "ok") {
+            presentCommandToast(result);
+            return;
+          }
+
+          locallyEditedCycleCountItemIdsRef.current.delete(productSkuId);
+        })
+        .finally(() => {
+          pendingCycleCountSavePromisesRef.current =
+            pendingCycleCountSavePromisesRef.current.filter(
+              (pendingSave) => pendingSave !== savePromise,
+            );
+          setPendingCycleCountSaveCount(
+            pendingCycleCountSavePromisesRef.current.length,
+          );
+        });
+
+      pendingCycleCountSavePromisesRef.current = [
+        ...pendingCycleCountSavePromisesRef.current,
+        savePromise,
+      ];
+      setPendingCycleCountSaveCount(
+        pendingCycleCountSavePromisesRef.current.length,
+      );
+
+      await savePromise;
+    },
+    [adjustmentType, onSaveCycleCountDraftLine],
   );
 
   const rows: StockAdjustmentRow[] = useMemo(
@@ -707,14 +753,14 @@ export function StockAdjustmentWorkspaceContent({
     : {
         description:
           totalDraftChangedLineCount > 0
-            ? `Overall draft: ${totalDraftChangedLineCount} ${pluralize(
+            ? `Saved count: ${totalDraftChangedLineCount} ${pluralize(
                 totalDraftChangedLineCount,
                 "SKU",
-              )} saved across ${totalDraftScopeCount || 1} ${pluralize(
+              )} across ${totalDraftScopeCount || 1} ${pluralize(
                 totalDraftScopeCount || 1,
                 "scope",
               )}.`
-            : "Overall draft: no saved SKUs yet.",
+            : "No saved counts yet.",
         label:
           isCycleCountDraftSaving
             ? "Saving draft"
@@ -741,40 +787,23 @@ export function StockAdjustmentWorkspaceContent({
 
   useEffect(() => {
     if (adjustmentType !== "cycle_count") return;
+    if (selectedCountScopeKeys.length === 0) return;
 
-    if (
-      selectedCountScopeKeys.length > 0 &&
-      selectedCountScopeKeys.every((selectedKey) =>
-        countScopeOptions.some((scope) => scope.key === selectedKey),
-      )
-    ) {
-      return;
-    }
+    const validScopeKeys = selectedCountScopeKeys.filter((selectedKey) =>
+      countScopeOptions.some((scope) => scope.key === selectedKey),
+    );
+    if (validScopeKeys.length === selectedCountScopeKeys.length) return;
 
-    const fallbackScopeKey = countScopeOptions[0]?.key;
-
-    if (!fallbackScopeKey) {
-      if (selectedCountScopeKeys.length === 0) return;
-
-      setSelectedCountScopeKeys([]);
-      return;
-    }
-
-    setSelectedCountScopeKeys([fallbackScopeKey]);
-    const firstScopedItem = rows.find(
-      (row) => getCountScopeKey(row.inventoryItem) === fallbackScopeKey,
-    )?.inventoryItem;
-
+    setSelectedCountScopeKeys(validScopeKeys);
     onSearchStateChange?.({
       page: 1,
-      scope: fallbackScopeKey,
-      sku: firstScopedItem?._id,
+      scope: serializeCountScopeKeys(validScopeKeys),
+      sku: undefined,
     });
   }, [
     adjustmentType,
     countScopeOptions,
     onSearchStateChange,
-    rows,
     selectedCountScopeKeys,
   ]);
 
@@ -934,49 +963,6 @@ export function StockAdjustmentWorkspaceContent({
               setStaleDraftLines([]);
             }
           };
-          const saveCycleCountDraftValue = async (value: string) => {
-            if (adjustmentType !== "cycle_count" || !onSaveCycleCountDraftLine) {
-              return;
-            }
-
-            const parsedCount = value.trim() === "" ? Number.NaN : Number(value);
-            if (!Number.isInteger(parsedCount) || parsedCount < 0) {
-              return;
-            }
-
-            const savePromise = onSaveCycleCountDraftLine({
-              countedQuantity: parsedCount,
-              productSkuId: item._id,
-            })
-              .then((result) => {
-                if (result.kind !== "ok") {
-                  presentCommandToast(result);
-                  return;
-                }
-
-                locallyEditedCycleCountItemIdsRef.current.delete(item._id);
-              })
-              .finally(() => {
-                pendingCycleCountSavePromisesRef.current =
-                  pendingCycleCountSavePromisesRef.current.filter(
-                    (pendingSave) => pendingSave !== savePromise,
-                  );
-                setPendingCycleCountSaveCount(
-                  pendingCycleCountSavePromisesRef.current.length,
-                );
-              });
-
-            pendingCycleCountSavePromisesRef.current = [
-              ...pendingCycleCountSavePromisesRef.current,
-              savePromise,
-            ];
-            setPendingCycleCountSaveCount(
-              pendingCycleCountSavePromisesRef.current.length,
-            );
-
-            await savePromise;
-          };
-
           return (
             <div className="ml-auto flex max-w-56 items-center justify-end gap-2">
               <Input
@@ -986,7 +972,7 @@ export function StockAdjustmentWorkspaceContent({
                 min={adjustmentType === "manual" ? undefined : 0}
                 onFocus={() => handleSelectInventoryItem(item._id)}
                 onBlur={(event) =>
-                  saveCycleCountDraftValue(event.currentTarget.value)
+                  saveCycleCountDraftValue(item._id, event.currentTarget.value)
                 }
                 onChange={(event) => handleDraftChange(event.target.value)}
                 type="number"
@@ -1003,7 +989,7 @@ export function StockAdjustmentWorkspaceContent({
                   if (adjustmentType === "cycle_count") {
                     setCycleCountSubmissionOutcome(null);
                     setStaleDraftLines([]);
-                    void saveCycleCountDraftValue(resetValue);
+                    void saveCycleCountDraftValue(item._id, resetValue);
                   }
                 }}
                 size="icon"
@@ -1044,7 +1030,7 @@ export function StockAdjustmentWorkspaceContent({
         ),
       },
     ],
-    [adjustmentType, handleSelectInventoryItem, onSaveCycleCountDraftLine],
+    [adjustmentType, handleSelectInventoryItem, saveCycleCountDraftValue],
   );
 
   const handleModeChange = (nextType: StockAdjustmentType) => {
@@ -1055,11 +1041,7 @@ export function StockAdjustmentWorkspaceContent({
     }
 
     const currentScopeKeys =
-      selectedCountScopeKeys.length > 0
-        ? selectedCountScopeKeys
-        : countScopeOptions[0]?.key
-          ? [countScopeOptions[0].key]
-          : [];
+      selectedCountScopeKeys.length > 0 ? selectedCountScopeKeys : [];
     const nextScope = serializeCountScopeKeys(currentScopeKeys);
     const nextActiveItem =
       currentScopeKeys.length > 0
@@ -1114,9 +1096,7 @@ export function StockAdjustmentWorkspaceContent({
     if (inventoryState.unavailableUnits === 0) return;
 
     if (isUnavailableScopeSelectionActive) {
-      setSelectedCountScopeKeys(
-        countScopeOptions[0]?.key ? [countScopeOptions[0].key] : [],
-      );
+      setSelectedCountScopeKeys([]);
       setFilters((current) => ({
         ...current,
         availability: "all",
@@ -1171,6 +1151,20 @@ export function StockAdjustmentWorkspaceContent({
     await Promise.allSettled(pendingSaves);
   };
 
+  const flushLocallyEditedCycleCountDraftLines = async () => {
+    await awaitPendingCycleCountSaves();
+
+    const editedItemIds = Array.from(locallyEditedCycleCountItemIdsRef.current);
+    if (editedItemIds.length === 0) return;
+
+    await Promise.allSettled(
+      editedItemIds.map((itemId) =>
+        saveCycleCountDraftValue(itemId, cycleCounts[itemId] ?? ""),
+      ),
+    );
+    await awaitPendingCycleCountSaves();
+  };
+
   const handleSubmit = async () => {
     if (!storeId) {
       toast.error("Select a store before submitting a stock adjustment");
@@ -1178,13 +1172,13 @@ export function StockAdjustmentWorkspaceContent({
     }
 
     if (adjustmentType === "cycle_count") {
-      await awaitPendingCycleCountSaves();
+      await flushLocallyEditedCycleCountDraftLines();
     }
 
     if (
       adjustmentType === "manual"
         ? changedRows.length === 0
-        : overallSummary.lineItemCount === 0
+        : overallSummary.lineItemCount === 0 && changedRows.length === 0
     ) {
       toast.error(
         adjustmentType === "manual"
@@ -1329,25 +1323,24 @@ export function StockAdjustmentWorkspaceContent({
           <h2 className="sr-only" id="count-scope-heading">
             Stock scopes
           </h2>
-          {adjustmentType === "manual" && selectedCountScopeKeys.length > 0 ? (
-            <div className="flex justify-end">
-              <Button
-                className="h-8 px-2 text-xs"
-                onClick={() => {
-                  setSelectedCountScopeKeys([]);
-                  onSearchStateChange?.({
-                    page: 1,
-                    scope: undefined,
-                    sku: rows[0]?.inventoryItem._id,
-                  });
-                }}
-                type="button"
-                variant="outline"
-              >
-                Show all scopes
-              </Button>
-            </div>
-          ) : null}
+          <div className="flex justify-end">
+            <Button
+              className="h-8 px-2 text-xs"
+              disabled={selectedCountScopeKeys.length === 0}
+              onClick={() => {
+                setSelectedCountScopeKeys([]);
+                onSearchStateChange?.({
+                  page: 1,
+                  scope: undefined,
+                  sku: rows[0]?.inventoryItem._id,
+                });
+              }}
+              type="button"
+              variant="outline"
+            >
+              Show all scopes
+            </Button>
+          </div>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             {countScopeOptions.map((scope) => {
               const isSelected = selectedCountScopeKeySet.has(scope.key);
@@ -1364,7 +1357,9 @@ export function StockAdjustmentWorkspaceContent({
                   onClick={() => {
                     const nextScopeKeys =
                       adjustmentType === "cycle_count"
-                        ? [scope.key]
+                        ? isSelected
+                          ? []
+                          : [scope.key]
                         : isSelected
                           ? selectedCountScopeKeys.filter(
                               (selectedKey) => selectedKey !== scope.key,
@@ -1425,7 +1420,7 @@ export function StockAdjustmentWorkspaceContent({
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div className="min-w-0 flex-1">
               <Label className="sr-only" htmlFor="stock-adjustment-sku-search">
-                Search product SKUs
+                Search products, SKUs, or barcodes
               </Label>
               <div className="relative">
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -1434,7 +1429,7 @@ export function StockAdjustmentWorkspaceContent({
                   onChange={(event) =>
                     handleFilterChange({ query: event.target.value })
                   }
-                  placeholder="Search product or SKU"
+                  placeholder="Search product, SKU, or barcode"
                   value={filters.query}
                   className="pl-9"
                 />
@@ -1662,7 +1657,7 @@ export function StockAdjustmentWorkspaceContent({
                 <div className="grid gap-2">
                   <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
                     <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                      Overall draft
+                      All saved counts
                     </p>
                     <div className="mt-2 grid grid-cols-3 gap-2">
                       <div>
@@ -1695,7 +1690,7 @@ export function StockAdjustmentWorkspaceContent({
                   </div>
                   <div className="rounded-md border border-border px-3 py-3">
                     <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                      Current scope
+                      Selected scope
                     </p>
                     <div className="mt-2 grid grid-cols-3 gap-2">
                       <div>
@@ -1729,36 +1724,44 @@ export function StockAdjustmentWorkspaceContent({
                 </div>
               </div>
             ) : (
-              <>
-                <div className="grid grid-cols-2 gap-layout-md">
-                  <div className="space-y-1">
-                    <p className="text-xs font-medium text-muted-foreground">
-                      Changed SKUs
-                    </p>
-                    <p className="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground">
-                      {summary.lineItemCount}
-                    </p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-xs font-medium text-muted-foreground">
-                      Net delta
-                    </p>
-                    <p className="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground">
-                      {summary.netQuantityDelta > 0
-                        ? `+${summary.netQuantityDelta}`
-                        : summary.netQuantityDelta}
-                    </p>
+              <div className="space-y-3">
+                <p className="text-xs font-medium text-muted-foreground">
+                  Adjustment metrics
+                </p>
+                <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+                  <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                    Manual batch
+                  </p>
+                  <div className="mt-2 grid grid-cols-3 gap-2">
+                    <div>
+                      <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                        {summary.lineItemCount}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        SKUs
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                        {summary.netQuantityDelta > 0
+                          ? `+${summary.netQuantityDelta}`
+                          : summary.netQuantityDelta}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        Net
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+                        {summary.largestAbsoluteDelta}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        Variance
+                      </p>
+                    </div>
                   </div>
                 </div>
-                <div className="space-y-1 border-t border-border pt-layout-md">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Largest variance
-                  </p>
-                  <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
-                    {summary.largestAbsoluteDelta} units
-                  </p>
-                </div>
-              </>
+              </div>
             )}
             <div
               className={`rounded-md border px-layout-md py-layout-sm text-sm leading-6 ${
@@ -1909,6 +1912,11 @@ export function StockAdjustmentWorkspaceContent({
                 (isCycleCountDraftSaving || pendingCycleCountSaveCount > 0))
             }
             onClick={handleSubmit}
+            onMouseDown={(event) => {
+              if (adjustmentType === "cycle_count") {
+                event.preventDefault();
+              }
+            }}
           >
             {adjustmentType === "manual" ? "Submit adjustment" : "Submit count"}
           </LoadingButton>


### PR DESCRIPTION
## Summary
- refine cycle-count scope behavior so operators can deselect scopes without automatic fallback selection
- keep the Show all scopes control stable while disabling it when no scope is selected
- align manual adjustment summary metrics with the cycle-count metric card layout
- add barcode matching to stock adjustment search
- flush focused cycle-count edits before submit so the latest typed count is saved

## Validation
- bun run --cwd packages/athena-webapp test src/components/operations/StockAdjustmentWorkspace.test.tsx
- bun run --cwd packages/athena-webapp typecheck
- bun run graphify:rebuild
- git diff --check
- bun run pre-push:review
- git push -u origin codex/stock-adjustments-workflow (normal hook path; pre-push suite passed)
