### PR TITLE
chore: harden agent delivery workflow gates

### DIFF
--- a/.agents/skills/ce-commit-push-pr/SKILL.md
+++ b/.agents/skills/ce-commit-push-pr/SKILL.md
@@ -222,4 +222,12 @@ The new commits are already on the PR from Step 5. Report the PR URL, then ask w
 
 ### Step 8: Report
 
-Output the PR URL.
+If this PR is part of an execution or delivery workflow that should merge when required checks pass, arm auto-merge after the PR is ready and local merge-level validation has passed. In Athena, use the worktree-safe repo helper:
+
+```bash
+bun run github:pr-merge -- <pr-number-or-url> --auto --method squash
+```
+
+Pending required checks are expected after auto-merge is armed. Failed or cancelled checks are not a handoff state; inspect and fix them.
+
+Output the PR URL and whether auto-merge was armed.

--- a/.agents/skills/compound-delivery-kernel/SKILL.md
+++ b/.agents/skills/compound-delivery-kernel/SKILL.md
@@ -34,6 +34,7 @@ Plan -> Work -> Review -> Compound -> Repeat.
 - For `characterization-first`, write a test or fixture that captures current behavior before changing it.
 - Implement the smallest behavior slice that can turn the selected test green.
 - Run the relevant sensor after each meaningful slice, not only at the end.
+- Regenerate tracked generated client APIs before commit when source changes can affect them; for Athena Convex work this includes `convex/_generated/` via the repo's generated-artifacts hook, not just staging whatever happened to be dirty.
 - If a repo sensor fails, classify it:
   - deterministic repairable drift: run the documented repair once, inspect the result, and rerun the sensor
   - semantic blocker: investigate normally and fix the root cause
@@ -45,6 +46,7 @@ Plan -> Work -> Review -> Compound -> Repeat.
 - Use specialized reviewers when risk warrants it: correctness, tests, security, performance, data, architecture, frontend behavior, agent-native access, or project standards.
 - Treat important review findings as work, not commentary.
 - After fixes, rerun the specific sensor that should catch the issue and then the merge-level sensor set.
+- When GitHub required checks are the only remaining gate and the repo supports auto-merge, arm auto-merge after local merge-level sensors and review gates pass. Pending remote checks should be delegated to auto-merge instead of spending agent time polling green checks just to run a manual merge; failing checks still require investigation.
 
 ### Compound
 

--- a/.agents/skills/execute/SKILL.md
+++ b/.agents/skills/execute/SKILL.md
@@ -25,9 +25,10 @@ Do not use this skill when:
 ## Delivery Contract
 
 - Default to completing the ticket autonomously end-to-end.
-- Delivery means the PR is merged into remote `main`, the local root checkout has fast-forwarded to the merged `origin/main`, and the ticket is already marked `Done` in Linear by merge automation.
+- Delivery usually means the PR is merged into remote `main`, the local root checkout has fast-forwarded to the merged `origin/main`, and the ticket is already marked `Done` in Linear by merge automation.
+- When the user or repo workflow asks to skip waiting on remote checks, delivery can hand off with GitHub auto-merge armed after local merge-level sensors and review gates pass. In that case, leave the ticket in the accurate pre-merge state, report that auto-merge is armed, and only claim merged/local fast-forwarded after the remote merge actually happens.
 - When executing a coordinated batch of related tickets, delivery can mean all tickets land through one shared integration PR rather than one PR per ticket.
-- Delivery always includes remote merge and local fast-forward unless the user explicitly opts out or permissions prevent it.
+- Delivery always includes remote merge and local fast-forward unless the user explicitly opts out, asks to rely on auto-merge, or permissions prevent it.
 - Delivery also means you leave the local repo tidy, back on `main`, and reflecting the merged remote state.
 - Do not stop at "PR open" or "ready for review" unless the user explicitly asked for that narrower handoff.
 - Only treat something as a blocker when it genuinely requires user input.
@@ -74,9 +75,9 @@ Use this resolution order before asking the user for context:
 - Merge target `main`; merge method `squash`; review loop cap `3`.
 - Merge is the default delivery posture. Do not stop at an open PR when auto-review and merge are on.
 - After merge, fast-forward the local root checkout to `origin/main`; do not leave the repo on a stale local `main`.
-- In Athena, merge PRs with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch` instead of raw `gh pr merge`. The helper uses the GitHub API directly, so it does not try to check out or update local `main` and is safe when `main` is already checked out in the root worktree.
+- In Athena, merge or arm auto-merge with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch` or `bun run github:pr-merge -- <pr-number-or-url> --auto --method squash` instead of raw `gh pr merge`. The helper uses GitHub APIs directly, so it does not try to check out or update local `main` and is safe when `main` is already checked out in the root worktree.
 - Human approval is not required unless the user explicitly asks for it.
-- All PR checks must be green before merge.
+- All PR checks must be green before the PR actually merges. If required checks are still pending after local gates pass, arm auto-merge instead of waiting and manually merging; if a check fails, investigate and fix it.
 
 ## Workflow
 
@@ -144,6 +145,7 @@ Use this resolution order before asking the user for context:
 - Run the smallest targeted test first, then the relevant suite, typecheck, build, lint, repo preflight, and `git diff --check`.
 - Match validation to the ticket's expected sensors and supplement with discovered repo sensors when the ticket is incomplete.
 - If the repo defines a PR-equivalent command, run that before trusting local parity with remote CI.
+- If the repo has generated-artifact repair hooks, run them before the final commit and inspect the diff. For Athena, `bun run pre-commit:generated-artifacts` refreshes harness docs, Convex generated API files, graphify artifacts, and tracked generated changes so new Convex modules do not leave `_generated/api.d.ts` drift for a follow-up PR.
 - When harness or repo validation fails, first classify it as deterministic repairable drift or a semantic blocker.
 - If the repo already defines a canonical repair command for deterministic drift, run that repair once, rerun the blocked validation once, and continue only if the rerun passes.
 - Do not invent self-corrections for semantic failures; investigate those normally.
@@ -186,7 +188,7 @@ After opening the PR:
   - `important_count > 0`
   - GitHub review state `CHANGES_REQUESTED`
   - unresolved actionable PR review threads or comments
-  - any PR check not green
+  - any PR check that failed or was cancelled
 - If blocked, fix the issue, rerun the relevant validations, push, rerun `$requesting-code-review`, and recheck GitHub feedback plus CI.
 - If remote GitHub Actions fails after local validation passed, inspect the failing logs and deduce the concrete root cause instead of guessing from the check name alone.
 - Treat remote-only failures as a local parity or harness gap until disproven:
@@ -196,7 +198,8 @@ After opening the PR:
 - The follow-up issue should capture the failing remote check, the local validations that passed, the root cause, and the local command, harness mapping, or coverage addition needed so the failure is caught before CI next time.
 - Link that follow-up issue from the current Linear ticket and the PR comment trail when it materially affects the handoff.
 - Iterate up to `3` times by default, but continue autonomously if the next fix is still clear.
-- When all gates pass, mark the PR ready if needed and squash-merge into `main` with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch`.
+- When local gates and review gates pass, mark the PR ready if needed and arm auto-merge with `bun run github:pr-merge -- <pr-number-or-url> --auto --method squash` unless the user explicitly asked you to wait through merge completion or repo settings reject auto-merge.
+- If auto-merge cannot be armed and all PR checks are already green, squash-merge into `main` with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch`.
 - Treat the merge as incomplete until the remote merge is confirmed and the local root checkout fast-forwards to the merged `origin/main`.
 
 ### 9. Compound The Learning

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4290 nodes · 3974 edges · 1506 communities detected
+- 4298 nodes · 3986 edges · 1506 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1717,31 +1717,31 @@ Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCus
 
 ### Community 43 - "Community 43"
 Cohesion: 0.26
-Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
+Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 44 - "Community 44"
+Cohesion: 0.26
+Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
+
+### Community 45 - "Community 45"
 Cohesion: 0.28
 Nodes (10): buildCompleteTransactionResult(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid(), registerSessionMatchesIdentity() (+2 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
-
-### Community 49 - "Community 49"
-Cohesion: 0.32
-Nodes (10): deleteHeadBranch(), encodeGitRefPath(), ghJson(), mergePullRequest(), parseArgs(), parseMergeMethod(), requireValue(), resolveCurrentRepo() (+2 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.18
@@ -1816,276 +1816,276 @@ Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
 ### Community 68 - "Community 68"
+Cohesion: 0.31
+Nodes (7): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readGeneratedConvexApiModules(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts(), stageTrackedWorkingTreeChanges(), verifyAthenaConvexGeneratedApi()
+
+### Community 69 - "Community 69"
 Cohesion: 0.42
 Nodes (7): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.28
 Nodes (3): modifyProduct(), onSubmit(), saveProduct()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.33
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 85 - "Community 85"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 86 - "Community 86"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 87 - "Community 87"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 88 - "Community 88"
 Cohesion: 0.36
 Nodes (4): buildPendingSkuContextById(), listPurchaseOrderLineItems(), listReplenishmentRecommendationsWithCtx(), listStoreProductSkus()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.43
 Nodes (4): assertRegisterNumberIsAvailable(), mapRegisterTerminalError(), normalizeRegisterNumber(), registerTerminal()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.33
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 115 - "Community 115"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 116 - "Community 116"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 117 - "Community 117"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 118 - "Community 118"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 118 - "Community 118"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 119 - "Community 119"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 120 - "Community 120"
 Cohesion: 0.48
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 125 - "Community 125"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 126 - "Community 126"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 128 - "Community 128"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 129 - "Community 129"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 135 - "Community 135"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 136 - "Community 136"
 Cohesion: 0.33
@@ -2100,8 +2100,8 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 139 - "Community 139"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
@@ -2172,32 +2172,32 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 157 - "Community 157"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 158 - "Community 158"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.6
 Nodes (5): assertCoverageToolchainParity(), checkCoverageToolchainParity(), declaredVersion(), installedVersion(), readManifest()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 163 - "Community 163"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 164 - "Community 164"
 Cohesion: 0.4
@@ -2208,52 +2208,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 166 - "Community 166"
-Cohesion: 0.7
-Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 167 - "Community 167"
 Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
 ### Community 168 - "Community 168"
-Cohesion: 0.5
-Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 169 - "Community 169"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 171 - "Community 171"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 172 - "Community 172"
 Cohesion: 0.7
-Nodes (4): listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Nodes (4): listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
 ### Community 174 - "Community 174"
-Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 175 - "Community 175"
 Cohesion: 0.6
-Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 176 - "Community 176"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.6
+Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 177 - "Community 177"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.4
@@ -2272,16 +2272,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 182 - "Community 182"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 183 - "Community 183"
 Cohesion: 0.5
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
 
 ### Community 185 - "Community 185"
 Cohesion: 0.4
@@ -2293,23 +2293,23 @@ Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 188 - "Community 188"
+Cohesion: 0.4
+Nodes (1): Header()
+
+### Community 189 - "Community 189"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 191 - "Community 191"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 192 - "Community 192"
 Cohesion: 0.4
@@ -2328,32 +2328,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 196 - "Community 196"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 197 - "Community 197"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 198 - "Community 198"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 200 - "Community 200"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 201 - "Community 201"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.4
@@ -2364,52 +2364,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 205 - "Community 205"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 206 - "Community 206"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 207 - "Community 207"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 209 - "Community 209"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 210 - "Community 210"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 212 - "Community 212"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 213 - "Community 213"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 213 - "Community 213"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
 ### Community 214 - "Community 214"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 215 - "Community 215"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
-
-### Community 216 - "Community 216"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.5
@@ -2420,12 +2420,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 219 - "Community 219"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 220 - "Community 220"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 221 - "Community 221"
 Cohesion: 0.5
@@ -2436,64 +2436,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 223 - "Community 223"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 224 - "Community 224"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 230 - "Community 230"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 232 - "Community 232"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 236 - "Community 236"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 237 - "Community 237"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.5
@@ -2504,24 +2504,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 240 - "Community 240"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 241 - "Community 241"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 243 - "Community 243"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 244 - "Community 244"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.5
@@ -2536,12 +2536,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 249 - "Community 249"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 249 - "Community 249"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.5
@@ -2556,12 +2556,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 254 - "Community 254"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 254 - "Community 254"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.5
@@ -2588,68 +2588,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 261 - "Community 261"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 262 - "Community 262"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 262 - "Community 262"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 264 - "Community 264"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 265 - "Community 265"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 266 - "Community 266"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 267 - "Community 267"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 269 - "Community 269"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 270 - "Community 270"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 276 - "Community 276"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 277 - "Community 277"
 Cohesion: 0.5
@@ -2676,48 +2676,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 283 - "Community 283"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
-
-### Community 284 - "Community 284"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
-
-### Community 285 - "Community 285"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
-
-### Community 286 - "Community 286"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 287 - "Community 287"
-Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
-
-### Community 288 - "Community 288"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 289 - "Community 289"
+### Community 284 - "Community 284"
 Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
+### Community 285 - "Community 285"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 286 - "Community 286"
+Cohesion: 0.83
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+
+### Community 287 - "Community 287"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 288 - "Community 288"
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+
+### Community 289 - "Community 289"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 291 - "Community 291"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 292 - "Community 292"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 293 - "Community 293"
-Cohesion: 0.83
-Nodes (3): runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts(), stageTrackedWorkingTreeChanges()
 
 ### Community 294 - "Community 294"
 Cohesion: 0.5
@@ -7568,6 +7568,8 @@ Cohesion: 1.0
 Nodes (0):
 
 ## Knowledge Gaps
+- **1 isolated node(s):** `HelpRequested`
+  These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 442`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 443`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
@@ -9700,6 +9702,8 @@ Nodes (0):
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
+- **What connects `HelpRequested` to the rest of the system?**
+  _1 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
@@ -9712,5 +9716,3 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 17` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 20` be split into smaller, more focused modules?**
-  _Cohesion score 0.11 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4298 nodes · 3986 edges · 1506 communities detected
+- 4300 nodes · 3988 edges · 1506 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2265,7 +2265,7 @@ Nodes (0):
 
 ### Community 180 - "Community 180"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.4
@@ -2276,16 +2276,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 183 - "Community 183"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 184 - "Community 184"
 Cohesion: 0.5
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.4
@@ -2297,7 +2297,7 @@ Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 189 - "Community 189"
 Cohesion: 0.5
@@ -2408,12 +2408,12 @@ Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 216 - "Community 216"
-Cohesion: 0.7
-Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 217 - "Community 217"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.5
@@ -2424,12 +2424,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 220 - "Community 220"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 221 - "Community 221"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 221 - "Community 221"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.5
@@ -2440,64 +2440,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 224 - "Community 224"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 225 - "Community 225"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 231 - "Community 231"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 232 - "Community 232"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 234 - "Community 234"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 236 - "Community 236"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 237 - "Community 237"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 238 - "Community 238"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.5
@@ -2508,24 +2508,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 241 - "Community 241"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 244 - "Community 244"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 245 - "Community 245"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.5
@@ -2540,12 +2540,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 249 - "Community 249"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 250 - "Community 250"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 250 - "Community 250"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 251 - "Community 251"
 Cohesion: 0.5
@@ -2560,12 +2560,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 255 - "Community 255"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 255 - "Community 255"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.5
@@ -2592,68 +2592,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 262 - "Community 262"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 263 - "Community 263"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 263 - "Community 263"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 264 - "Community 264"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 265 - "Community 265"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 266 - "Community 266"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 267 - "Community 267"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 269 - "Community 269"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 270 - "Community 270"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 271 - "Community 271"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 277 - "Community 277"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 278 - "Community 278"
 Cohesion: 0.5
@@ -2680,51 +2680,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 284 - "Community 284"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 286 - "Community 286"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 289 - "Community 289"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 291 - "Community 291"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 292 - "Community 292"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 293 - "Community 293"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 294 - "Community 294"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 295 - "Community 295"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 296 - "Community 296"
@@ -2777,35 +2777,35 @@ Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 311 - "Community 311"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 312 - "Community 312"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 312 - "Community 312"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 315 - "Community 315"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 315 - "Community 315"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 316 - "Community 316"
 Cohesion: 0.67
@@ -2816,36 +2816,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 320 - "Community 320"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 323 - "Community 323"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 324 - "Community 324"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.67
@@ -2860,24 +2860,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 331 - "Community 331"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.67
@@ -2885,23 +2885,23 @@ Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 336 - "Community 336"
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
+
+### Community 337 - "Community 337"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 338 - "Community 338"
-Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 339 - "Community 339"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
@@ -2956,84 +2956,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 353 - "Community 353"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 354 - "Community 354"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 371 - "Community 371"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 372 - "Community 372"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 373 - "Community 373"
 Cohesion: 0.67
@@ -3061,11 +3061,11 @@ Nodes (0):
 
 ### Community 379 - "Community 379"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 380 - "Community 380"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 381 - "Community 381"
 Cohesion: 0.67
@@ -3080,16 +3080,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 384 - "Community 384"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 385 - "Community 385"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 385 - "Community 385"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 386 - "Community 386"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
@@ -3105,71 +3105,71 @@ Nodes (0):
 
 ### Community 390 - "Community 390"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 394 - "Community 394"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 396 - "Community 396"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 400 - "Community 400"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 401 - "Community 401"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 402 - "Community 402"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 403 - "Community 403"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 404 - "Community 404"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 405 - "Community 405"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
@@ -3180,12 +3180,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 409 - "Community 409"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 410 - "Community 410"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 410 - "Community 410"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.67
@@ -3196,12 +3196,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 414 - "Community 414"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 414 - "Community 414"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
@@ -3276,8 +3276,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 433 - "Community 433"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 1.0
@@ -3296,8 +3296,8 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 438 - "Community 438"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3311,7 +3311,7 @@
       "relation": "calls",
       "source": "github_pr_merge_deleteheadbranch",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L190",
+      "source_location": "L218",
       "target": "github_pr_merge_encodegitrefpath",
       "weight": 1
     },
@@ -3323,7 +3323,7 @@
       "relation": "calls",
       "source": "github_pr_merge_deleteheadbranch",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L184",
+      "source_location": "L212",
       "target": "github_pr_merge_ghjson",
       "weight": 1
     },
@@ -3335,8 +3335,20 @@
       "relation": "calls",
       "source": "github_pr_merge_mergepullrequest",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L88",
+      "source_location": "L108",
       "target": "github_pr_merge_deleteheadbranch",
+      "weight": 1
+    },
+    {
+      "_src": "github_pr_merge_mergepullrequest",
+      "_tgt": "github_pr_merge_enablepullrequestautomerge",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "github_pr_merge_mergepullrequest",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L85",
+      "target": "github_pr_merge_enablepullrequestautomerge",
       "weight": 1
     },
     {
@@ -3347,7 +3359,7 @@
       "relation": "calls",
       "source": "github_pr_merge_mergepullrequest",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L69",
+      "source_location": "L89",
       "target": "github_pr_merge_ghjson",
       "weight": 1
     },
@@ -3359,7 +3371,7 @@
       "relation": "calls",
       "source": "github_pr_merge_mergepullrequest",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L54",
+      "source_location": "L69",
       "target": "github_pr_merge_resolvecurrentrepo",
       "weight": 1
     },
@@ -3371,7 +3383,7 @@
       "relation": "calls",
       "source": "github_pr_merge_mergepullrequest",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L87",
+      "source_location": "L107",
       "target": "github_pr_merge_shoulddeleteheadbranch",
       "weight": 1
     },
@@ -3383,7 +3395,7 @@
       "relation": "calls",
       "source": "github_pr_merge_mergepullrequest",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L55",
+      "source_location": "L70",
       "target": "github_pr_merge_viewpullrequest",
       "weight": 1
     },
@@ -3395,7 +3407,7 @@
       "relation": "calls",
       "source": "github_pr_merge_parseargs",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L115",
+      "source_location": "L145",
       "target": "github_pr_merge_parsemergemethod",
       "weight": 1
     },
@@ -3407,7 +3419,7 @@
       "relation": "calls",
       "source": "github_pr_merge_parseargs",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L110",
+      "source_location": "L140",
       "target": "github_pr_merge_requirevalue",
       "weight": 1
     },
@@ -3419,7 +3431,7 @@
       "relation": "calls",
       "source": "github_pr_merge_viewpullrequest",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L163",
+      "source_location": "L191",
       "target": "github_pr_merge_ghjson",
       "weight": 1
     },
@@ -37732,6 +37744,18 @@
       "weight": 1
     },
     {
+      "_src": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "_tgt": "pre_commit_generated_artifacts_collectconvexsourcemodulesfromdir",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L201",
+      "target": "pre_commit_generated_artifacts_collectconvexsourcemodulesfromdir",
+      "weight": 1
+    },
+    {
       "_src": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "_tgt": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "confidence": "EXTRACTED",
@@ -37739,7 +37763,7 @@
       "relation": "calls",
       "source": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L98",
+      "source_location": "L281",
       "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "weight": 1
     },
@@ -37751,8 +37775,32 @@
       "relation": "calls",
       "source": "pre_commit_generated_artifacts_stagetrackedworkingtreechanges",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L115",
+      "source_location": "L312",
       "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "weight": 1
+    },
+    {
+      "_src": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
+      "_tgt": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L178",
+      "target": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "weight": 1
+    },
+    {
+      "_src": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
+      "_tgt": "pre_commit_generated_artifacts_readgeneratedconvexapimodules",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L179",
+      "target": "pre_commit_generated_artifacts_readgeneratedconvexapimodules",
       "weight": 1
     },
     {
@@ -39743,7 +39791,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_test_ts",
       "source_file": "scripts/github-pr-merge.test.ts",
-      "source_location": "L297",
+      "source_location": "L345",
       "target": "github_pr_merge_test_runcommand",
       "weight": 1
     },
@@ -39755,8 +39803,20 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L179",
+      "source_location": "L207",
       "target": "github_pr_merge_deleteheadbranch",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_github_pr_merge_ts",
+      "_tgt": "github_pr_merge_enablepullrequestautomerge",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_github_pr_merge_ts",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L225",
+      "target": "github_pr_merge_enablepullrequestautomerge",
       "weight": 1
     },
     {
@@ -39767,7 +39827,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L201",
+      "source_location": "L268",
       "target": "github_pr_merge_encodegitrefpath",
       "weight": 1
     },
@@ -39779,8 +39839,20 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L205",
+      "source_location": "L272",
       "target": "github_pr_merge_ghjson",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_github_pr_merge_ts",
+      "_tgt": "github_pr_merge_helprequested",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_github_pr_merge_ts",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L318",
+      "target": "github_pr_merge_helprequested",
       "weight": 1
     },
     {
@@ -39791,7 +39863,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L50",
+      "source_location": "L65",
       "target": "github_pr_merge_mergepullrequest",
       "weight": 1
     },
@@ -39803,7 +39875,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L95",
+      "source_location": "L115",
       "target": "github_pr_merge_parseargs",
       "weight": 1
     },
@@ -39815,7 +39887,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L259",
+      "source_location": "L328",
       "target": "github_pr_merge_parsemergemethod",
       "weight": 1
     },
@@ -39827,7 +39899,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L251",
+      "source_location": "L320",
       "target": "github_pr_merge_requirevalue",
       "weight": 1
     },
@@ -39839,7 +39911,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L149",
+      "source_location": "L177",
       "target": "github_pr_merge_resolvecurrentrepo",
       "weight": 1
     },
@@ -39851,7 +39923,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L227",
+      "source_location": "L294",
       "target": "github_pr_merge_runprocess",
       "weight": 1
     },
@@ -39863,7 +39935,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L197",
+      "source_location": "L264",
       "target": "github_pr_merge_shoulddeleteheadbranch",
       "weight": 1
     },
@@ -39875,7 +39947,7 @@
       "relation": "contains",
       "source": "scripts_github_pr_merge_ts",
       "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L158",
+      "source_location": "L186",
       "target": "github_pr_merge_viewpullrequest",
       "weight": 1
     },
@@ -44195,7 +44267,7 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_test_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L205",
+      "source_location": "L309",
       "target": "pre_commit_generated_artifacts_test_log",
       "weight": 1
     },
@@ -44207,8 +44279,68 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_test_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L191",
+      "source_location": "L295",
       "target": "pre_commit_generated_artifacts_test_spawn",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L200",
+      "target": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_collectconvexsourcemodulesfromdir",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L207",
+      "target": "pre_commit_generated_artifacts_collectconvexsourcemodulesfromdir",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_hasathenaconvexsourcechanges",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L120",
+      "target": "pre_commit_generated_artifacts_hasathenaconvexsourcechanges",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_readgeneratedconvexapimodules",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L243",
+      "target": "pre_commit_generated_artifacts_readgeneratedconvexapimodules",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_refreshathenaconvexgeneratedapi",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L151",
+      "target": "pre_commit_generated_artifacts_refreshathenaconvexgeneratedapi",
       "weight": 1
     },
     {
@@ -44219,7 +44351,7 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L81",
+      "source_location": "L256",
       "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "weight": 1
     },
@@ -44231,7 +44363,7 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L29",
+      "source_location": "L68",
       "target": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
       "weight": 1
     },
@@ -44243,8 +44375,20 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L56",
+      "source_location": "L95",
       "target": "pre_commit_generated_artifacts_stagetrackedworkingtreechanges",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L176",
+      "target": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
       "weight": 1
     },
     {
@@ -48732,65 +48876,65 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L1"
+      "id": "expensesessiontracing_buildexpensesessiontraceevent",
+      "label": "buildExpenseSessionTraceEvent()",
+      "norm_label": "buildexpensesessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L150"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "terminals_assertregisternumberisavailable",
-      "label": "assertRegisterNumberIsAvailable()",
-      "norm_label": "assertregisternumberisavailable()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L47"
+      "id": "expensesessiontracing_buildexpensesessiontracerecord",
+      "label": "buildExpenseSessionTraceRecord()",
+      "norm_label": "buildexpensesessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L101"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "terminals_deleteterminal",
-      "label": "deleteTerminal()",
-      "norm_label": "deleteterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "terminals_mapregisterterminalerror",
-      "label": "mapRegisterTerminalError()",
-      "norm_label": "mapregisterterminalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "terminals_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "terminals_registerterminal",
-      "label": "registerTerminal()",
-      "norm_label": "registerterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "id": "expensesessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
       "source_location": "L71"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "terminals_updateterminal",
-      "label": "updateTerminal()",
-      "norm_label": "updateterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L134"
+      "id": "expensesessiontracing_createexpensesessiontracerecorder",
+      "label": "createExpenseSessionTraceRecorder()",
+      "norm_label": "createexpensesessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
+      "label": "recordExpenseSessionTraceBestEffort()",
+      "norm_label": "recordexpensesessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "expensesessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
+      "label": "expenseSessionTracing.ts",
+      "norm_label": "expensesessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L1"
     },
     {
       "community": 1000,
@@ -48885,65 +49029,65 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
       "source_location": "L1"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L95"
+      "id": "terminals_assertregisternumberisavailable",
+      "label": "assertRegisterNumberIsAvailable()",
+      "norm_label": "assertregisternumberisavailable()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L47"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L122"
+      "id": "terminals_deleteterminal",
+      "label": "deleteTerminal()",
+      "norm_label": "deleteterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L169"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L66"
+      "id": "terminals_mapregisterterminalerror",
+      "label": "mapRegisterTerminalError()",
+      "norm_label": "mapregisterterminalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L30"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerprofileidforposcustomer",
-      "label": "getCustomerProfileIdForPosCustomer()",
-      "norm_label": "getcustomerprofileidforposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
+      "id": "terminals_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L25"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L75"
+      "id": "terminals_registerterminal",
+      "label": "registerTerminal()",
+      "norm_label": "registerterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L71"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L27"
+      "id": "terminals_updateterminal",
+      "label": "updateTerminal()",
+      "norm_label": "updateterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L134"
     },
     {
       "community": 1010,
@@ -49038,65 +49182,65 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
-      "label": "sessionRepository.ts",
-      "norm_label": "sessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
       "source_location": "L1"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessionrepository_getactivesessionforregisterstate",
-      "label": "getActiveSessionForRegisterState()",
-      "norm_label": "getactivesessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L18"
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L95"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessionrepository_listheldsessionsforregisterstate",
-      "label": "listHeldSessionsForRegisterState()",
-      "norm_label": "listheldsessionsforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L26"
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L122"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessionrepository_matchesregisteridentity",
-      "label": "matchesRegisterIdentity()",
-      "norm_label": "matchesregisteridentity()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L119"
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L66"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessionrepository_querysessionsbystatus",
-      "label": "querySessionsByStatus()",
-      "norm_label": "querysessionsbystatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L33"
+      "id": "searchcustomers_getcustomerprofileidforposcustomer",
+      "label": "getCustomerProfileIdForPosCustomer()",
+      "norm_label": "getcustomerprofileidforposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessionrepository_selectregisterstatelookupstrategy",
-      "label": "selectRegisterStateLookupStrategy()",
-      "norm_label": "selectregisterstatelookupstrategy()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L83"
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L75"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessionrepository_summarizeregisterstatesessions",
-      "label": "summarizeRegisterStateSessions()",
-      "norm_label": "summarizeregisterstatesessions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L97"
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L27"
     },
     {
       "community": 1020,
@@ -49191,65 +49335,65 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
+      "label": "sessionRepository.ts",
+      "norm_label": "sessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessionrepository_getactivesessionforregisterstate",
+      "label": "getActiveSessionForRegisterState()",
+      "norm_label": "getactivesessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessionrepository_listheldsessionsforregisterstate",
+      "label": "listHeldSessionsForRegisterState()",
+      "norm_label": "listheldsessionsforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessionrepository_matchesregisteridentity",
+      "label": "matchesRegisterIdentity()",
+      "norm_label": "matchesregisteridentity()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessionrepository_querysessionsbystatus",
+      "label": "querySessionsByStatus()",
+      "norm_label": "querysessionsbystatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessionrepository_selectregisterstatelookupstrategy",
+      "label": "selectRegisterStateLookupStrategy()",
+      "norm_label": "selectregisterstatelookupstrategy()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessionrepository_summarizeregisterstatesessions",
+      "label": "summarizeRegisterStateSessions()",
+      "norm_label": "summarizeregisterstatesessions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 1030,
@@ -49344,64 +49488,64 @@
     {
       "community": 104,
       "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L45"
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L104"
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L21"
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L33"
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L14"
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L57"
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1"
     },
     {
@@ -49497,64 +49641,64 @@
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L45"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L104"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L21"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L33"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L14"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L57"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -49650,65 +49794,65 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L61"
     },
     {
       "community": 1060,
@@ -49803,65 +49947,65 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L61"
     },
     {
       "community": 1070,
@@ -49956,64 +50100,64 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L61"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L85"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L206"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L214"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L51"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L221"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -50109,65 +50253,65 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_hashighstockadjustmentvariance",
-      "label": "hasHighStockAdjustmentVariance()",
-      "norm_label": "hashighstockadjustmentvariance()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
     },
     {
       "community": 1090,
@@ -50460,65 +50604,65 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L404"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L181"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L231"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L275"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L259"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1100,
@@ -50613,65 +50757,65 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "posregisterview_cartcountsummary",
-      "label": "CartCountSummary()",
-      "norm_label": "cartcountsummary()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L152"
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "posregisterview_cashierauthworkspace",
-      "label": "CashierAuthWorkspace()",
-      "norm_label": "cashierauthworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L114"
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L181"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L431"
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L253"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L73"
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L231"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "posregisterview_registersetupresolvingworkspace",
-      "label": "RegisterSetupResolvingWorkspace()",
-      "norm_label": "registersetupresolvingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L146"
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L41"
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L259"
     },
     {
       "community": 1110,
@@ -50766,65 +50910,65 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
+      "id": "posregisterview_cartcountsummary",
+      "label": "CartCountSummary()",
+      "norm_label": "cartcountsummary()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L431"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L73"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
+      "id": "posregisterview_registersetupresolvingworkspace",
+      "label": "RegisterSetupResolvingWorkspace()",
+      "norm_label": "registersetupresolvingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L146"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L41"
     },
     {
       "community": 1120,
@@ -50919,65 +51063,65 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 1130,
@@ -51072,65 +51216,65 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexregistercatalog",
-      "label": "useConvexRegisterCatalog()",
-      "norm_label": "useconvexregistercatalog()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1140,
@@ -51225,64 +51369,64 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L40"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L107"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L78"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L139"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
+      "id": "cataloggateway_useconvexregistercatalog",
+      "label": "useConvexRegisterCatalog()",
+      "norm_label": "useconvexregistercatalog()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L69"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
     },
     {
@@ -51378,65 +51522,65 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
     },
     {
       "community": 1160,
@@ -51531,65 +51675,65 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1170,
@@ -51684,65 +51828,65 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1180,
@@ -51837,65 +51981,65 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L13"
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createpackage",
-      "label": "createPackage()",
-      "norm_label": "createpackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
-      "label": "installFixtureToolchain()",
-      "norm_label": "installfixturetoolchain()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L63"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
-      "label": "linkWorkspacePackage()",
-      "norm_label": "linkworkspacepackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L32"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writefixturemanifests",
-      "label": "writeFixtureManifests()",
-      "norm_label": "writefixturemanifests()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L42"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writejson",
-      "label": "writeJson()",
-      "norm_label": "writejson()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L19"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "scripts_coverage_toolchain_parity_test_ts",
-      "label": "coverage-toolchain-parity.test.ts",
-      "norm_label": "coverage-toolchain-parity.test.ts",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L1"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1190,
@@ -52179,65 +52323,65 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "coverage_toolchain_parity_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_createpackage",
+      "label": "createPackage()",
+      "norm_label": "createpackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
+      "label": "installFixtureToolchain()",
+      "norm_label": "installfixturetoolchain()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
+      "label": "linkWorkspacePackage()",
+      "norm_label": "linkworkspacepackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writefixturemanifests",
+      "label": "writeFixtureManifests()",
+      "norm_label": "writefixturemanifests()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writejson",
+      "label": "writeJson()",
+      "norm_label": "writejson()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "scripts_coverage_toolchain_parity_test_ts",
+      "label": "coverage-toolchain-parity.test.ts",
+      "norm_label": "coverage-toolchain-parity.test.ts",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
     },
     {
       "community": 1200,
@@ -52332,65 +52476,65 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1210,
@@ -52485,64 +52629,64 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -52638,55 +52782,64 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -52782,56 +52935,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1240,
@@ -52926,56 +53079,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L42"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1250,
@@ -53070,56 +53223,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
     },
     {
       "community": 1260,
@@ -53214,56 +53367,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
     },
     {
       "community": 1270,
@@ -53358,55 +53511,55 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -53502,55 +53655,55 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -53826,56 +53979,56 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
     },
     {
       "community": 1300,
@@ -53970,56 +54123,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1310,
@@ -54114,55 +54267,55 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "analyticsview_activecheckoutsessions",
-      "label": "ActiveCheckoutSessions()",
-      "norm_label": "activecheckoutsessions()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L89"
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "analyticsview_formatmetric",
-      "label": "formatMetric()",
-      "norm_label": "formatmetric()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L22"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "analyticsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L154"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "analyticsview_storefrontsignalcard",
-      "label": "StorefrontSignalCard()",
-      "norm_label": "storefrontsignalcard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L26"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "analyticsview_storevisitors",
-      "label": "StoreVisitors()",
-      "norm_label": "storevisitors()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L59"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "label": "AnalyticsView.tsx",
-      "norm_label": "analyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -54258,56 +54411,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "analyticsview_activecheckoutsessions",
+      "label": "ActiveCheckoutSessions()",
+      "norm_label": "activecheckoutsessions()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "analyticsview_formatmetric",
+      "label": "formatMetric()",
+      "norm_label": "formatmetric()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "analyticsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L154"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "analyticsview_storefrontsignalcard",
+      "label": "StorefrontSignalCard()",
+      "norm_label": "storefrontsignalcard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "analyticsview_storevisitors",
+      "label": "StoreVisitors()",
+      "norm_label": "storevisitors()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
+      "label": "AnalyticsView.tsx",
+      "norm_label": "analyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1330,
@@ -54402,56 +54555,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1340,
@@ -54546,55 +54699,55 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
-      "label": "CashControlsHeaderSkeleton()",
-      "norm_label": "cashcontrolsheaderskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L83"
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L373"
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L544"
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_metriccardskeleton",
-      "label": "MetricCardSkeleton()",
-      "norm_label": "metriccardskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L97"
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L266"
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
     },
     {
@@ -54690,55 +54843,55 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
+      "id": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
+      "label": "CashControlsHeaderSkeleton()",
+      "norm_label": "cashcontrolsheaderskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L83"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
+      "id": "cashcontrolsdashboard_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L373"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
+      "id": "cashcontrolsdashboard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L544"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
+      "id": "cashcontrolsdashboard_metriccardskeleton",
+      "label": "MetricCardSkeleton()",
+      "norm_label": "metriccardskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L97"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
+      "id": "cashcontrolsdashboard_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L266"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
       "source_location": "L1"
     },
     {
@@ -54834,55 +54987,55 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "ordersummary_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L418"
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L285"
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "ordersummary_handleeditingpaymentidchange",
-      "label": "handleEditingPaymentIdChange()",
-      "norm_label": "handleeditingpaymentidchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L318"
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "ordersummary_handleselectedpaymentmethodchange",
-      "label": "handleSelectedPaymentMethodChange()",
-      "norm_label": "handleselectedpaymentmethodchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L308"
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "ordersummary_handlestartnewtransaction",
-      "label": "handleStartNewTransaction()",
-      "norm_label": "handlestartnewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L302"
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
     },
     {
@@ -54978,56 +55131,56 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L418"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L285"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "ordersummary_handleeditingpaymentidchange",
+      "label": "handleEditingPaymentIdChange()",
+      "norm_label": "handleeditingpaymentidchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L318"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "ordersummary_handleselectedpaymentmethodchange",
+      "label": "handleSelectedPaymentMethodChange()",
+      "norm_label": "handleselectedpaymentmethodchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L308"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "ordersummary_handlestartnewtransaction",
+      "label": "handleStartNewTransaction()",
+      "norm_label": "handlestartnewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L302"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
     },
     {
       "community": 1380,
@@ -55122,56 +55275,56 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
     },
     {
       "community": 1390,
@@ -57498,6 +57651,60 @@
     {
       "community": 157,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
       "norm_label": "getremainingforfreedelivery()",
@@ -57505,7 +57712,7 @@
       "source_location": "L138"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -57514,7 +57721,7 @@
       "source_location": "L100"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -57523,7 +57730,7 @@
       "source_location": "L74"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -57532,7 +57739,7 @@
       "source_location": "L34"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -57541,7 +57748,7 @@
       "source_location": "L17"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -57550,7 +57757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -57559,7 +57766,7 @@
       "source_location": "L149"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -57568,7 +57775,7 @@
       "source_location": "L156"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -57577,7 +57784,7 @@
       "source_location": "L201"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -57586,7 +57793,7 @@
       "source_location": "L93"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -57595,66 +57802,12 @@
       "source_location": "L282"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
       "norm_label": "auth.verify.tsx",
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "coverage_summary_test_coveragesummary",
-      "label": "coverageSummary()",
-      "norm_label": "coveragesummary()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "coverage_summary_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "coverage_summary_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "coverage_summary_test_writepackagesummaries",
-      "label": "writePackageSummaries()",
-      "norm_label": "writepackagesummaries()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "coverage_summary_test_writerealbaselinesummaries",
-      "label": "writeRealBaselineSummaries()",
-      "norm_label": "writerealbaselinesummaries()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "scripts_coverage_summary_test_ts",
-      "label": "coverage-summary.test.ts",
-      "norm_label": "coverage-summary.test.ts",
-      "source_file": "scripts/coverage-summary.test.ts",
       "source_location": "L1"
     },
     {
@@ -57831,6 +57984,60 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "coverage_summary_test_coveragesummary",
+      "label": "coverageSummary()",
+      "norm_label": "coveragesummary()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "coverage_summary_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "coverage_summary_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "coverage_summary_test_writepackagesummaries",
+      "label": "writePackageSummaries()",
+      "norm_label": "writepackagesummaries()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "coverage_summary_test_writerealbaselinesummaries",
+      "label": "writeRealBaselineSummaries()",
+      "norm_label": "writerealbaselinesummaries()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "scripts_coverage_summary_test_ts",
+      "label": "coverage-summary.test.ts",
+      "norm_label": "coverage-summary.test.ts",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "coverage_toolchain_parity_assertcoveragetoolchainparity",
       "label": "assertCoverageToolchainParity()",
       "norm_label": "assertcoveragetoolchainparity()",
@@ -57838,7 +58045,7 @@
       "source_location": "L104"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "coverage_toolchain_parity_checkcoveragetoolchainparity",
       "label": "checkCoverageToolchainParity()",
@@ -57847,7 +58054,7 @@
       "source_location": "L69"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "coverage_toolchain_parity_declaredversion",
       "label": "declaredVersion()",
@@ -57856,7 +58063,7 @@
       "source_location": "L41"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "coverage_toolchain_parity_installedversion",
       "label": "installedVersion()",
@@ -57865,7 +58072,7 @@
       "source_location": "L49"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "coverage_toolchain_parity_readmanifest",
       "label": "readManifest()",
@@ -57874,7 +58081,7 @@
       "source_location": "L37"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "scripts_coverage_toolchain_parity_ts",
       "label": "coverage-toolchain-parity.ts",
@@ -57883,7 +58090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -57892,7 +58099,7 @@
       "source_location": "L72"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -57901,7 +58108,7 @@
       "source_location": "L124"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -57910,7 +58117,7 @@
       "source_location": "L106"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -57919,7 +58126,7 @@
       "source_location": "L63"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -57928,7 +58135,7 @@
       "source_location": "L151"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -57937,7 +58144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -57946,7 +58153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -57955,7 +58162,7 @@
       "source_location": "L46"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -57964,7 +58171,7 @@
       "source_location": "L22"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -57973,7 +58180,7 @@
       "source_location": "L118"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -57982,7 +58189,7 @@
       "source_location": "L81"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -57991,7 +58198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -58000,7 +58207,7 @@
       "source_location": "L292"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -58009,7 +58216,7 @@
       "source_location": "L94"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -58018,7 +58225,7 @@
       "source_location": "L110"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -58027,7 +58234,7 @@
       "source_location": "L311"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -58036,7 +58243,7 @@
       "source_location": "L135"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -58045,7 +58252,7 @@
       "source_location": "L39"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -58054,7 +58261,7 @@
       "source_location": "L19"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -58063,7 +58270,7 @@
       "source_location": "L92"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -58072,7 +58279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
       "label": "products.ts",
@@ -58081,7 +58288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "products_calculatetotalavailablecount",
       "label": "calculateTotalAvailableCount()",
@@ -58090,7 +58297,7 @@
       "source_location": "L70"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "products_calculatetotalinventorycount",
       "label": "calculateTotalInventoryCount()",
@@ -58099,7 +58306,7 @@
       "source_location": "L65"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "products_generatebarcode",
       "label": "generateBarcode()",
@@ -58108,7 +58315,7 @@
       "source_location": "L42"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "products_generatesku",
       "label": "generateSKU()",
@@ -58117,7 +58324,7 @@
       "source_location": "L18"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -58126,7 +58333,7 @@
       "source_location": "L85"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestascommandwithctx",
       "label": "decideApprovalRequestAsCommandWithCtx()",
@@ -58135,7 +58342,7 @@
       "source_location": "L173"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -58144,7 +58351,7 @@
       "source_location": "L28"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "approvalrequests_mapdecideapprovalrequesterror",
       "label": "mapDecideApprovalRequestError()",
@@ -58153,7 +58360,7 @@
       "source_location": "L114"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -58162,7 +58369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -58171,7 +58378,7 @@
       "source_location": "L24"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -58180,7 +58387,7 @@
       "source_location": "L207"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -58189,7 +58396,7 @@
       "source_location": "L45"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -58198,7 +58405,7 @@
       "source_location": "L30"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -58207,7 +58414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "inventorymovements_buildinventorymovement",
       "label": "buildInventoryMovement()",
@@ -58216,7 +58423,7 @@
       "source_location": "L25"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "inventorymovements_matchesexistingmovement",
       "label": "matchesExistingMovement()",
@@ -58225,7 +58432,7 @@
       "source_location": "L51"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "inventorymovements_recordinventorymovementwithctx",
       "label": "recordInventoryMovementWithCtx()",
@@ -58234,7 +58441,7 @@
       "source_location": "L70"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "inventorymovements_summarizeinventorymovements",
       "label": "summarizeInventoryMovements()",
@@ -58243,58 +58450,13 @@
       "source_location": "L36"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
       "label": "inventoryMovements.ts",
       "norm_label": "inventorymovements.ts",
       "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
-      "label": "serviceIntake.test.ts",
-      "norm_label": "serviceintake.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "serviceintake_test_buildcreateserviceintakeargs",
-      "label": "buildCreateServiceIntakeArgs()",
-      "norm_label": "buildcreateserviceintakeargs()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "serviceintake_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "serviceintake_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "serviceintake_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 17,
@@ -58470,6 +58632,51 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
+      "label": "serviceIntake.test.ts",
+      "norm_label": "serviceintake.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "serviceintake_test_buildcreateserviceintakeargs",
+      "label": "buildCreateServiceIntakeArgs()",
+      "norm_label": "buildcreateserviceintakeargs()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "serviceintake_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "serviceintake_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "serviceintake_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
       "norm_label": "customerprofile()",
@@ -58477,7 +58684,7 @@
       "source_location": "L255"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -58486,7 +58693,7 @@
       "source_location": "L282"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -58495,7 +58702,7 @@
       "source_location": "L239"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -58504,7 +58711,7 @@
       "source_location": "L269"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -58513,7 +58720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -58522,7 +58729,7 @@
       "source_location": "L100"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -58531,7 +58738,7 @@
       "source_location": "L110"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -58540,7 +58747,7 @@
       "source_location": "L84"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -58549,7 +58756,7 @@
       "source_location": "L92"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -58558,7 +58765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "listregistercatalog_listregistercatalog",
       "label": "listRegisterCatalog()",
@@ -58567,7 +58774,7 @@
       "source_location": "L89"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "listregistercatalog_mapskutoregistercatalogrow",
       "label": "mapSkuToRegisterCatalogRow()",
@@ -58576,7 +58783,7 @@
       "source_location": "L62"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "listregistercatalog_readcategoryname",
       "label": "readCategoryName()",
@@ -58585,7 +58792,7 @@
       "source_location": "L24"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "listregistercatalog_readcolorname",
       "label": "readColorName()",
@@ -58594,7 +58801,7 @@
       "source_location": "L41"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
       "label": "listRegisterCatalog.ts",
@@ -58603,7 +58810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -58612,7 +58819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -58621,7 +58828,7 @@
       "source_location": "L11"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -58630,7 +58837,7 @@
       "source_location": "L21"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -58639,7 +58846,7 @@
       "source_location": "L87"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -58648,7 +58855,7 @@
       "source_location": "L65"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -58657,7 +58864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -58666,7 +58873,7 @@
       "source_location": "L115"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -58675,7 +58882,7 @@
       "source_location": "L90"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -58684,7 +58891,7 @@
       "source_location": "L74"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -58693,7 +58900,7 @@
       "source_location": "L70"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -58702,7 +58909,7 @@
       "source_location": "L89"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -58711,7 +58918,7 @@
       "source_location": "L765"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -58720,7 +58927,7 @@
       "source_location": "L37"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -58729,7 +58936,7 @@
       "source_location": "L60"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -58738,7 +58945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -58747,7 +58954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -58756,7 +58963,7 @@
       "source_location": "L124"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -58765,7 +58972,7 @@
       "source_location": "L67"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -58774,7 +58981,7 @@
       "source_location": "L106"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -58783,7 +58990,7 @@
       "source_location": "L73"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -58792,7 +58999,7 @@
       "source_location": "L61"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -58801,7 +59008,7 @@
       "source_location": "L75"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -58810,7 +59017,7 @@
       "source_location": "L116"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -58819,7 +59026,7 @@
       "source_location": "L20"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -58828,7 +59035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -58837,7 +59044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -58846,7 +59053,7 @@
       "source_location": "L287"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -58855,7 +59062,7 @@
       "source_location": "L203"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -58864,58 +59071,13 @@
       "source_location": "L243"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
       "norm_label": "setinitialselectedoption()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66"
     },
     {
       "community": 18,
@@ -59091,6 +59253,51 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
       "norm_label": "getperiodrange()",
@@ -59098,7 +59305,7 @@
       "source_location": "L20"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -59107,7 +59314,7 @@
       "source_location": "L50"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -59116,7 +59323,7 @@
       "source_location": "L342"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -59125,7 +59332,7 @@
       "source_location": "L322"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -59134,7 +59341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -59143,7 +59350,7 @@
       "source_location": "L61"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -59152,7 +59359,7 @@
       "source_location": "L57"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -59161,7 +59368,7 @@
       "source_location": "L98"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -59170,7 +59377,7 @@
       "source_location": "L134"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -59179,7 +59386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -59188,7 +59395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -59197,7 +59404,7 @@
       "source_location": "L38"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -59206,7 +59413,7 @@
       "source_location": "L64"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -59215,7 +59422,7 @@
       "source_location": "L135"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -59224,7 +59431,7 @@
       "source_location": "L43"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_getapprovalrequestcopy",
       "label": "getApprovalRequestCopy()",
@@ -59233,7 +59440,7 @@
       "source_location": "L63"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_getdefaultworkflow",
       "label": "getDefaultWorkflow()",
@@ -59242,7 +59449,7 @@
       "source_location": "L54"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_if",
       "label": "if()",
@@ -59251,7 +59458,7 @@
       "source_location": "L579"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_setdecisioningapprovalrequestid",
       "label": "setDecisioningApprovalRequestId()",
@@ -59260,7 +59467,7 @@
       "source_location": "L638"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -59269,7 +59476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -59278,7 +59485,7 @@
       "source_location": "L58"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -59287,7 +59494,7 @@
       "source_location": "L63"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -59296,7 +59503,7 @@
       "source_location": "L50"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -59305,7 +59512,7 @@
       "source_location": "L53"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -59314,7 +59521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -59323,7 +59530,7 @@
       "source_location": "L140"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -59332,7 +59539,7 @@
       "source_location": "L177"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -59341,7 +59548,7 @@
       "source_location": "L195"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -59350,7 +59557,7 @@
       "source_location": "L45"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -59359,7 +59566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -59368,7 +59575,7 @@
       "source_location": "L92"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -59377,7 +59584,7 @@
       "source_location": "L307"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -59386,7 +59593,7 @@
       "source_location": "L70"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -59395,7 +59602,7 @@
       "source_location": "L50"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -59404,7 +59611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
@@ -59413,7 +59620,7 @@
       "source_location": "L30"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -59422,7 +59629,7 @@
       "source_location": "L43"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -59431,7 +59638,7 @@
       "source_location": "L106"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -59440,7 +59647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -59449,7 +59656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -59458,7 +59665,7 @@
       "source_location": "L36"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -59467,7 +59674,7 @@
       "source_location": "L53"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -59476,7 +59683,7 @@
       "source_location": "L62"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -59485,58 +59692,13 @@
       "source_location": "L32"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
       "norm_label": "ordersummary.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
-      "label": "PaymentsAddedList.test.tsx",
-      "norm_label": "paymentsaddedlist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummaryamount",
-      "label": "getSummaryAmount()",
-      "norm_label": "getsummaryamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarylabel",
-      "label": "getSummaryLabel()",
-      "norm_label": "getsummarylabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarypanel",
-      "label": "getSummaryPanel()",
-      "norm_label": "getsummarypanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L14"
     },
     {
       "community": 19,
@@ -59703,6 +59865,51 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
+      "label": "PaymentsAddedList.test.tsx",
+      "norm_label": "paymentsaddedlist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummaryamount",
+      "label": "getSummaryAmount()",
+      "norm_label": "getsummaryamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarylabel",
+      "label": "getSummaryLabel()",
+      "norm_label": "getsummarylabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarypanel",
+      "label": "getSummaryPanel()",
+      "norm_label": "getsummarypanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
       "norm_label": "productentry.tsx",
@@ -59710,7 +59917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -59719,7 +59926,7 @@
       "source_location": "L229"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -59728,7 +59935,7 @@
       "source_location": "L234"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -59737,7 +59944,7 @@
       "source_location": "L263"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -59746,7 +59953,7 @@
       "source_location": "L254"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -59755,7 +59962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -59764,7 +59971,7 @@
       "source_location": "L80"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -59773,7 +59980,7 @@
       "source_location": "L84"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -59782,7 +59989,7 @@
       "source_location": "L73"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -59791,7 +59998,7 @@
       "source_location": "L61"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -59800,7 +60007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -59809,7 +60016,7 @@
       "source_location": "L37"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -59818,7 +60025,7 @@
       "source_location": "L46"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -59827,7 +60034,7 @@
       "source_location": "L33"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -59836,7 +60043,7 @@
       "source_location": "L72"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -59845,7 +60052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -59854,7 +60061,7 @@
       "source_location": "L157"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -59863,7 +60070,7 @@
       "source_location": "L230"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -59872,7 +60079,7 @@
       "source_location": "L322"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -59881,7 +60088,7 @@
       "source_location": "L377"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -59890,7 +60097,7 @@
       "source_location": "L99"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -59899,7 +60106,7 @@
       "source_location": "L53"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -59908,7 +60115,7 @@
       "source_location": "L75"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -59917,7 +60124,7 @@
       "source_location": "L63"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -59926,7 +60133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -59935,7 +60142,7 @@
       "source_location": "L7"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -59944,7 +60151,7 @@
       "source_location": "L69"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -59953,7 +60160,7 @@
       "source_location": "L44"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -59962,7 +60169,7 @@
       "source_location": "L103"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -59971,7 +60178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -59980,7 +60187,7 @@
       "source_location": "L12"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -59989,7 +60196,7 @@
       "source_location": "L20"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -59998,7 +60205,7 @@
       "source_location": "L24"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -60007,7 +60214,7 @@
       "source_location": "L8"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -60016,7 +60223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -60025,7 +60232,7 @@
       "source_location": "L18"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -60034,7 +60241,7 @@
       "source_location": "L23"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -60043,7 +60250,7 @@
       "source_location": "L65"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -60052,7 +60259,7 @@
       "source_location": "L45"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -60061,7 +60268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -60070,7 +60277,7 @@
       "source_location": "L78"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -60079,7 +60286,7 @@
       "source_location": "L74"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -60088,7 +60295,7 @@
       "source_location": "L103"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -60097,57 +60304,12 @@
       "source_location": "L109"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
       "norm_label": "imageutils.test.ts",
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "imageutils_convertimagestojpg",
-      "label": "convertImagesToJpg()",
-      "norm_label": "convertimagestojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "imageutils_convertimagestowebp",
-      "label": "convertImagesToWebp()",
-      "norm_label": "convertimagestowebp()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "imageutils_converttojpg",
-      "label": "convertToJpg()",
-      "norm_label": "converttojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "imageutils_getuploadimagesdata",
-      "label": "getUploadImagesData()",
-      "norm_label": "getuploadimagesdata()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "label": "imageUtils.ts",
-      "norm_label": "imageutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1"
     },
     {
@@ -60612,6 +60774,51 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "imageutils_convertimagestojpg",
+      "label": "convertImagesToJpg()",
+      "norm_label": "convertimagestojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "imageutils_convertimagestowebp",
+      "label": "convertImagesToWebp()",
+      "norm_label": "convertimagestowebp()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "imageutils_converttojpg",
+      "label": "convertToJpg()",
+      "norm_label": "converttojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "imageutils_getuploadimagesdata",
+      "label": "getUploadImagesData()",
+      "norm_label": "getuploadimagesdata()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_imageutils_ts",
+      "label": "imageUtils.ts",
+      "norm_label": "imageutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
       "norm_label": "calculateposcarttotals()",
@@ -60619,7 +60826,7 @@
       "source_location": "L3"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -60628,7 +60835,7 @@
       "source_location": "L29"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -60637,7 +60844,7 @@
       "source_location": "L33"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -60646,7 +60853,7 @@
       "source_location": "L40"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -60655,7 +60862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -60664,7 +60871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -60673,7 +60880,7 @@
       "source_location": "L12"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -60682,7 +60889,7 @@
       "source_location": "L30"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -60691,7 +60898,7 @@
       "source_location": "L36"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -60700,7 +60907,7 @@
       "source_location": "L58"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -60709,7 +60916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -60718,7 +60925,7 @@
       "source_location": "L42"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -60727,7 +60934,7 @@
       "source_location": "L29"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -60736,7 +60943,7 @@
       "source_location": "L49"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -60745,7 +60952,7 @@
       "source_location": "L14"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -60754,7 +60961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -60763,7 +60970,7 @@
       "source_location": "L184"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -60772,7 +60979,7 @@
       "source_location": "L200"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -60781,7 +60988,7 @@
       "source_location": "L244"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -60790,7 +60997,7 @@
       "source_location": "L206"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -60799,7 +61006,7 @@
       "source_location": "L29"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -60808,7 +61015,7 @@
       "source_location": "L99"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "authed_topbar",
       "label": "TopBar()",
@@ -60817,7 +61024,7 @@
       "source_location": "L74"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "authed_usermenu",
       "label": "UserMenu()",
@@ -60826,7 +61033,7 @@
       "source_location": "L39"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -60835,7 +61042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -60844,7 +61051,7 @@
       "source_location": "L114"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -60853,7 +61060,7 @@
       "source_location": "L81"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -60862,7 +61069,7 @@
       "source_location": "L23"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -60871,7 +61078,7 @@
       "source_location": "L27"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -60880,7 +61087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -60889,7 +61096,7 @@
       "source_location": "L93"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -60898,7 +61105,7 @@
       "source_location": "L75"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -60907,7 +61114,7 @@
       "source_location": "L4"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -60916,7 +61123,7 @@
       "source_location": "L47"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -60925,7 +61132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -60934,7 +61141,7 @@
       "source_location": "L11"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -60943,7 +61150,7 @@
       "source_location": "L25"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -60952,7 +61159,7 @@
       "source_location": "L9"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -60961,7 +61168,7 @@
       "source_location": "L39"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -60970,7 +61177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -60979,7 +61186,7 @@
       "source_location": "L4"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -60988,7 +61195,7 @@
       "source_location": "L24"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -60997,7 +61204,7 @@
       "source_location": "L6"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -61006,58 +61213,13 @@
       "source_location": "L42"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "storefrontuser_getactiveuser",
-      "label": "getActiveUser()",
-      "norm_label": "getactiveuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "storefrontuser_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "storefrontuser_getguest",
-      "label": "getGuest()",
-      "norm_label": "getguest()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "storefrontuser_updateuser",
-      "label": "updateUser()",
-      "norm_label": "updateuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L46"
     },
     {
       "community": 21,
@@ -61224,6 +61386,51 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "storefrontuser_getactiveuser",
+      "label": "getActiveUser()",
+      "norm_label": "getactiveuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "storefrontuser_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "storefrontuser_getguest",
+      "label": "getGuest()",
+      "norm_label": "getguest()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "storefrontuser_updateuser",
+      "label": "updateUser()",
+      "norm_label": "updateuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
       "norm_label": "enableprompts()",
@@ -61231,7 +61438,7 @@
       "source_location": "L147"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -61240,7 +61447,7 @@
       "source_location": "L186"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -61249,7 +61456,7 @@
       "source_location": "L115"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -61258,7 +61465,7 @@
       "source_location": "L31"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -61267,7 +61474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -61276,7 +61483,7 @@
       "source_location": "L14"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -61285,7 +61492,7 @@
       "source_location": "L22"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -61294,7 +61501,7 @@
       "source_location": "L30"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -61303,7 +61510,7 @@
       "source_location": "L3"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -61312,7 +61519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -61321,7 +61528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -61330,7 +61537,7 @@
       "source_location": "L136"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -61339,7 +61546,7 @@
       "source_location": "L154"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -61348,7 +61555,7 @@
       "source_location": "L25"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -61357,7 +61564,7 @@
       "source_location": "L47"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -61366,7 +61573,7 @@
       "source_location": "L52"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61375,7 +61582,7 @@
       "source_location": "L22"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -61384,7 +61591,7 @@
       "source_location": "L44"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -61393,7 +61600,7 @@
       "source_location": "L16"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -61402,7 +61609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -61411,7 +61618,7 @@
       "source_location": "L45"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -61420,7 +61627,7 @@
       "source_location": "L37"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -61429,7 +61636,7 @@
       "source_location": "L27"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -61438,7 +61645,7 @@
       "source_location": "L31"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -61447,7 +61654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -61456,7 +61663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61465,7 +61672,7 @@
       "source_location": "L17"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -61474,7 +61681,7 @@
       "source_location": "L72"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -61483,7 +61690,7 @@
       "source_location": "L45"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -61492,7 +61699,7 @@
       "source_location": "L59"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -61501,7 +61708,7 @@
       "source_location": "L12"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -61510,7 +61717,7 @@
       "source_location": "L26"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -61519,7 +61726,7 @@
       "source_location": "L20"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -61528,7 +61735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -61537,7 +61744,7 @@
       "source_location": "L109"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -61546,7 +61753,7 @@
       "source_location": "L84"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -61555,7 +61762,7 @@
       "source_location": "L95"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -61564,7 +61771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -61573,7 +61780,7 @@
       "source_location": "L149"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -61582,7 +61789,7 @@
       "source_location": "L39"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -61591,48 +61798,12 @@
       "source_location": "L164"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
       "norm_label": "expensesessions.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "expensetransactions_createexpensetransactionfromsessionhandler",
-      "label": "createExpenseTransactionFromSessionHandler()",
-      "norm_label": "createexpensetransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "expensetransactions_expensetransactionerror",
-      "label": "expenseTransactionError()",
-      "norm_label": "expensetransactionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "expensetransactions_formatexpensestaffprofilename",
-      "label": "formatExpenseStaffProfileName()",
-      "norm_label": "formatexpensestaffprofilename()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "label": "expenseTransactions.ts",
-      "norm_label": "expensetransactions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
       "source_location": "L1"
     },
     {
@@ -61800,6 +61971,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "expensetransactions_createexpensetransactionfromsessionhandler",
+      "label": "createExpenseTransactionFromSessionHandler()",
+      "norm_label": "createexpensetransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "expensetransactions_expensetransactionerror",
+      "label": "expenseTransactionError()",
+      "norm_label": "expensetransactionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "expensetransactions_formatexpensestaffprofilename",
+      "label": "formatExpenseStaffProfileName()",
+      "norm_label": "formatexpensestaffprofilename()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
+      "label": "expenseTransactions.ts",
+      "norm_label": "expensetransactions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
       "norm_label": "calculateexpensesessionexpiration()",
@@ -61807,7 +62014,7 @@
       "source_location": "L21"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -61816,7 +62023,7 @@
       "source_location": "L35"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -61825,7 +62032,7 @@
       "source_location": "L45"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -61834,7 +62041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -61843,7 +62050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -61852,7 +62059,7 @@
       "source_location": "L21"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -61861,7 +62068,7 @@
       "source_location": "L35"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -61870,7 +62077,7 @@
       "source_location": "L45"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -61879,7 +62086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -61888,7 +62095,7 @@
       "source_location": "L248"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -61897,7 +62104,7 @@
       "source_location": "L92"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -61906,7 +62113,7 @@
       "source_location": "L265"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -61915,7 +62122,7 @@
       "source_location": "L5"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -61924,7 +62131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -61933,7 +62140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -61942,7 +62149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -61951,7 +62158,7 @@
       "source_location": "L26"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -61960,7 +62167,7 @@
       "source_location": "L79"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -61969,7 +62176,7 @@
       "source_location": "L33"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -61978,7 +62185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -61987,7 +62194,7 @@
       "source_location": "L10"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -61996,7 +62203,7 @@
       "source_location": "L18"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -62005,7 +62212,7 @@
       "source_location": "L52"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -62014,7 +62221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -62023,7 +62230,7 @@
       "source_location": "L98"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -62032,7 +62239,7 @@
       "source_location": "L56"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -62041,7 +62248,7 @@
       "source_location": "L49"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -62050,7 +62257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -62059,7 +62266,7 @@
       "source_location": "L28"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -62068,7 +62275,7 @@
       "source_location": "L42"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -62077,7 +62284,7 @@
       "source_location": "L73"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -62086,7 +62293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -62095,7 +62302,7 @@
       "source_location": "L8"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -62104,7 +62311,7 @@
       "source_location": "L32"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -62113,48 +62320,12 @@
       "source_location": "L64"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
       "norm_label": "operationalworkitems.ts",
       "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "operationsqueryindexes_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "operationsqueryindexes_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "operationsqueryindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
-      "label": "operationsQueryIndexes.test.ts",
-      "norm_label": "operationsqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
       "source_location": "L1"
     },
     {
@@ -62322,6 +62493,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "operationsqueryindexes_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "operationsqueryindexes_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "operationsqueryindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
+      "label": "operationsQueryIndexes.test.ts",
+      "norm_label": "operationsqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
       "norm_label": "registersessiontracing.test.ts",
@@ -62329,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -62338,7 +62545,7 @@
       "source_location": "L33"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -62347,7 +62554,7 @@
       "source_location": "L19"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -62356,7 +62563,7 @@
       "source_location": "L42"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -62365,7 +62572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -62374,7 +62581,7 @@
       "source_location": "L31"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -62383,7 +62590,7 @@
       "source_location": "L48"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -62392,7 +62599,7 @@
       "source_location": "L131"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -62401,7 +62608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -62410,7 +62617,7 @@
       "source_location": "L37"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -62419,7 +62626,7 @@
       "source_location": "L24"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -62428,7 +62635,7 @@
       "source_location": "L19"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -62437,7 +62644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -62446,7 +62653,7 @@
       "source_location": "L31"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -62455,7 +62662,7 @@
       "source_location": "L26"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -62464,7 +62671,7 @@
       "source_location": "L53"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -62473,7 +62680,7 @@
       "source_location": "L36"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -62482,7 +62689,7 @@
       "source_location": "L96"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -62491,7 +62698,7 @@
       "source_location": "L71"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -62500,7 +62707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -62509,7 +62716,7 @@
       "source_location": "L21"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -62518,7 +62725,7 @@
       "source_location": "L42"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -62527,7 +62734,7 @@
       "source_location": "L80"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -62536,7 +62743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -62545,7 +62752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -62554,7 +62761,7 @@
       "source_location": "L122"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -62563,7 +62770,7 @@
       "source_location": "L34"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -62572,7 +62779,7 @@
       "source_location": "L72"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -62581,7 +62788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -62590,7 +62797,7 @@
       "source_location": "L162"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -62599,7 +62806,7 @@
       "source_location": "L56"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -62608,7 +62815,7 @@
       "source_location": "L180"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -62617,7 +62824,7 @@
       "source_location": "L32"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -62626,7 +62833,7 @@
       "source_location": "L177"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -62635,49 +62842,13 @@
       "source_location": "L28"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
       "norm_label": "adjustments.test.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
-      "label": "replenishment.test.ts",
-      "norm_label": "replenishment.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "replenishment_test_createreplenishmentqueryctx",
-      "label": "createReplenishmentQueryCtx()",
-      "norm_label": "createreplenishmentqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "replenishment_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "replenishment_test_toasynciterable",
-      "label": "toAsyncIterable()",
-      "norm_label": "toasynciterable()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L13"
     },
     {
       "community": 24,
@@ -62835,6 +63006,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
+      "label": "replenishment.test.ts",
+      "norm_label": "replenishment.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "replenishment_test_createreplenishmentqueryctx",
+      "label": "createReplenishmentQueryCtx()",
+      "norm_label": "createreplenishmentqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "replenishment_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "replenishment_test_toasynciterable",
+      "label": "toAsyncIterable()",
+      "norm_label": "toasynciterable()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -62842,7 +63049,7 @@
       "source_location": "L19"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -62851,7 +63058,7 @@
       "source_location": "L26"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -62860,7 +63067,7 @@
       "source_location": "L12"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -62869,7 +63076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -62878,7 +63085,7 @@
       "source_location": "L21"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -62887,7 +63094,7 @@
       "source_location": "L63"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -62896,7 +63103,7 @@
       "source_location": "L71"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -62905,7 +63112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -62914,7 +63121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -62923,7 +63130,7 @@
       "source_location": "L13"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -62932,7 +63139,7 @@
       "source_location": "L31"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -62941,7 +63148,7 @@
       "source_location": "L9"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -62950,7 +63157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -62959,7 +63166,7 @@
       "source_location": "L12"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -62968,7 +63175,7 @@
       "source_location": "L46"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -62977,7 +63184,7 @@
       "source_location": "L7"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -62986,7 +63193,7 @@
       "source_location": "L227"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -62995,7 +63202,7 @@
       "source_location": "L46"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -63004,7 +63211,7 @@
       "source_location": "L27"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -63013,7 +63220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -63022,7 +63229,7 @@
       "source_location": "L55"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -63031,7 +63238,7 @@
       "source_location": "L32"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -63040,7 +63247,7 @@
       "source_location": "L211"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -63049,7 +63256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -63058,7 +63265,7 @@
       "source_location": "L52"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -63067,7 +63274,7 @@
       "source_location": "L27"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -63076,7 +63283,7 @@
       "source_location": "L288"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -63085,7 +63292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -63094,7 +63301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -63103,7 +63310,7 @@
       "source_location": "L15"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -63112,7 +63319,7 @@
       "source_location": "L32"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -63121,7 +63328,7 @@
       "source_location": "L19"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -63130,7 +63337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -63139,7 +63346,7 @@
       "source_location": "L52"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -63148,49 +63355,13 @@
       "source_location": "L3"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
       "norm_label": "groupproductviewsbyday()",
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "label": "MaintenanceMessageEditor.tsx",
-      "norm_label": "maintenancemessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L1"
     },
     {
       "community": 25,
@@ -63348,6 +63519,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "maintenancemessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
+      "label": "MaintenanceMessageEditor.tsx",
+      "norm_label": "maintenancemessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
       "norm_label": "shoplook.tsx",
@@ -63355,7 +63562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -63364,7 +63571,7 @@
       "source_location": "L67"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -63373,7 +63580,7 @@
       "source_location": "L90"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -63382,7 +63589,7 @@
       "source_location": "L73"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -63391,7 +63598,7 @@
       "source_location": "L78"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -63400,7 +63607,7 @@
       "source_location": "L67"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -63409,7 +63616,7 @@
       "source_location": "L85"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -63418,7 +63625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -63427,7 +63634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -63436,7 +63643,7 @@
       "source_location": "L67"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -63445,7 +63652,7 @@
       "source_location": "L61"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -63454,7 +63661,7 @@
       "source_location": "L73"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -63463,7 +63670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -63472,7 +63679,7 @@
       "source_location": "L105"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -63481,7 +63688,7 @@
       "source_location": "L97"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -63490,7 +63697,7 @@
       "source_location": "L83"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -63499,7 +63706,7 @@
       "source_location": "L91"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -63508,7 +63715,7 @@
       "source_location": "L68"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -63517,7 +63724,7 @@
       "source_location": "L22"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -63526,7 +63733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -63535,7 +63742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -63544,7 +63751,7 @@
       "source_location": "L162"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -63553,7 +63760,7 @@
       "source_location": "L384"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -63562,7 +63769,7 @@
       "source_location": "L345"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -63571,7 +63778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -63580,7 +63787,7 @@
       "source_location": "L22"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -63589,7 +63796,7 @@
       "source_location": "L27"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -63598,7 +63805,7 @@
       "source_location": "L40"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -63607,7 +63814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -63616,7 +63823,7 @@
       "source_location": "L78"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -63625,7 +63832,7 @@
       "source_location": "L118"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -63634,7 +63841,7 @@
       "source_location": "L89"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -63643,7 +63850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -63652,7 +63859,7 @@
       "source_location": "L63"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -63661,49 +63868,13 @@
       "source_location": "L54"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
       "norm_label": "productstockstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -63861,6 +64032,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
       "norm_label": "promocodemoney.ts",
@@ -63868,7 +64075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -63877,7 +64084,7 @@
       "source_location": "L5"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -63886,7 +64093,7 @@
       "source_location": "L30"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -63895,7 +64102,7 @@
       "source_location": "L21"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -63904,7 +64111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -63913,7 +64120,7 @@
       "source_location": "L178"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -63922,7 +64129,7 @@
       "source_location": "L205"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -63931,7 +64138,7 @@
       "source_location": "L806"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -63940,7 +64147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -63949,7 +64156,7 @@
       "source_location": "L41"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -63958,7 +64165,7 @@
       "source_location": "L45"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -63967,7 +64174,7 @@
       "source_location": "L65"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -63976,7 +64183,7 @@
       "source_location": "L75"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -63985,7 +64192,7 @@
       "source_location": "L82"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -63994,7 +64201,7 @@
       "source_location": "L93"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -64003,7 +64210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -64012,7 +64219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -64021,7 +64228,7 @@
       "source_location": "L15"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -64030,7 +64237,7 @@
       "source_location": "L28"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -64039,7 +64246,7 @@
       "source_location": "L54"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -64048,7 +64255,7 @@
       "source_location": "L66"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -64057,7 +64264,7 @@
       "source_location": "L121"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -64066,7 +64273,7 @@
       "source_location": "L74"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -64075,7 +64282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -64084,7 +64291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -64093,7 +64300,7 @@
       "source_location": "L34"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -64102,7 +64309,7 @@
       "source_location": "L28"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -64111,7 +64318,7 @@
       "source_location": "L48"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -64120,7 +64327,7 @@
       "source_location": "L51"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -64129,7 +64336,7 @@
       "source_location": "L92"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -64138,7 +64345,7 @@
       "source_location": "L16"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -64147,7 +64354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -64156,7 +64363,7 @@
       "source_location": "L22"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -64165,7 +64372,7 @@
       "source_location": "L10"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -64174,49 +64381,13 @@
       "source_location": "L57"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
       "norm_label": "customergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
     },
     {
       "community": 27,
@@ -64365,6 +64536,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
       "norm_label": "sessiongateway.ts",
@@ -64372,7 +64579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -64381,7 +64588,7 @@
       "source_location": "L38"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -64390,7 +64597,7 @@
       "source_location": "L65"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -64399,7 +64606,7 @@
       "source_location": "L91"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -64408,7 +64615,7 @@
       "source_location": "L4"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -64417,7 +64624,7 @@
       "source_location": "L20"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -64426,7 +64633,7 @@
       "source_location": "L42"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -64435,7 +64642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -64444,7 +64651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -64453,7 +64660,7 @@
       "source_location": "L37"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -64462,7 +64669,7 @@
       "source_location": "L49"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -64471,7 +64678,7 @@
       "source_location": "L65"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -64480,7 +64687,7 @@
       "source_location": "L13"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -64489,7 +64696,7 @@
       "source_location": "L46"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -64498,7 +64705,7 @@
       "source_location": "L21"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -64507,7 +64714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -64516,7 +64723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -64525,7 +64732,7 @@
       "source_location": "L8"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -64534,7 +64741,7 @@
       "source_location": "L5"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -64543,7 +64750,7 @@
       "source_location": "L20"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -64552,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -64561,7 +64768,7 @@
       "source_location": "L11"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -64570,7 +64777,7 @@
       "source_location": "L9"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -64579,7 +64786,7 @@
       "source_location": "L25"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -64588,7 +64795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -64597,7 +64804,7 @@
       "source_location": "L50"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -64606,7 +64813,7 @@
       "source_location": "L92"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -64615,7 +64822,7 @@
       "source_location": "L74"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -64624,7 +64831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -64633,7 +64840,7 @@
       "source_location": "L62"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -64642,7 +64849,7 @@
       "source_location": "L109"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -64651,7 +64858,7 @@
       "source_location": "L177"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -64660,7 +64867,7 @@
       "source_location": "L18"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -64669,7 +64876,7 @@
       "source_location": "L52"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -64678,48 +64885,12 @@
       "source_location": "L68"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
       "norm_label": "billingdetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -64869,6 +65040,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
       "norm_label": "productattribute.tsx",
@@ -64876,7 +65083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -64885,7 +65092,7 @@
       "source_location": "L81"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -64894,7 +65101,7 @@
       "source_location": "L85"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -64903,7 +65110,7 @@
       "source_location": "L27"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -64912,7 +65119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -64921,7 +65128,7 @@
       "source_location": "L43"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -64930,7 +65137,7 @@
       "source_location": "L13"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -64939,7 +65146,7 @@
       "source_location": "L88"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -64948,7 +65155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -64957,7 +65164,7 @@
       "source_location": "L111"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -64966,7 +65173,7 @@
       "source_location": "L66"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -64975,7 +65182,7 @@
       "source_location": "L127"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -64984,7 +65191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -64993,7 +65200,7 @@
       "source_location": "L25"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -65002,7 +65209,7 @@
       "source_location": "L90"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -65011,7 +65218,7 @@
       "source_location": "L82"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -65020,7 +65227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -65029,7 +65236,7 @@
       "source_location": "L115"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -65038,7 +65245,7 @@
       "source_location": "L105"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -65047,7 +65254,7 @@
       "source_location": "L110"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -65056,7 +65263,7 @@
       "source_location": "L121"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -65065,7 +65272,7 @@
       "source_location": "L26"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -65074,7 +65281,7 @@
       "source_location": "L71"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -65083,7 +65290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -65092,7 +65299,7 @@
       "source_location": "L46"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -65101,7 +65308,7 @@
       "source_location": "L24"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -65110,7 +65317,7 @@
       "source_location": "L20"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -65119,7 +65326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -65128,7 +65335,7 @@
       "source_location": "L17"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -65137,7 +65344,7 @@
       "source_location": "L11"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -65146,7 +65353,7 @@
       "source_location": "L24"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -65155,7 +65362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -65164,7 +65371,7 @@
       "source_location": "L20"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -65173,7 +65380,7 @@
       "source_location": "L65"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -65182,48 +65389,12 @@
       "source_location": "L14"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
       "norm_label": "graphify-rebuild.test.ts",
       "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpaths",
-      "label": "buildHarnessDocPaths()",
-      "norm_label": "buildharnessdocpaths()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
-      "label": "buildHarnessDocPathsForArchetype()",
-      "norm_label": "buildharnessdocpathsforarchetype()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "harness_app_registry_getharnesspackageregistration",
-      "label": "getHarnessPackageRegistration()",
-      "norm_label": "getharnesspackageregistration()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L879"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_ts",
-      "label": "harness-app-registry.ts",
-      "norm_label": "harness-app-registry.ts",
-      "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1"
     },
     {
@@ -65373,6 +65544,42 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpaths",
+      "label": "buildHarnessDocPaths()",
+      "norm_label": "buildharnessdocpaths()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
+      "label": "buildHarnessDocPathsForArchetype()",
+      "norm_label": "buildharnessdocpathsforarchetype()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "harness_app_registry_getharnesspackageregistration",
+      "label": "getHarnessPackageRegistration()",
+      "norm_label": "getharnesspackageregistration()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L879"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_ts",
+      "label": "harness-app-registry.ts",
+      "norm_label": "harness-app-registry.ts",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
       "norm_label": "valkey-runtime-app.ts",
@@ -65380,7 +65587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -65389,7 +65596,7 @@
       "source_location": "L8"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -65398,7 +65605,7 @@
       "source_location": "L79"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -65407,7 +65614,7 @@
       "source_location": "L61"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65416,7 +65623,7 @@
       "source_location": "L49"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -65425,7 +65632,7 @@
       "source_location": "L17"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -65434,7 +65641,7 @@
       "source_location": "L11"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -65443,7 +65650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -65452,7 +65659,7 @@
       "source_location": "L26"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -65461,7 +65668,7 @@
       "source_location": "L72"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -65470,48 +65677,12 @@
       "source_location": "L36"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
       "norm_label": "harness-test.ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
-      "label": "runPreCommitGeneratedArtifacts()",
-      "norm_label": "runprecommitgeneratedartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
-      "label": "stageTrackedGeneratedArtifacts()",
-      "norm_label": "stagetrackedgeneratedartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedworkingtreechanges",
-      "label": "stageTrackedWorkingTreeChanges()",
-      "norm_label": "stagetrackedworkingtreechanges()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_ts",
-      "label": "pre-commit-generated-artifacts.ts",
-      "norm_label": "pre-commit-generated-artifacts.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
       "source_location": "L1"
     },
     {
@@ -71484,118 +71655,127 @@
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "github_pr_merge_deleteheadbranch",
+      "label": "deleteHeadBranch()",
+      "norm_label": "deleteheadbranch()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L207"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "github_pr_merge_enablepullrequestautomerge",
+      "label": "enablePullRequestAutoMerge()",
+      "norm_label": "enablepullrequestautomerge()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L225"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "github_pr_merge_encodegitrefpath",
+      "label": "encodeGitRefPath()",
+      "norm_label": "encodegitrefpath()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L268"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L341"
+      "id": "github_pr_merge_ghjson",
+      "label": "ghJson()",
+      "norm_label": "ghjson()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L272"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "github_pr_merge_helprequested",
+      "label": "HelpRequested",
+      "norm_label": "helprequested",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L318"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "github_pr_merge_mergepullrequest",
+      "label": "mergePullRequest()",
+      "norm_label": "mergepullrequest()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L65"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L469"
+      "id": "github_pr_merge_parseargs",
+      "label": "parseArgs()",
+      "norm_label": "parseargs()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L115"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "github_pr_merge_parsemergemethod",
+      "label": "parseMergeMethod()",
+      "norm_label": "parsemergemethod()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L328"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L375"
+      "id": "github_pr_merge_requirevalue",
+      "label": "requireValue()",
+      "norm_label": "requirevalue()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L320"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "github_pr_merge_resolvecurrentrepo",
+      "label": "resolveCurrentRepo()",
+      "norm_label": "resolvecurrentrepo()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L177"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "github_pr_merge_runprocess",
+      "label": "runProcess()",
+      "norm_label": "runprocess()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L294"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "github_pr_merge_shoulddeleteheadbranch",
+      "label": "shouldDeleteHeadBranch()",
+      "norm_label": "shoulddeleteheadbranch()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L264"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "github_pr_merge_viewpullrequest",
+      "label": "viewPullRequest()",
+      "norm_label": "viewpullrequest()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "scripts_github_pr_merge_ts",
+      "label": "github-pr-merge.ts",
+      "norm_label": "github-pr-merge.ts",
+      "source_file": "scripts/github-pr-merge.ts",
       "source_location": "L1"
     },
     {
@@ -71848,7 +72028,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L30"
+      "source_location": "L41"
     },
     {
       "community": 439,
@@ -71857,7 +72037,7 @@
       "label": "spawn()",
       "norm_label": "spawn()",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L22"
+      "source_location": "L33"
     },
     {
       "community": 439,
@@ -71871,118 +72051,118 @@
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_buildcompletetransactionresult",
-      "label": "buildCompleteTransactionResult()",
-      "norm_label": "buildcompletetransactionresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L46"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_calculatetotalpaid",
-      "label": "calculateTotalPaid()",
-      "norm_label": "calculatetotalpaid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L67"
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_completetransaction",
-      "label": "completeTransaction()",
-      "norm_label": "completetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L5"
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_createtransactionfromsessionhandler",
-      "label": "createTransactionFromSessionHandler()",
-      "norm_label": "createtransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L480"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L341"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L86"
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_recordregistersessionsale",
-      "label": "recordRegisterSessionSale()",
-      "norm_label": "recordregistersessionsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionvoid",
-      "label": "recordRegisterSessionVoid()",
-      "norm_label": "recordregistersessionvoid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "completetransaction_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L71"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_resolvesessionregistersessionid",
-      "label": "resolveSessionRegisterSessionId()",
-      "norm_label": "resolvesessionregistersessionid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L469"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L375"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L90"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L190"
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "completetransaction_voidtransaction",
-      "label": "voidTransaction()",
-      "norm_label": "voidtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L404"
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
     },
     {
@@ -72186,119 +72366,119 @@
     {
       "community": 45,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_ts",
-      "label": "serviceCases.ts",
-      "norm_label": "servicecases.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L1"
+      "id": "completetransaction_buildcompletetransactionresult",
+      "label": "buildCompleteTransactionResult()",
+      "norm_label": "buildcompletetransactionresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L46"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_assertvalidservicecasestatustransition",
-      "label": "assertValidServiceCaseStatusTransition()",
-      "norm_label": "assertvalidservicecasestatustransition()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L226"
+      "id": "completetransaction_calculatetotalpaid",
+      "label": "calculateTotalPaid()",
+      "norm_label": "calculatetotalpaid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L67"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_buildservicecase",
-      "label": "buildServiceCase()",
-      "norm_label": "buildservicecase()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L240"
+      "id": "completetransaction_completetransaction",
+      "label": "completeTransaction()",
+      "norm_label": "completetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L5"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_buildservicecaselineitem",
-      "label": "buildServiceCaseLineItem()",
-      "norm_label": "buildservicecaselineitem()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L268"
+      "id": "completetransaction_createtransactionfromsessionhandler",
+      "label": "createTransactionFromSessionHandler()",
+      "norm_label": "createtransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L480"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_createservicecasewithctx",
-      "label": "createServiceCaseWithCtx()",
-      "norm_label": "createservicecasewithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L304"
+      "id": "completetransaction_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L86"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_deriveservicecasepaymentstatus",
-      "label": "deriveServiceCasePaymentStatus()",
-      "norm_label": "deriveservicecasepaymentstatus()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L87"
+      "id": "completetransaction_recordregistersessionsale",
+      "label": "recordRegisterSessionSale()",
+      "norm_label": "recordregistersessionsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L140"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_getservicecasecontext",
-      "label": "getServiceCaseContext()",
-      "norm_label": "getservicecasecontext()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L191"
+      "id": "completetransaction_recordregistersessionvoid",
+      "label": "recordRegisterSessionVoid()",
+      "norm_label": "recordregistersessionvoid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L165"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_listpendingapprovalrequestswithctx",
-      "label": "listPendingApprovalRequestsWithCtx()",
-      "norm_label": "listpendingapprovalrequestswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "servicecases_listservicecaseallocationswithctx",
-      "label": "listServiceCaseAllocationsWithCtx()",
-      "norm_label": "listservicecaseallocationswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "servicecases_listservicecaselineitemswithctx",
-      "label": "listServiceCaseLineItemsWithCtx()",
-      "norm_label": "listservicecaselineitemswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "servicecases_listserviceinventoryusagewithctx",
-      "label": "listServiceInventoryUsageWithCtx()",
-      "norm_label": "listserviceinventoryusagewithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "servicecases_mapservicecasestatustoworkitemstatus",
-      "label": "mapServiceCaseStatusToWorkItemStatus()",
-      "norm_label": "mapservicecasestatustoworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "id": "completetransaction_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
       "source_location": "L71"
     },
     {
       "community": 45,
       "file_type": "code",
-      "id": "servicecases_syncservicecasefinancialswithctx",
-      "label": "syncServiceCaseFinancialsWithCtx()",
-      "norm_label": "syncservicecasefinancialswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L156"
+      "id": "completetransaction_resolvesessionregistersessionid",
+      "label": "resolveSessionRegisterSessionId()",
+      "norm_label": "resolvesessionregistersessionid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "completetransaction_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "completetransaction_voidtransaction",
+      "label": "voidTransaction()",
+      "norm_label": "voidtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L1"
     },
     {
       "community": 450,
@@ -72483,119 +72663,119 @@
     {
       "community": 46,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
-      "label": "receiving.ts",
-      "norm_label": "receiving.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_ts",
+      "label": "serviceCases.ts",
+      "norm_label": "servicecases.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
       "source_location": "L1"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_assertdistinctreceivinglineitems",
-      "label": "assertDistinctReceivingLineItems()",
-      "norm_label": "assertdistinctreceivinglineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "servicecases_assertvalidservicecasestatustransition",
+      "label": "assertValidServiceCaseStatusTransition()",
+      "norm_label": "assertvalidservicecasestatustransition()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "servicecases_buildservicecase",
+      "label": "buildServiceCase()",
+      "norm_label": "buildservicecase()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "servicecases_buildservicecaselineitem",
+      "label": "buildServiceCaseLineItem()",
+      "norm_label": "buildservicecaselineitem()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "servicecases_createservicecasewithctx",
+      "label": "createServiceCaseWithCtx()",
+      "norm_label": "createservicecasewithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L304"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "servicecases_deriveservicecasepaymentstatus",
+      "label": "deriveServiceCasePaymentStatus()",
+      "norm_label": "deriveservicecasepaymentstatus()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
       "source_location": "L87"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_assertreceivablepurchaseorderstatus",
-      "label": "assertReceivablePurchaseOrderStatus()",
-      "norm_label": "assertreceivablepurchaseorderstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L63"
+      "id": "servicecases_getservicecasecontext",
+      "label": "getServiceCaseContext()",
+      "norm_label": "getservicecasecontext()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L191"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_assertreceivinglinequantities",
-      "label": "assertReceivingLineQuantities()",
-      "norm_label": "assertreceivinglinequantities()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L73"
+      "id": "servicecases_listpendingapprovalrequestswithctx",
+      "label": "listPendingApprovalRequestsWithCtx()",
+      "norm_label": "listpendingapprovalrequestswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L144"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_buildreceivingbatchsourceid",
-      "label": "buildReceivingBatchSourceId()",
-      "norm_label": "buildreceivingbatchsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L135"
+      "id": "servicecases_listservicecaseallocationswithctx",
+      "label": "listServiceCaseAllocationsWithCtx()",
+      "norm_label": "listservicecaseallocationswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L131"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_calculatepurchaseorderreceivingstatus",
-      "label": "calculatePurchaseOrderReceivingStatus()",
-      "norm_label": "calculatepurchaseorderreceivingstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L53"
+      "id": "servicecases_listservicecaselineitemswithctx",
+      "label": "listServiceCaseLineItemsWithCtx()",
+      "norm_label": "listservicecaselineitemswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L111"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_calculatereceivingbatchtotals",
-      "label": "calculateReceivingBatchTotals()",
-      "norm_label": "calculatereceivingbatchtotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L32"
+      "id": "servicecases_listserviceinventoryusagewithctx",
+      "label": "listServiceInventoryUsageWithCtx()",
+      "norm_label": "listserviceinventoryusagewithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L121"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L142"
+      "id": "servicecases_mapservicecasestatustoworkitemstatus",
+      "label": "mapServiceCaseStatusToWorkItemStatus()",
+      "norm_label": "mapservicecasestatustoworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L71"
     },
     {
       "community": 46,
       "file_type": "code",
-      "id": "receiving_mapreceivepurchaseorderbatcherror",
-      "label": "mapReceivePurchaseOrderBatchError()",
-      "norm_label": "mapreceivepurchaseorderbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
-      "label": "receivePurchaseOrderBatchCommandWithCtx()",
-      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L390"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchwithctx",
-      "label": "receivePurchaseOrderBatchWithCtx()",
-      "norm_label": "receivepurchaseorderbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "receiving_summarizereceivingskudeltas",
-      "label": "summarizeReceivingSkuDeltas()",
-      "norm_label": "summarizereceivingskudeltas()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "receiving_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L27"
+      "id": "servicecases_syncservicecasefinancialswithctx",
+      "label": "syncServiceCaseFinancialsWithCtx()",
+      "norm_label": "syncservicecasefinancialswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L156"
     },
     {
       "community": 460,
@@ -72780,119 +72960,119 @@
     {
       "community": 47,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
+      "label": "receiving.ts",
+      "norm_label": "receiving.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
       "source_location": "L1"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "receiving_assertdistinctreceivinglineitems",
+      "label": "assertDistinctReceivingLineItems()",
+      "norm_label": "assertdistinctreceivinglineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L87"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "receiving_assertreceivablepurchaseorderstatus",
+      "label": "assertReceivablePurchaseOrderStatus()",
+      "norm_label": "assertreceivablepurchaseorderstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L63"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "receiving_assertreceivinglinequantities",
+      "label": "assertReceivingLineQuantities()",
+      "norm_label": "assertreceivinglinequantities()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L73"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "receiving_buildreceivingbatchsourceid",
+      "label": "buildReceivingBatchSourceId()",
+      "norm_label": "buildreceivingbatchsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "receiving_calculatepurchaseorderreceivingstatus",
+      "label": "calculatePurchaseOrderReceivingStatus()",
+      "norm_label": "calculatepurchaseorderreceivingstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "receiving_calculatereceivingbatchtotals",
+      "label": "calculateReceivingBatchTotals()",
+      "norm_label": "calculatereceivingbatchtotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
       "source_location": "L32"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "receiving_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L142"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "receiving_mapreceivepurchaseorderbatcherror",
+      "label": "mapReceivePurchaseOrderBatchError()",
+      "norm_label": "mapreceivepurchaseorderbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L347"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
+      "label": "receivePurchaseOrderBatchCommandWithCtx()",
+      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L390"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "receiving_receivepurchaseorderbatchwithctx",
+      "label": "receivePurchaseOrderBatchWithCtx()",
+      "norm_label": "receivepurchaseorderbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L171"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "receiving_summarizereceivingskudeltas",
+      "label": "summarizeReceivingSkuDeltas()",
+      "norm_label": "summarizereceivingskudeltas()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L103"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "receiving_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L27"
     },
     {
       "community": 470,
@@ -73077,119 +73257,119 @@
     {
       "community": 48,
       "file_type": "code",
-      "id": "coverage_summary_addtoaggregate",
-      "label": "addToAggregate()",
-      "norm_label": "addtoaggregate()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_buildcoveragereport",
-      "label": "buildCoverageReport()",
-      "norm_label": "buildcoveragereport()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_checksourcethresholds",
-      "label": "checkSourceThresholds()",
-      "norm_label": "checksourcethresholds()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L159"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_emptysummary",
-      "label": "emptySummary()",
-      "norm_label": "emptysummary()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_formatmetric",
-      "label": "formatMetric()",
-      "norm_label": "formatmetric()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_parselcovsummary",
-      "label": "parseLcovSummary()",
-      "norm_label": "parselcovsummary()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_percentage",
-      "label": "percentage()",
-      "norm_label": "percentage()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_pickmetric",
-      "label": "pickMetric()",
-      "norm_label": "pickmetric()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_printcoveragereport",
-      "label": "printCoverageReport()",
-      "norm_label": "printcoveragereport()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_readvitestjsonsummary",
-      "label": "readVitestJsonSummary()",
-      "norm_label": "readvitestjsonsummary()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_resolvesourcesummary",
-      "label": "resolveSourceSummary()",
-      "norm_label": "resolvesourcesummary()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "coverage_summary_tocoveragesummary",
-      "label": "toCoverageSummary()",
-      "norm_label": "tocoveragesummary()",
-      "source_file": "scripts/coverage-summary.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "scripts_coverage_summary_ts",
-      "label": "coverage-summary.ts",
-      "norm_label": "coverage-summary.ts",
-      "source_file": "scripts/coverage-summary.ts",
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 480,
@@ -73374,109 +73554,118 @@
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_deleteheadbranch",
-      "label": "deleteHeadBranch()",
-      "norm_label": "deleteheadbranch()",
-      "source_file": "scripts/github-pr-merge.ts",
+      "id": "coverage_summary_addtoaggregate",
+      "label": "addToAggregate()",
+      "norm_label": "addtoaggregate()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "coverage_summary_buildcoveragereport",
+      "label": "buildCoverageReport()",
+      "norm_label": "buildcoveragereport()",
+      "source_file": "scripts/coverage-summary.ts",
       "source_location": "L179"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_encodegitrefpath",
-      "label": "encodeGitRefPath()",
-      "norm_label": "encodegitrefpath()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L201"
+      "id": "coverage_summary_checksourcethresholds",
+      "label": "checkSourceThresholds()",
+      "norm_label": "checksourcethresholds()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L159"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_ghjson",
-      "label": "ghJson()",
-      "norm_label": "ghjson()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L205"
+      "id": "coverage_summary_emptysummary",
+      "label": "emptySummary()",
+      "norm_label": "emptysummary()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L79"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_mergepullrequest",
-      "label": "mergePullRequest()",
-      "norm_label": "mergepullrequest()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L50"
+      "id": "coverage_summary_formatmetric",
+      "label": "formatMetric()",
+      "norm_label": "formatmetric()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L147"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_parseargs",
-      "label": "parseArgs()",
-      "norm_label": "parseargs()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L95"
+      "id": "coverage_summary_parselcovsummary",
+      "label": "parseLcovSummary()",
+      "norm_label": "parselcovsummary()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L109"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_parsemergemethod",
-      "label": "parseMergeMethod()",
-      "norm_label": "parsemergemethod()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L259"
+      "id": "coverage_summary_percentage",
+      "label": "percentage()",
+      "norm_label": "percentage()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L75"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_requirevalue",
-      "label": "requireValue()",
-      "norm_label": "requirevalue()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L251"
+      "id": "coverage_summary_pickmetric",
+      "label": "pickMetric()",
+      "norm_label": "pickmetric()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L97"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_resolvecurrentrepo",
-      "label": "resolveCurrentRepo()",
-      "norm_label": "resolvecurrentrepo()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L149"
+      "id": "coverage_summary_printcoveragereport",
+      "label": "printCoverageReport()",
+      "norm_label": "printcoveragereport()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L198"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_runprocess",
-      "label": "runProcess()",
-      "norm_label": "runprocess()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L227"
+      "id": "coverage_summary_readvitestjsonsummary",
+      "label": "readVitestJsonSummary()",
+      "norm_label": "readvitestjsonsummary()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L105"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_shoulddeleteheadbranch",
-      "label": "shouldDeleteHeadBranch()",
-      "norm_label": "shoulddeleteheadbranch()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L197"
+      "id": "coverage_summary_resolvesourcesummary",
+      "label": "resolveSourceSummary()",
+      "norm_label": "resolvesourcesummary()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L151"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "github_pr_merge_viewpullrequest",
-      "label": "viewPullRequest()",
-      "norm_label": "viewpullrequest()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L158"
+      "id": "coverage_summary_tocoveragesummary",
+      "label": "toCoverageSummary()",
+      "norm_label": "tocoveragesummary()",
+      "source_file": "scripts/coverage-summary.ts",
+      "source_location": "L88"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "scripts_github_pr_merge_ts",
-      "label": "github-pr-merge.ts",
-      "norm_label": "github-pr-merge.ts",
-      "source_file": "scripts/github-pr-merge.ts",
+      "id": "scripts_coverage_summary_ts",
+      "label": "coverage-summary.ts",
+      "norm_label": "coverage-summary.ts",
+      "source_file": "scripts/coverage-summary.ts",
       "source_location": "L1"
     },
     {
@@ -79116,83 +79305,92 @@
     {
       "community": 68,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "pre_commit_generated_artifacts_collectconvexsourcemodules",
+      "label": "collectConvexSourceModules()",
+      "norm_label": "collectconvexsourcemodules()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_collectconvexsourcemodulesfromdir",
+      "label": "collectConvexSourceModulesFromDir()",
+      "norm_label": "collectconvexsourcemodulesfromdir()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_hasathenaconvexsourcechanges",
+      "label": "hasAthenaConvexSourceChanges()",
+      "norm_label": "hasathenaconvexsourcechanges()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_readgeneratedconvexapimodules",
+      "label": "readGeneratedConvexApiModules()",
+      "norm_label": "readgeneratedconvexapimodules()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_refreshathenaconvexgeneratedapi",
+      "label": "refreshAthenaConvexGeneratedApi()",
+      "norm_label": "refreshathenaconvexgeneratedapi()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "label": "runPreCommitGeneratedArtifacts()",
+      "norm_label": "runprecommitgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedgeneratedartifacts",
+      "label": "stageTrackedGeneratedArtifacts()",
+      "norm_label": "stagetrackedgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedworkingtreechanges",
+      "label": "stageTrackedWorkingTreeChanges()",
+      "norm_label": "stagetrackedworkingtreechanges()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_verifyathenaconvexgeneratedapi",
+      "label": "verifyAthenaConvexGeneratedApi()",
+      "norm_label": "verifyathenaconvexgeneratedapi()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_ts",
+      "label": "pre-commit-generated-artifacts.ts",
+      "norm_label": "pre-commit-generated-artifacts.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L78"
     },
     {
       "community": 680,
@@ -79377,83 +79575,83 @@
     {
       "community": 69,
       "file_type": "code",
-      "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "label": "buildCustomerObservabilityTimeline()",
-      "norm_label": "buildcustomerobservabilitytimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
-      "label": "getOperationalEventJourney()",
-      "norm_label": "getoperationaleventjourney()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
-      "label": "getOperationalEventStatus()",
-      "norm_label": "getoperationaleventstatus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventstep",
-      "label": "getOperationalEventStep()",
-      "norm_label": "getoperationaleventstep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "label": "isFailureStatus()",
-      "norm_label": "isfailurestatus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
-      "label": "isOperationalEventDoc()",
-      "norm_label": "isoperationaleventdoc()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_normalizeevent",
-      "label": "normalizeEvent()",
-      "norm_label": "normalizeevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
-      "label": "customerObservabilityTimelineData.ts",
-      "norm_label": "customerobservabilitytimelinedata.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L78"
     },
     {
       "community": 690,
@@ -79890,83 +80088,83 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
+      "label": "buildCustomerObservabilityTimeline()",
+      "norm_label": "buildcustomerobservabilitytimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
+      "label": "getOperationalEventJourney()",
+      "norm_label": "getoperationaleventjourney()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
+      "label": "getOperationalEventStatus()",
+      "norm_label": "getoperationaleventstatus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getoperationaleventstep",
+      "label": "getOperationalEventStep()",
+      "norm_label": "getoperationaleventstep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_isfailurestatus",
+      "label": "isFailureStatus()",
+      "norm_label": "isfailurestatus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
+      "label": "isOperationalEventDoc()",
+      "norm_label": "isoperationaleventdoc()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_normalizeevent",
+      "label": "normalizeEvent()",
+      "norm_label": "normalizeevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
+      "label": "customerObservabilityTimelineData.ts",
+      "norm_label": "customerobservabilitytimelinedata.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L241"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L372"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L361"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_updateproductvisibility",
-      "label": "updateProductVisibility()",
-      "norm_label": "updateproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L423"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L294"
     },
     {
       "community": 700,
@@ -80151,83 +80349,83 @@
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
-      "label": "refundUtils.ts",
-      "norm_label": "refundutils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "refundutils_calculaterefundamount",
-      "label": "calculateRefundAmount()",
-      "norm_label": "calculaterefundamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L124"
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L241"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "refundutils_getamountrefunded",
-      "label": "getAmountRefunded()",
-      "norm_label": "getamountrefunded()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L98"
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L83"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "refundutils_getavailableitems",
-      "label": "getAvailableItems()",
-      "norm_label": "getavailableitems()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L372"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L361"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "refundutils_getitemstorefund",
-      "label": "getItemsToRefund()",
-      "norm_label": "getitemstorefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L174"
+      "id": "productview_updateproductvisibility",
+      "label": "updateProductVisibility()",
+      "norm_label": "updateproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L423"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "refundutils_getnetamount",
-      "label": "getNetAmount()",
-      "norm_label": "getnetamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "refundutils_refundreducer",
-      "label": "refundReducer()",
-      "norm_label": "refundreducer()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "refundutils_shouldshowreturntostock",
-      "label": "shouldShowReturnToStock()",
-      "norm_label": "shouldshowreturntostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "refundutils_validaterefund",
-      "label": "validateRefund()",
-      "norm_label": "validaterefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L199"
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L294"
     },
     {
       "community": 710,
@@ -80412,83 +80610,83 @@
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
-      "label": "ServiceCatalogView.tsx",
-      "norm_label": "servicecatalogview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
+      "label": "refundUtils.ts",
+      "norm_label": "refundutils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L187"
+      "id": "refundutils_calculaterefundamount",
+      "label": "calculateRefundAmount()",
+      "norm_label": "calculaterefundamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L124"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_handleedit",
-      "label": "handleEdit()",
-      "norm_label": "handleedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L197"
+      "id": "refundutils_getamountrefunded",
+      "label": "getAmountRefunded()",
+      "norm_label": "getamountrefunded()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L98"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_handlereset",
-      "label": "handleReset()",
-      "norm_label": "handlereset()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L203"
+      "id": "refundutils_getavailableitems",
+      "label": "getAvailableItems()",
+      "norm_label": "getavailableitems()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L115"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L209"
+      "id": "refundutils_getitemstorefund",
+      "label": "getItemsToRefund()",
+      "norm_label": "getitemstorefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L174"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_itemtoformstate",
-      "label": "itemToFormState()",
-      "norm_label": "itemtoformstate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L101"
+      "id": "refundutils_getnetamount",
+      "label": "getNetAmount()",
+      "norm_label": "getnetamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L106"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_parseservicecatalogform",
-      "label": "parseServiceCatalogForm()",
-      "norm_label": "parseservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L121"
+      "id": "refundutils_refundreducer",
+      "label": "refundReducer()",
+      "norm_label": "refundreducer()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L31"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_validateservicecatalogform",
-      "label": "validateServiceCatalogForm()",
-      "norm_label": "validateservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L74"
+      "id": "refundutils_shouldshowreturntostock",
+      "label": "shouldShowReturnToStock()",
+      "norm_label": "shouldshowreturntostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L255"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "servicecatalogview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L499"
+      "id": "refundutils_validaterefund",
+      "label": "validateRefund()",
+      "norm_label": "validaterefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L199"
     },
     {
       "community": 720,
@@ -80673,83 +80871,83 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "label": "handleDeliveryRestrictionToggle()",
-      "norm_label": "handledeliveryrestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L155"
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
+      "label": "ServiceCatalogView.tsx",
+      "norm_label": "servicecatalogview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "label": "handlePickupRestrictionToggle()",
-      "norm_label": "handlepickuprestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L116"
+      "id": "servicecatalogview_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L187"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "label": "handleSaveDeliveryRestriction()",
-      "norm_label": "handlesavedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "id": "servicecatalogview_handleedit",
+      "label": "handleEdit()",
+      "norm_label": "handleedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "servicecatalogview_handlereset",
+      "label": "handleReset()",
+      "norm_label": "handlereset()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
       "source_location": "L203"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_handlesavepickuprestriction",
-      "label": "handleSavePickupRestriction()",
-      "norm_label": "handlesavepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L194"
+      "id": "servicecatalogview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L209"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_savedeliveryrestriction",
-      "label": "saveDeliveryRestriction()",
-      "norm_label": "savedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "id": "servicecatalogview_itemtoformstate",
+      "label": "itemToFormState()",
+      "norm_label": "itemtoformstate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
       "source_location": "L101"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_saveenabledeliverychanges",
-      "label": "saveEnableDeliveryChanges()",
-      "norm_label": "saveenabledeliverychanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L63"
+      "id": "servicecatalogview_parseservicecatalogform",
+      "label": "parseServiceCatalogForm()",
+      "norm_label": "parseservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L121"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_saveenablestorepickupchanges",
-      "label": "saveEnableStorePickupChanges()",
-      "norm_label": "saveenablestorepickupchanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L40"
+      "id": "servicecatalogview_validateservicecatalogform",
+      "label": "validateServiceCatalogForm()",
+      "norm_label": "validateservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L74"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "fulfillmentview_savepickuprestriction",
-      "label": "savePickupRestriction()",
-      "norm_label": "savepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
-      "label": "FulfillmentView.tsx",
-      "norm_label": "fulfillmentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L1"
+      "id": "servicecatalogview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L499"
     },
     {
       "community": 730,
@@ -80934,82 +81132,82 @@
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger",
-      "label": "Logger",
-      "norm_label": "logger",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L12"
+      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
+      "label": "handleDeliveryRestrictionToggle()",
+      "norm_label": "handledeliveryrestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L155"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L15"
+      "id": "fulfillmentview_handlepickuprestrictiontoggle",
+      "label": "handlePickupRestrictionToggle()",
+      "norm_label": "handlepickuprestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger_debug",
-      "label": ".debug()",
-      "norm_label": ".debug()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L45"
+      "id": "fulfillmentview_handlesavedeliveryrestriction",
+      "label": "handleSaveDeliveryRestriction()",
+      "norm_label": "handlesavedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L203"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger_error",
-      "label": ".error()",
-      "norm_label": ".error()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "id": "fulfillmentview_handlesavepickuprestriction",
+      "label": "handleSavePickupRestriction()",
+      "norm_label": "handlesavepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "fulfillmentview_savedeliveryrestriction",
+      "label": "saveDeliveryRestriction()",
+      "norm_label": "savedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "fulfillmentview_saveenabledeliverychanges",
+      "label": "saveEnableDeliveryChanges()",
+      "norm_label": "saveenabledeliverychanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L63"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger_formatmessage",
-      "label": ".formatMessage()",
-      "norm_label": ".formatmessage()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L30"
+      "id": "fulfillmentview_saveenablestorepickupchanges",
+      "label": "saveEnableStorePickupChanges()",
+      "norm_label": "saveenablestorepickupchanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger_info",
-      "label": ".info()",
-      "norm_label": ".info()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L51"
+      "id": "fulfillmentview_savepickuprestriction",
+      "label": "savePickupRestriction()",
+      "norm_label": "savepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L86"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "logger_logger_shouldlog",
-      "label": ".shouldLog()",
-      "norm_label": ".shouldlog()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "logger_logger_warn",
-      "label": ".warn()",
-      "norm_label": ".warn()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_logger_ts",
-      "label": "logger.ts",
-      "norm_label": "logger.ts",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
+      "label": "FulfillmentView.tsx",
+      "norm_label": "fulfillmentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1"
     },
     {
@@ -81195,82 +81393,82 @@
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L222"
+      "id": "logger_logger",
+      "label": "Logger",
+      "norm_label": "logger",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L12"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L283"
+      "id": "logger_logger_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L15"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L363"
+      "id": "logger_logger_debug",
+      "label": ".debug()",
+      "norm_label": ".debug()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L45"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L214"
+      "id": "logger_logger_error",
+      "label": ".error()",
+      "norm_label": ".error()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L63"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L342"
+      "id": "logger_logger_formatmessage",
+      "label": ".formatMessage()",
+      "norm_label": ".formatmessage()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L30"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L265"
+      "id": "logger_logger_info",
+      "label": ".info()",
+      "norm_label": ".info()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L51"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L218"
+      "id": "logger_logger_shouldlog",
+      "label": ".shouldLog()",
+      "norm_label": ".shouldlog()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L20"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L246"
+      "id": "logger_logger_warn",
+      "label": ".warn()",
+      "norm_label": ".warn()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L57"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "id": "packages_athena_webapp_src_lib_logger_ts",
+      "label": "logger.ts",
+      "norm_label": "logger.ts",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L1"
     },
     {
@@ -81456,82 +81654,82 @@
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_clusterredis",
-      "label": "ClusterRedis",
-      "norm_label": "clusterredis",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L85"
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L222"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_clusterredis_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L86"
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L283"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_createinmemoryredis",
-      "label": "createInMemoryRedis()",
-      "norm_label": "createinmemoryredis()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L39"
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L363"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_createresponserecorder",
-      "label": "createResponseRecorder()",
-      "norm_label": "createresponserecorder()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L12"
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L214"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_createsilentlogger",
-      "label": "createSilentLogger()",
-      "norm_label": "createsilentlogger()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L31"
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L342"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L261"
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L265"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_standaloneredis",
-      "label": "StandaloneRedis",
-      "norm_label": "standaloneredis",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L61"
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L218"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "app_test_standaloneredis_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L62"
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L246"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_test_js",
-      "label": "app.test.js",
-      "norm_label": "app.test.js",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
     },
     {
@@ -81717,74 +81915,83 @@
     {
       "community": 77,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "id": "app_test_clusterredis",
+      "label": "ClusterRedis",
+      "norm_label": "clusterredis",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L85"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_clusterredis_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L86"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_createinmemoryredis",
+      "label": "createInMemoryRedis()",
+      "norm_label": "createinmemoryredis()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L39"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_createresponserecorder",
+      "label": "createResponseRecorder()",
+      "norm_label": "createresponserecorder()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L12"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_createsilentlogger",
+      "label": "createSilentLogger()",
+      "norm_label": "createsilentlogger()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L31"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L261"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_standaloneredis",
+      "label": "StandaloneRedis",
+      "norm_label": "standaloneredis",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L61"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "app_test_standaloneredis_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L62"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_app_test_js",
+      "label": "app.test.js",
+      "norm_label": "app.test.js",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
       "source_location": "L1"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_getr2",
-      "label": "getR2()",
-      "norm_label": "getr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_readenvvalue",
-      "label": "readEnvValue()",
-      "norm_label": "readenvvalue()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_resolver2configfromenv",
-      "label": "resolveR2ConfigFromEnv()",
-      "norm_label": "resolver2configfromenv()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L98"
     },
     {
       "community": 770,
@@ -81969,74 +82176,74 @@
     {
       "community": 78,
       "file_type": "code",
-      "id": "athenauserauth_findathenauserbyemailwithctx",
-      "label": "findAthenaUserByEmailWithCtx()",
-      "norm_label": "findathenauserbyemailwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "athenauserauth_getauthenticatedathenauserwithctx",
-      "label": "getAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "getauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "athenauserauth_getauthenticateduserrecord",
-      "label": "getAuthenticatedUserRecord()",
-      "norm_label": "getauthenticateduserrecord()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "athenauserauth_normalizeemail",
-      "label": "normalizeEmail()",
-      "norm_label": "normalizeemail()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
-      "label": "requireAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "requireauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "athenauserauth_requireorganizationmemberrolewithctx",
-      "label": "requireOrganizationMemberRoleWithCtx()",
-      "norm_label": "requireorganizationmemberrolewithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
-      "label": "syncAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "syncauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
-      "label": "athenaUserAuth.ts",
-      "norm_label": "athenauserauth.ts",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_getr2",
+      "label": "getR2()",
+      "norm_label": "getr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_readenvvalue",
+      "label": "readEnvValue()",
+      "norm_label": "readenvvalue()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_resolver2configfromenv",
+      "label": "resolveR2ConfigFromEnv()",
+      "norm_label": "resolver2configfromenv()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L98"
     },
     {
       "community": 780,
@@ -82221,73 +82428,73 @@
     {
       "community": 79,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "athenauserauth_findathenauserbyemailwithctx",
+      "label": "findAthenaUserByEmailWithCtx()",
+      "norm_label": "findathenauserbyemailwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L12"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
+      "id": "athenauserauth_getauthenticatedathenauserwithctx",
+      "label": "getAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "getauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L54"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
+      "id": "athenauserauth_getauthenticateduserrecord",
+      "label": "getAuthenticatedUserRecord()",
+      "norm_label": "getauthenticateduserrecord()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L34"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
+      "id": "athenauserauth_normalizeemail",
+      "label": "normalizeEmail()",
+      "norm_label": "normalizeemail()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L8"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
+      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
+      "label": "requireAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "requireauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L64"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "athenauserauth_requireorganizationmemberrolewithctx",
+      "label": "requireOrganizationMemberRoleWithCtx()",
+      "norm_label": "requireorganizationmemberrolewithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L74"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
+      "label": "syncAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "syncauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L100"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
+      "label": "athenaUserAuth.ts",
+      "norm_label": "athenauserauth.ts",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
       "source_location": "L1"
     },
     {
@@ -82698,73 +82905,73 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -82950,73 +83157,73 @@
     {
       "community": 81,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
     },
     {
       "community": 81,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -83202,74 +83409,74 @@
     {
       "community": 82,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
     },
     {
       "community": 820,
@@ -83400,74 +83607,74 @@
     {
       "community": 83,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 830,
@@ -83562,74 +83769,74 @@
     {
       "community": 84,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
     },
     {
       "community": 84,
       "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 840,
@@ -83724,74 +83931,74 @@
     {
       "community": 85,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 850,
@@ -83886,74 +84093,74 @@
     {
       "community": 86,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
+      "id": "expensesessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2359"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
     },
     {
       "community": 86,
       "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
+      "id": "expensesessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2353"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
     },
     {
       "community": 86,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
+      "id": "expensesessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2349"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
     },
     {
       "community": 86,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
+      "id": "expensesessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2369"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
     },
     {
       "community": 86,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
+      "id": "expensesessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2115"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
     },
     {
       "community": 86,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
+      "id": "expensesessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2205"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
     },
     {
       "community": 86,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
+      "id": "expensesessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2097"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 860,
@@ -84048,74 +84255,74 @@
     {
       "community": 87,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L42"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2359"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_buildpendingskucontextbyid",
-      "label": "buildPendingSkuContextById()",
-      "norm_label": "buildpendingskucontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L111"
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2353"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_getstatusrank",
-      "label": "getStatusRank()",
-      "norm_label": "getstatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L31"
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2349"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L94"
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2369"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L179"
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2115"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L62"
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2205"
     },
     {
       "community": 87,
       "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L74"
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2097"
     },
     {
       "community": 870,
@@ -84210,74 +84417,74 @@
     {
       "community": 88,
       "file_type": "code",
-      "id": "data_table_row_actions_datatablerowactions",
-      "label": "DataTableRowActions()",
-      "norm_label": "datatablerowactions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L1"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L42"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_buildpendingskucontextbyid",
+      "label": "buildPendingSkuContextById()",
+      "norm_label": "buildpendingskucontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L111"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_getstatusrank",
+      "label": "getStatusRank()",
+      "norm_label": "getstatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L31"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L94"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L179"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L74"
     },
     {
       "community": 880,
@@ -84372,73 +84579,73 @@
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_clearcustomer",
-      "label": "clearCustomer()",
-      "norm_label": "clearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L172"
+      "id": "data_table_row_actions_datatablerowactions",
+      "label": "DataTableRowActions()",
+      "norm_label": "datatablerowactions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L25"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L163"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_handlecreatecustomer",
-      "label": "handleCreateCustomer()",
-      "norm_label": "handlecreatecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L90"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L130"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L69"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L120"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "customerinfopanel_showcommanderror",
-      "label": "showCommandError()",
-      "norm_label": "showcommanderror()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L65"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
-      "label": "CustomerInfoPanel.tsx",
-      "norm_label": "customerinfopanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1"
     },
     {
@@ -84732,74 +84939,74 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "label": "welcome-offer-modal.tsx",
-      "norm_label": "welcome-offer-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "id": "customerinfopanel_clearcustomer",
+      "label": "clearCustomer()",
+      "norm_label": "clearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L172"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecreatecustomer",
+      "label": "handleCreateCustomer()",
+      "norm_label": "handlecreatecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "customerinfopanel_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L130"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "customerinfopanel_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "customerinfopanel_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "customerinfopanel_showcommanderror",
+      "label": "showCommandError()",
+      "norm_label": "showcommanderror()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "label": "CustomerInfoPanel.tsx",
+      "norm_label": "customerinfopanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlecolorchange",
-      "label": "handleColorChange()",
-      "norm_label": "handlecolorchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlenumberchange",
-      "label": "handleNumberChange()",
-      "norm_label": "handlenumberchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleselectchange",
-      "label": "handleSelectChange()",
-      "norm_label": "handleselectchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleswitchchange",
-      "label": "handleSwitchChange()",
-      "norm_label": "handleswitchchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "welcome_offer_modal_updateimages",
-      "label": "updateImages()",
-      "norm_label": "updateimages()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L100"
     },
     {
       "community": 900,
@@ -84894,74 +85101,74 @@
     {
       "community": 91,
       "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
+      "label": "welcome-offer-modal.tsx",
+      "norm_label": "welcome-offer-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlecolorchange",
+      "label": "handleColorChange()",
+      "norm_label": "handlecolorchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlenumberchange",
+      "label": "handleNumberChange()",
+      "norm_label": "handlenumberchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleselectchange",
+      "label": "handleSelectChange()",
+      "norm_label": "handleselectchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleswitchchange",
+      "label": "handleSwitchChange()",
+      "norm_label": "handleswitchchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "welcome_offer_modal_updateimages",
+      "label": "updateImages()",
+      "norm_label": "updateimages()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L100"
     },
     {
       "community": 910,
@@ -85056,74 +85263,74 @@
     {
       "community": 92,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_getbaseurl",
+      "id": "bag_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
     },
     {
       "community": 920,
@@ -85218,74 +85425,74 @@
     {
       "community": 93,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L1"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
     },
     {
       "community": 930,
@@ -85380,74 +85587,74 @@
     {
       "community": 94,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
     },
     {
       "community": 940,
@@ -85542,65 +85749,74 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "expensesessions_expensesessionerror",
-      "label": "expenseSessionError()",
-      "norm_label": "expensesessionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "label": "listExpenseSessionsByStatusBefore()",
-      "norm_label": "listexpensesessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "expensesessions_loadexpensesessionitems",
-      "label": "loadExpenseSessionItems()",
-      "norm_label": "loadexpensesessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "expensesessions_mapexpensesessionvalidationerror",
-      "label": "mapExpenseSessionValidationError()",
-      "norm_label": "mapexpensesessionvalidationerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "expensesessions_recordexpensesessionlifecycletrace",
-      "label": "recordExpenseSessionLifecycleTrace()",
-      "norm_label": "recordexpensesessionlifecycletrace()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
-      "label": "userErrorFromExpenseSessionCommandFailure()",
-      "norm_label": "usererrorfromexpensesessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "label": "expenseSessions.ts",
-      "norm_label": "expensesessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
     },
     {
       "community": 950,
@@ -85695,64 +85911,64 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L76"
+      "id": "expensesessions_expensesessionerror",
+      "label": "expenseSessionError()",
+      "norm_label": "expensesessionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L47"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L190"
+      "id": "expensesessions_listexpensesessionsbystatusbefore",
+      "label": "listExpenseSessionsByStatusBefore()",
+      "norm_label": "listexpensesessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L163"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_loadexpensesessionitems",
+      "label": "loadExpenseSessionItems()",
+      "norm_label": "loadexpensesessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L114"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L239"
+      "id": "expensesessions_mapexpensesessionvalidationerror",
+      "label": "mapExpenseSessionValidationError()",
+      "norm_label": "mapexpensesessionvalidationerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L95"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L20"
+      "id": "expensesessions_recordexpensesessionlifecycletrace",
+      "label": "recordExpenseSessionLifecycleTrace()",
+      "norm_label": "recordexpensesessionlifecycletrace()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L139"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
+      "label": "userErrorFromExpenseSessionCommandFailure()",
+      "norm_label": "usererrorfromexpensesessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
+      "label": "expenseSessions.ts",
+      "norm_label": "expensesessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1"
     },
     {
@@ -85848,64 +86064,64 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1"
     },
     {
@@ -86001,64 +86217,64 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L1"
     },
     {
@@ -86154,64 +86370,64 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontraceevent",
-      "label": "buildExpenseSessionTraceEvent()",
-      "norm_label": "buildexpensesessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L150"
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontracerecord",
-      "label": "buildExpenseSessionTraceRecord()",
-      "norm_label": "buildexpensesessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L101"
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L71"
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessiontracing_createexpensesessiontracerecorder",
-      "label": "createExpenseSessionTraceRecorder()",
-      "norm_label": "createexpensesessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L293"
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
-      "label": "recordExpenseSessionTraceBestEffort()",
-      "norm_label": "recordexpensesessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L266"
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L258"
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
-      "label": "expenseSessionTracing.ts",
-      "norm_label": "expensesessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6431,7 +6431,7 @@
       "relation": "calls",
       "source": "harness_repo_validation_sortuniquepaths",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L46",
+      "source_location": "L47",
       "target": "harness_repo_validation_collectharnessrepovalidationselection",
       "weight": 1
     },
@@ -6443,7 +6443,7 @@
       "relation": "calls",
       "source": "harness_repo_validation_normalizerepopath",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "target": "harness_repo_validation_matchesharnessrepovalidationpath",
       "weight": 1
     },
@@ -42959,7 +42959,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L45",
+      "source_location": "L46",
       "target": "harness_repo_validation_collectharnessrepovalidationselection",
       "weight": 1
     },
@@ -42971,7 +42971,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L37",
+      "source_location": "L38",
       "target": "harness_repo_validation_matchesharnessrepovalidationpath",
       "weight": 1
     },
@@ -42983,7 +42983,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L27",
+      "source_location": "L28",
       "target": "harness_repo_validation_normalizerepopath",
       "weight": 1
     },
@@ -42995,7 +42995,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L31",
+      "source_location": "L32",
       "target": "harness_repo_validation_sortuniquepaths",
       "weight": 1
     },
@@ -43019,7 +43019,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L999",
+      "source_location": "L1002",
       "target": "harness_review_test_error",
       "weight": 1
     },
@@ -43043,7 +43043,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L998",
+      "source_location": "L1001",
       "target": "harness_review_test_log",
       "weight": 1
     },
@@ -44267,7 +44267,7 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_test_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L309",
+      "source_location": "L484",
       "target": "pre_commit_generated_artifacts_test_log",
       "weight": 1
     },
@@ -44279,8 +44279,32 @@
       "relation": "contains",
       "source": "scripts_pre_commit_generated_artifacts_test_ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L295",
+      "source_location": "L470",
       "target": "pre_commit_generated_artifacts_test_spawn",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_test_ts",
+      "_tgt": "pre_commit_generated_artifacts_test_withtemprepo",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_test_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L14",
+      "target": "pre_commit_generated_artifacts_test_withtemprepo",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_test_ts",
+      "_tgt": "pre_commit_generated_artifacts_test_writeconvexapifixture",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_test_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L24",
+      "target": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "weight": 1
     },
     {
@@ -59253,366 +59277,6 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_getapprovalrequestcopy",
-      "label": "getApprovalRequestCopy()",
-      "norm_label": "getapprovalrequestcopy()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_getdefaultworkflow",
-      "label": "getDefaultWorkflow()",
-      "norm_label": "getdefaultworkflow()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L579"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_setdecisioningapprovalrequestid",
-      "label": "setDecisioningApprovalRequestId()",
-      "norm_label": "setdecisioningapprovalrequestid()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L638"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -59620,7 +59284,7 @@
       "source_location": "L30"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -59629,7 +59293,7 @@
       "source_location": "L43"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -59638,7 +59302,7 @@
       "source_location": "L106"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -59647,12 +59311,372 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_getapprovalrequestcopy",
+      "label": "getApprovalRequestCopy()",
+      "norm_label": "getapprovalrequestcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_getdefaultworkflow",
+      "label": "getDefaultWorkflow()",
+      "norm_label": "getdefaultworkflow()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L579"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_setdecisioningapprovalrequestid",
+      "label": "setDecisioningApprovalRequestId()",
+      "norm_label": "setdecisioningapprovalrequestid()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L638"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -61615,7 +61639,7 @@
       "label": "collectHarnessRepoValidationSelection()",
       "norm_label": "collectharnessrepovalidationselection()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L45"
+      "source_location": "L46"
     },
     {
       "community": 215,
@@ -61624,7 +61648,7 @@
       "label": "matchesHarnessRepoValidationPath()",
       "norm_label": "matchesharnessrepovalidationpath()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L37"
+      "source_location": "L38"
     },
     {
       "community": 215,
@@ -61633,7 +61657,7 @@
       "label": "normalizeRepoPath()",
       "norm_label": "normalizerepopath()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L27"
+      "source_location": "L28"
     },
     {
       "community": 215,
@@ -61642,7 +61666,7 @@
       "label": "sortUniquePaths()",
       "norm_label": "sortuniquepaths()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L31"
+      "source_location": "L32"
     },
     {
       "community": 215,
@@ -61656,6 +61680,51 @@
     {
       "community": 216,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_withtemprepo",
+      "label": "withTempRepo()",
+      "norm_label": "withtemprepo()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
+      "label": "writeConvexApiFixture()",
+      "norm_label": "writeconvexapifixture()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
       "norm_label": "worktree-manager.test.ts",
@@ -61663,7 +61732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61672,7 +61741,7 @@
       "source_location": "L17"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -61681,7 +61750,7 @@
       "source_location": "L72"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -61690,7 +61759,7 @@
       "source_location": "L45"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -61699,7 +61768,7 @@
       "source_location": "L59"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -61708,7 +61777,7 @@
       "source_location": "L12"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -61717,7 +61786,7 @@
       "source_location": "L26"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -61726,7 +61795,7 @@
       "source_location": "L20"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -61735,7 +61804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -61744,7 +61813,7 @@
       "source_location": "L109"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -61753,7 +61822,7 @@
       "source_location": "L84"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -61762,48 +61831,12 @@
       "source_location": "L95"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
       "norm_label": "checkout.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "expensesessions_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "expensesessions_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "expensesessions_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
-      "label": "expenseSessions.test.ts",
-      "norm_label": "expensesessions.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
       "source_location": "L1"
     },
     {
@@ -61971,6 +62004,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "expensesessions_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "expensesessions_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "expensesessions_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
+      "label": "expenseSessions.test.ts",
+      "norm_label": "expensesessions.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
       "norm_label": "createexpensetransactionfromsessionhandler()",
@@ -61978,7 +62047,7 @@
       "source_location": "L50"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -61987,7 +62056,7 @@
       "source_location": "L23"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -61996,7 +62065,7 @@
       "source_location": "L37"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -62005,7 +62074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -62014,7 +62083,7 @@
       "source_location": "L21"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -62023,7 +62092,7 @@
       "source_location": "L35"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -62032,7 +62101,7 @@
       "source_location": "L45"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -62041,7 +62110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -62050,7 +62119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -62059,7 +62128,7 @@
       "source_location": "L21"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -62068,7 +62137,7 @@
       "source_location": "L35"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -62077,7 +62146,7 @@
       "source_location": "L45"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -62086,7 +62155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -62095,7 +62164,7 @@
       "source_location": "L248"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -62104,7 +62173,7 @@
       "source_location": "L92"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -62113,7 +62182,7 @@
       "source_location": "L265"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -62122,7 +62191,7 @@
       "source_location": "L5"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -62131,7 +62200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -62140,7 +62209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -62149,7 +62218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -62158,7 +62227,7 @@
       "source_location": "L26"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -62167,7 +62236,7 @@
       "source_location": "L79"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -62176,7 +62245,7 @@
       "source_location": "L33"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -62185,7 +62254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -62194,7 +62263,7 @@
       "source_location": "L10"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -62203,7 +62272,7 @@
       "source_location": "L18"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -62212,7 +62281,7 @@
       "source_location": "L52"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -62221,7 +62290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -62230,7 +62299,7 @@
       "source_location": "L98"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -62239,7 +62308,7 @@
       "source_location": "L56"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -62248,7 +62317,7 @@
       "source_location": "L49"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -62257,7 +62326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -62266,7 +62335,7 @@
       "source_location": "L28"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -62275,7 +62344,7 @@
       "source_location": "L42"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -62284,48 +62353,12 @@
       "source_location": "L73"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
       "norm_label": "operationalevents.ts",
       "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "operationalworkitems_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "operationalworkitems_createoperationalworkitemwithctx",
-      "label": "createOperationalWorkItemWithCtx()",
-      "norm_label": "createoperationalworkitemwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
-      "label": "updateOperationalWorkItemStatusWithCtx()",
-      "norm_label": "updateoperationalworkitemstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
-      "label": "operationalWorkItems.ts",
-      "norm_label": "operationalworkitems.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
     },
     {
@@ -62493,6 +62526,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "operationalworkitems_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "operationalworkitems_createoperationalworkitemwithctx",
+      "label": "createOperationalWorkItemWithCtx()",
+      "norm_label": "createoperationalworkitemwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
+      "label": "updateOperationalWorkItemStatusWithCtx()",
+      "norm_label": "updateoperationalworkitemstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
+      "label": "operationalWorkItems.ts",
+      "norm_label": "operationalworkitems.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -62500,7 +62569,7 @@
       "source_location": "L18"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -62509,7 +62578,7 @@
       "source_location": "L25"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -62518,7 +62587,7 @@
       "source_location": "L11"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -62527,7 +62596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -62536,7 +62605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -62545,7 +62614,7 @@
       "source_location": "L33"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -62554,7 +62623,7 @@
       "source_location": "L19"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -62563,7 +62632,7 @@
       "source_location": "L42"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -62572,7 +62641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -62581,7 +62650,7 @@
       "source_location": "L31"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -62590,7 +62659,7 @@
       "source_location": "L48"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -62599,7 +62668,7 @@
       "source_location": "L131"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -62608,7 +62677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -62617,7 +62686,7 @@
       "source_location": "L37"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -62626,7 +62695,7 @@
       "source_location": "L24"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -62635,7 +62704,7 @@
       "source_location": "L19"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -62644,7 +62713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -62653,7 +62722,7 @@
       "source_location": "L31"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -62662,7 +62731,7 @@
       "source_location": "L26"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -62671,7 +62740,7 @@
       "source_location": "L53"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -62680,7 +62749,7 @@
       "source_location": "L36"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -62689,7 +62758,7 @@
       "source_location": "L96"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -62698,7 +62767,7 @@
       "source_location": "L71"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -62707,7 +62776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -62716,7 +62785,7 @@
       "source_location": "L21"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -62725,7 +62794,7 @@
       "source_location": "L42"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -62734,7 +62803,7 @@
       "source_location": "L80"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -62743,7 +62812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -62752,7 +62821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -62761,7 +62830,7 @@
       "source_location": "L122"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -62770,7 +62839,7 @@
       "source_location": "L34"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -62779,7 +62848,7 @@
       "source_location": "L72"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -62788,7 +62857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -62797,7 +62866,7 @@
       "source_location": "L162"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -62806,49 +62875,13 @@
       "source_location": "L56"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
       "norm_label": "findsessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L180"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "adjustments_test_createapprovaldecisionmutationctx",
-      "label": "createApprovalDecisionMutationCtx()",
-      "norm_label": "createapprovaldecisionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "adjustments_test_createsubmissionmutationctx",
-      "label": "createSubmissionMutationCtx()",
-      "norm_label": "createsubmissionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "adjustments_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
-      "label": "adjustments.test.ts",
-      "norm_label": "adjustments.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 24,
@@ -63006,6 +63039,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "adjustments_test_createapprovaldecisionmutationctx",
+      "label": "createApprovalDecisionMutationCtx()",
+      "norm_label": "createapprovaldecisionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "adjustments_test_createsubmissionmutationctx",
+      "label": "createSubmissionMutationCtx()",
+      "norm_label": "createsubmissionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "adjustments_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "label": "adjustments.test.ts",
+      "norm_label": "adjustments.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
       "norm_label": "replenishment.test.ts",
@@ -63013,7 +63082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -63022,7 +63091,7 @@
       "source_location": "L23"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -63031,7 +63100,7 @@
       "source_location": "L9"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -63040,7 +63109,7 @@
       "source_location": "L13"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -63049,7 +63118,7 @@
       "source_location": "L19"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -63058,7 +63127,7 @@
       "source_location": "L26"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -63067,7 +63136,7 @@
       "source_location": "L12"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -63076,7 +63145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -63085,7 +63154,7 @@
       "source_location": "L21"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -63094,7 +63163,7 @@
       "source_location": "L63"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -63103,7 +63172,7 @@
       "source_location": "L71"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -63112,7 +63181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -63121,7 +63190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -63130,7 +63199,7 @@
       "source_location": "L13"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -63139,7 +63208,7 @@
       "source_location": "L31"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -63148,7 +63217,7 @@
       "source_location": "L9"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -63157,7 +63226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -63166,7 +63235,7 @@
       "source_location": "L12"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -63175,7 +63244,7 @@
       "source_location": "L46"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -63184,7 +63253,7 @@
       "source_location": "L7"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -63193,7 +63262,7 @@
       "source_location": "L227"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -63202,7 +63271,7 @@
       "source_location": "L46"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -63211,7 +63280,7 @@
       "source_location": "L27"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -63220,7 +63289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -63229,7 +63298,7 @@
       "source_location": "L55"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -63238,7 +63307,7 @@
       "source_location": "L32"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -63247,7 +63316,7 @@
       "source_location": "L211"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -63256,7 +63325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -63265,7 +63334,7 @@
       "source_location": "L52"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -63274,7 +63343,7 @@
       "source_location": "L27"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -63283,7 +63352,7 @@
       "source_location": "L288"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -63292,7 +63361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -63301,7 +63370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -63310,7 +63379,7 @@
       "source_location": "L15"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -63319,49 +63388,13 @@
       "source_location": "L32"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
       "norm_label": "summarycard()",
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "utils_countgroupedanalytics",
-      "label": "countGroupedAnalytics()",
-      "norm_label": "countgroupedanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "utils_groupanalytics",
-      "label": "groupAnalytics()",
-      "norm_label": "groupanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "utils_groupproductviewsbyday",
-      "label": "groupProductViewsByDay()",
-      "norm_label": "groupproductviewsbyday()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L90"
     },
     {
       "community": 25,
@@ -63519,6 +63552,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "utils_countgroupedanalytics",
+      "label": "countGroupedAnalytics()",
+      "norm_label": "countgroupedanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "utils_groupanalytics",
+      "label": "groupAnalytics()",
+      "norm_label": "groupanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "utils_groupproductviewsbyday",
+      "label": "groupProductViewsByDay()",
+      "norm_label": "groupproductviewsbyday()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
       "norm_label": "getcountdownstatus()",
@@ -63526,7 +63595,7 @@
       "source_location": "L86"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -63535,7 +63604,7 @@
       "source_location": "L76"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -63544,7 +63613,7 @@
       "source_location": "L52"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -63553,7 +63622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -63562,7 +63631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -63571,7 +63640,7 @@
       "source_location": "L67"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -63580,7 +63649,7 @@
       "source_location": "L90"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -63589,7 +63658,7 @@
       "source_location": "L73"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -63598,7 +63667,7 @@
       "source_location": "L78"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -63607,7 +63676,7 @@
       "source_location": "L67"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -63616,7 +63685,7 @@
       "source_location": "L85"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -63625,7 +63694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -63634,7 +63703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -63643,7 +63712,7 @@
       "source_location": "L67"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -63652,7 +63721,7 @@
       "source_location": "L61"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -63661,7 +63730,7 @@
       "source_location": "L73"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -63670,7 +63739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -63679,7 +63748,7 @@
       "source_location": "L105"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -63688,7 +63757,7 @@
       "source_location": "L97"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -63697,7 +63766,7 @@
       "source_location": "L83"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -63706,7 +63775,7 @@
       "source_location": "L91"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -63715,7 +63784,7 @@
       "source_location": "L68"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -63724,7 +63793,7 @@
       "source_location": "L22"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -63733,7 +63802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -63742,7 +63811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -63751,7 +63820,7 @@
       "source_location": "L162"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -63760,7 +63829,7 @@
       "source_location": "L384"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -63769,7 +63838,7 @@
       "source_location": "L345"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -63778,7 +63847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -63787,7 +63856,7 @@
       "source_location": "L22"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -63796,7 +63865,7 @@
       "source_location": "L27"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -63805,7 +63874,7 @@
       "source_location": "L40"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -63814,7 +63883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -63823,7 +63892,7 @@
       "source_location": "L78"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -63832,49 +63901,13 @@
       "source_location": "L118"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
       "norm_label": "getrecommendationstatuscopy()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
       "source_location": "L89"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstock_tsx",
-      "label": "ProductStock.tsx",
-      "norm_label": "productstock.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "productstock_lowstockstatus",
-      "label": "LowStockStatus()",
-      "norm_label": "lowstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "productstock_outofstockstatus",
-      "label": "OutOfStockStatus()",
-      "norm_label": "outofstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "productstock_productstockstatus",
-      "label": "ProductStockStatus()",
-      "norm_label": "productstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L11"
     },
     {
       "community": 26,
@@ -64032,6 +64065,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstock_tsx",
+      "label": "ProductStock.tsx",
+      "norm_label": "productstock.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "productstock_lowstockstatus",
+      "label": "LowStockStatus()",
+      "norm_label": "lowstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "productstock_outofstockstatus",
+      "label": "OutOfStockStatus()",
+      "norm_label": "outofstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "productstock_productstockstatus",
+      "label": "ProductStockStatus()",
+      "norm_label": "productstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
       "norm_label": "body()",
@@ -64039,7 +64108,7 @@
       "source_location": "L16"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -64048,7 +64117,7 @@
       "source_location": "L35"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -64057,7 +64126,7 @@
       "source_location": "L6"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -64066,7 +64135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -64075,7 +64144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -64084,7 +64153,7 @@
       "source_location": "L5"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -64093,7 +64162,7 @@
       "source_location": "L30"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -64102,7 +64171,7 @@
       "source_location": "L21"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -64111,7 +64180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -64120,7 +64189,7 @@
       "source_location": "L178"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -64129,7 +64198,7 @@
       "source_location": "L205"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -64138,7 +64207,7 @@
       "source_location": "L806"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -64147,7 +64216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -64156,7 +64225,7 @@
       "source_location": "L41"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -64165,7 +64234,7 @@
       "source_location": "L45"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -64174,7 +64243,7 @@
       "source_location": "L65"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -64183,7 +64252,7 @@
       "source_location": "L75"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -64192,7 +64261,7 @@
       "source_location": "L82"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -64201,7 +64270,7 @@
       "source_location": "L93"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -64210,7 +64279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -64219,7 +64288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -64228,7 +64297,7 @@
       "source_location": "L15"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -64237,7 +64306,7 @@
       "source_location": "L28"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -64246,7 +64315,7 @@
       "source_location": "L54"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -64255,7 +64324,7 @@
       "source_location": "L66"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -64264,7 +64333,7 @@
       "source_location": "L121"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -64273,7 +64342,7 @@
       "source_location": "L74"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -64282,7 +64351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -64291,7 +64360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -64300,7 +64369,7 @@
       "source_location": "L34"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -64309,7 +64378,7 @@
       "source_location": "L28"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -64318,7 +64387,7 @@
       "source_location": "L48"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -64327,7 +64396,7 @@
       "source_location": "L51"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -64336,7 +64405,7 @@
       "source_location": "L92"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -64345,48 +64414,12 @@
       "source_location": "L16"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
       "norm_label": "barcodeutils.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "customergateway_useconvexposcustomercreate",
-      "label": "useConvexPosCustomerCreate()",
-      "norm_label": "useconvexposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "customergateway_useconvexposcustomersearch",
-      "label": "useConvexPosCustomerSearch()",
-      "norm_label": "useconvexposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "customergateway_useconvexposcustomerupdate",
-      "label": "useConvexPosCustomerUpdate()",
-      "norm_label": "useconvexposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
-      "label": "customerGateway.ts",
-      "norm_label": "customergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
     },
     {
@@ -64536,6 +64569,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "customergateway_useconvexposcustomercreate",
+      "label": "useConvexPosCustomerCreate()",
+      "norm_label": "useconvexposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "customergateway_useconvexposcustomersearch",
+      "label": "useConvexPosCustomerSearch()",
+      "norm_label": "useconvexposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "customergateway_useconvexposcustomerupdate",
+      "label": "useConvexPosCustomerUpdate()",
+      "norm_label": "useconvexposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
+      "label": "customerGateway.ts",
+      "norm_label": "customergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
       "norm_label": "sessiongateway.mapper.ts",
@@ -64543,7 +64612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -64552,7 +64621,7 @@
       "source_location": "L83"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -64561,7 +64630,7 @@
       "source_location": "L100"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -64570,7 +64639,7 @@
       "source_location": "L79"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -64579,7 +64648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -64588,7 +64657,7 @@
       "source_location": "L38"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -64597,7 +64666,7 @@
       "source_location": "L65"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -64606,7 +64675,7 @@
       "source_location": "L91"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -64615,7 +64684,7 @@
       "source_location": "L4"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -64624,7 +64693,7 @@
       "source_location": "L20"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -64633,7 +64702,7 @@
       "source_location": "L42"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -64642,7 +64711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -64651,7 +64720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -64660,7 +64729,7 @@
       "source_location": "L37"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -64669,7 +64738,7 @@
       "source_location": "L49"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -64678,7 +64747,7 @@
       "source_location": "L65"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -64687,7 +64756,7 @@
       "source_location": "L13"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -64696,7 +64765,7 @@
       "source_location": "L46"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -64705,7 +64774,7 @@
       "source_location": "L21"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -64714,7 +64783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -64723,7 +64792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -64732,7 +64801,7 @@
       "source_location": "L8"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -64741,7 +64810,7 @@
       "source_location": "L5"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -64750,7 +64819,7 @@
       "source_location": "L20"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -64759,7 +64828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -64768,7 +64837,7 @@
       "source_location": "L11"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -64777,7 +64846,7 @@
       "source_location": "L9"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -64786,7 +64855,7 @@
       "source_location": "L25"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -64795,7 +64864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -64804,7 +64873,7 @@
       "source_location": "L50"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -64813,7 +64882,7 @@
       "source_location": "L92"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -64822,7 +64891,7 @@
       "source_location": "L74"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -64831,7 +64900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -64840,7 +64909,7 @@
       "source_location": "L62"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -64849,49 +64918,13 @@
       "source_location": "L109"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
       "norm_label": "handledismiss()",
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "billingdetailssection_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "billingdetailssection_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "billingdetailssection_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
-      "label": "BillingDetailsSection.tsx",
-      "norm_label": "billingdetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L1"
     },
     {
       "community": 28,
@@ -65040,6 +65073,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "billingdetailssection_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "billingdetailssection_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "billingdetailssection_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
+      "label": "BillingDetailsSection.tsx",
+      "norm_label": "billingdetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
       "norm_label": "usegetshopsearchparams()",
@@ -65047,7 +65116,7 @@
       "source_location": "L68"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -65056,7 +65125,7 @@
       "source_location": "L26"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -65065,7 +65134,7 @@
       "source_location": "L7"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -65074,7 +65143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -65083,7 +65152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -65092,7 +65161,7 @@
       "source_location": "L81"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -65101,7 +65170,7 @@
       "source_location": "L85"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -65110,7 +65179,7 @@
       "source_location": "L27"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -65119,7 +65188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -65128,7 +65197,7 @@
       "source_location": "L43"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -65137,7 +65206,7 @@
       "source_location": "L13"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -65146,7 +65215,7 @@
       "source_location": "L88"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -65155,7 +65224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -65164,7 +65233,7 @@
       "source_location": "L111"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -65173,7 +65242,7 @@
       "source_location": "L66"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -65182,7 +65251,7 @@
       "source_location": "L127"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -65191,7 +65260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -65200,7 +65269,7 @@
       "source_location": "L25"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -65209,7 +65278,7 @@
       "source_location": "L90"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -65218,7 +65287,7 @@
       "source_location": "L82"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -65227,7 +65296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -65236,7 +65305,7 @@
       "source_location": "L115"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -65245,7 +65314,7 @@
       "source_location": "L105"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -65254,7 +65323,7 @@
       "source_location": "L110"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -65263,7 +65332,7 @@
       "source_location": "L121"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -65272,7 +65341,7 @@
       "source_location": "L26"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -65281,7 +65350,7 @@
       "source_location": "L71"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -65290,7 +65359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -65299,7 +65368,7 @@
       "source_location": "L46"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -65308,7 +65377,7 @@
       "source_location": "L24"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -65317,7 +65386,7 @@
       "source_location": "L20"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -65326,7 +65395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -65335,7 +65404,7 @@
       "source_location": "L17"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -65344,7 +65413,7 @@
       "source_location": "L11"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -65353,48 +65422,12 @@
       "source_location": "L24"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
       "norm_label": "graphify-check.test.ts",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1"
     },
     {
@@ -65544,6 +65577,42 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
       "norm_label": "buildharnessdocpaths()",
@@ -65551,7 +65620,7 @@
       "source_location": "L126"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -65560,7 +65629,7 @@
       "source_location": "L130"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -65569,7 +65638,7 @@
       "source_location": "L879"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -65578,7 +65647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -65587,7 +65656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -65596,7 +65665,7 @@
       "source_location": "L8"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -65605,7 +65674,7 @@
       "source_location": "L79"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -65614,7 +65683,7 @@
       "source_location": "L61"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -65623,7 +65692,7 @@
       "source_location": "L49"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -65632,7 +65701,7 @@
       "source_location": "L17"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -65641,7 +65710,7 @@
       "source_location": "L11"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -65650,7 +65719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -65659,7 +65728,7 @@
       "source_location": "L26"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -65668,7 +65737,7 @@
       "source_location": "L72"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -65677,7 +65746,7 @@
       "source_location": "L36"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -65686,7 +65755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -65695,7 +65764,7 @@
       "source_location": "L96"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -65704,7 +65773,7 @@
       "source_location": "L94"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -65713,7 +65782,7 @@
       "source_location": "L95"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -65722,7 +65791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -65731,7 +65800,7 @@
       "source_location": "L15"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -65740,7 +65809,7 @@
       "source_location": "L11"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -65749,7 +65818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -65758,7 +65827,7 @@
       "source_location": "L98"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -65767,7 +65836,7 @@
       "source_location": "L33"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -65776,7 +65845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -65785,7 +65854,7 @@
       "source_location": "L85"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -65794,7 +65863,7 @@
       "source_location": "L31"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -65803,7 +65872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -65812,7 +65881,7 @@
       "source_location": "L12"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -65821,40 +65890,13 @@
       "source_location": "L21"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/categories.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "utils_getstoredatafromrequest",
-      "label": "getStoreDataFromRequest()",
-      "norm_label": "getstoredatafromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "utils_getstorefrontuserfromrequest",
-      "label": "getStorefrontUserFromRequest()",
-      "norm_label": "getstorefrontuserfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L12"
     },
     {
       "community": 3,
@@ -66291,6 +66333,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "utils_getstoredatafromrequest",
+      "label": "getStoreDataFromRequest()",
+      "norm_label": "getstoredatafromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "utils_getstorefrontuserfromrequest",
+      "label": "getStorefrontUserFromRequest()",
+      "norm_label": "getstorefrontuserfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
       "norm_label": "products.sku.test.ts",
@@ -66298,7 +66367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -66307,7 +66376,7 @@
       "source_location": "L14"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -66316,7 +66385,7 @@
       "source_location": "L10"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -66325,7 +66394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -66334,7 +66403,7 @@
       "source_location": "L6"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -66343,7 +66412,7 @@
       "source_location": "L9"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -66352,7 +66421,7 @@
       "source_location": "L43"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -66361,7 +66430,7 @@
       "source_location": "L11"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -66370,7 +66439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -66379,7 +66448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -66388,7 +66457,7 @@
       "source_location": "L26"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -66397,7 +66466,7 @@
       "source_location": "L118"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -66406,7 +66475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -66415,7 +66484,7 @@
       "source_location": "L16"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -66424,7 +66493,7 @@
       "source_location": "L92"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -66433,7 +66502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -66442,7 +66511,7 @@
       "source_location": "L21"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -66451,7 +66520,7 @@
       "source_location": "L31"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -66460,7 +66529,7 @@
       "source_location": "L7"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -66469,7 +66538,7 @@
       "source_location": "L109"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -66478,7 +66547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -66487,7 +66556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -66496,7 +66565,7 @@
       "source_location": "L18"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -66505,7 +66574,7 @@
       "source_location": "L9"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -66514,7 +66583,7 @@
       "source_location": "L8"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -66523,40 +66592,13 @@
       "source_location": "L9"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
       "norm_label": "errors.ts",
       "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
-      "label": "sessionRules.ts",
-      "norm_label": "sessionrules.ts",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "sessionrules_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "sessionrules_selectresumablesession",
-      "label": "selectResumableSession()",
-      "norm_label": "selectresumablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L29"
     },
     {
       "community": 31,
@@ -66705,6 +66747,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
+      "label": "sessionRules.ts",
+      "norm_label": "sessionrules.ts",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "sessionrules_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "sessionrules_selectresumablesession",
+      "label": "selectResumableSession()",
+      "norm_label": "selectresumablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
       "norm_label": "paymentallocationservice.ts",
@@ -66712,7 +66781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -66721,7 +66790,7 @@
       "source_location": "L13"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -66730,7 +66799,7 @@
       "source_location": "L45"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -66739,7 +66808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -66748,7 +66817,7 @@
       "source_location": "L36"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -66757,7 +66826,7 @@
       "source_location": "L13"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -66766,7 +66835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -66775,7 +66844,7 @@
       "source_location": "L14"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -66784,7 +66853,7 @@
       "source_location": "L18"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -66793,7 +66862,7 @@
       "source_location": "L17"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -66802,7 +66871,7 @@
       "source_location": "L61"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -66811,7 +66880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -66820,7 +66889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -66829,7 +66898,7 @@
       "source_location": "L23"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -66838,7 +66907,7 @@
       "source_location": "L16"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -66847,7 +66916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -66856,7 +66925,7 @@
       "source_location": "L20"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -66865,7 +66934,7 @@
       "source_location": "L16"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -66874,7 +66943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -66883,7 +66952,7 @@
       "source_location": "L12"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -66892,7 +66961,7 @@
       "source_location": "L7"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -66901,7 +66970,7 @@
       "source_location": "L25"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -66910,7 +66979,7 @@
       "source_location": "L21"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -66919,7 +66988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -66928,7 +66997,7 @@
       "source_location": "L7"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -66937,40 +67006,13 @@
       "source_location": "L14"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
-      "label": "registerSession.ts",
-      "norm_label": "registersession.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "registersession_buildregistersessiontraceseed",
-      "label": "buildRegisterSessionTraceSeed()",
-      "norm_label": "buildregistersessiontraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "registersession_formatregistersessionlabel",
-      "label": "formatRegisterSessionLabel()",
-      "norm_label": "formatregistersessionlabel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
-      "source_location": "L37"
     },
     {
       "community": 32,
@@ -67119,6 +67161,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
+      "label": "registerSession.ts",
+      "norm_label": "registersession.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "registersession_buildregistersessiontraceseed",
+      "label": "buildRegisterSessionTraceSeed()",
+      "norm_label": "buildregistersessiontraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "registersession_formatregistersessionlabel",
+      "label": "formatRegisterSessionLabel()",
+      "norm_label": "formatregistersessionlabel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
       "norm_label": "public.ts",
@@ -67126,7 +67195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -67135,7 +67204,7 @@
       "source_location": "L10"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -67144,7 +67213,7 @@
       "source_location": "L44"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -67153,7 +67222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -67162,7 +67231,7 @@
       "source_location": "L84"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -67171,7 +67240,7 @@
       "source_location": "L100"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -67180,7 +67249,7 @@
       "source_location": "L5"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -67189,7 +67258,7 @@
       "source_location": "L25"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -67198,7 +67267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -67207,7 +67276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -67216,7 +67285,7 @@
       "source_location": "L35"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -67225,7 +67294,7 @@
       "source_location": "L25"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -67234,7 +67303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -67243,7 +67312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -67252,7 +67321,7 @@
       "source_location": "L4"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -67261,7 +67330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -67270,7 +67339,7 @@
       "source_location": "L19"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -67279,7 +67348,7 @@
       "source_location": "L5"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -67288,7 +67357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -67297,7 +67366,7 @@
       "source_location": "L19"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -67306,7 +67375,7 @@
       "source_location": "L11"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -67315,7 +67384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -67324,7 +67393,7 @@
       "source_location": "L22"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -67333,7 +67402,7 @@
       "source_location": "L8"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -67342,7 +67411,7 @@
       "source_location": "L21"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -67351,39 +67420,12 @@
       "source_location": "L13"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
       "norm_label": "copyimagesprovider.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "analyticscombinedusers_analyticscombinedusers",
-      "label": "AnalyticsCombinedUsers()",
-      "norm_label": "analyticscombinedusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "analyticscombinedusers_processanalyticstousers",
-      "label": "processAnalyticsToUsers()",
-      "norm_label": "processanalyticstousers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "label": "AnalyticsCombinedUsers.tsx",
-      "norm_label": "analyticscombinedusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1"
     },
     {
@@ -67524,6 +67566,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "analyticscombinedusers_analyticscombinedusers",
+      "label": "AnalyticsCombinedUsers()",
+      "norm_label": "analyticscombinedusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "analyticscombinedusers_processanalyticstousers",
+      "label": "processAnalyticsToUsers()",
+      "norm_label": "processanalyticstousers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
+      "label": "AnalyticsCombinedUsers.tsx",
+      "norm_label": "analyticscombinedusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
       "norm_label": "analyticstopusers()",
@@ -67531,7 +67600,7 @@
       "source_location": "L100"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -67540,7 +67609,7 @@
       "source_location": "L10"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -67549,7 +67618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -67558,7 +67627,7 @@
       "source_location": "L15"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -67567,7 +67636,7 @@
       "source_location": "L39"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -67576,7 +67645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -67585,7 +67654,7 @@
       "source_location": "L3"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -67594,7 +67663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -67603,7 +67672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -67612,7 +67681,7 @@
       "source_location": "L53"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -67621,7 +67690,7 @@
       "source_location": "L65"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -67630,7 +67699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -67639,7 +67708,7 @@
       "source_location": "L47"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -67648,7 +67717,7 @@
       "source_location": "L53"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -67657,7 +67726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -67666,7 +67735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -67675,7 +67744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -67684,7 +67753,7 @@
       "source_location": "L9"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -67693,7 +67762,7 @@
       "source_location": "L70"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -67702,7 +67771,7 @@
       "source_location": "L227"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -67711,7 +67780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -67720,7 +67789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -67729,7 +67798,7 @@
       "source_location": "L71"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -67738,7 +67807,7 @@
       "source_location": "L9"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
@@ -67747,7 +67816,7 @@
       "source_location": "L33"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -67756,40 +67825,13 @@
       "source_location": "L24"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
       "norm_label": "cashierauthdialog.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "label": "SearchResultsSection.tsx",
-      "norm_label": "searchresultssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "searchresultssection_handlequickaddproductshortcut",
-      "label": "handleQuickAddProductShortcut()",
-      "norm_label": "handlequickaddproductshortcut()",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "searchresultssection_handlequickaddvariantshortcut",
-      "label": "handleQuickAddVariantShortcut()",
-      "norm_label": "handlequickaddvariantshortcut()",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L82"
     },
     {
       "community": 34,
@@ -67929,6 +67971,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
+      "label": "SearchResultsSection.tsx",
+      "norm_label": "searchresultssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "searchresultssection_handlequickaddproductshortcut",
+      "label": "handleQuickAddProductShortcut()",
+      "norm_label": "handlequickaddproductshortcut()",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "searchresultssection_handlequickaddvariantshortcut",
+      "label": "handleQuickAddVariantShortcut()",
+      "norm_label": "handlequickaddvariantshortcut()",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
       "norm_label": "istoday()",
@@ -67936,7 +68005,7 @@
       "source_location": "L28"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -67945,7 +68014,7 @@
       "source_location": "L34"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -67954,7 +68023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -67963,7 +68032,7 @@
       "source_location": "L36"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -67972,7 +68041,7 @@
       "source_location": "L32"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -67981,7 +68050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -67990,7 +68059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "possettingsview_fingerprintregistrationcard",
       "label": "FingerprintRegistrationCard()",
@@ -67999,7 +68068,7 @@
       "source_location": "L53"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "possettingsview_possettingsview",
       "label": "POSSettingsView()",
@@ -68008,7 +68077,7 @@
       "source_location": "L180"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
@@ -68017,7 +68086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -68026,7 +68095,7 @@
       "source_location": "L8"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -68035,7 +68104,7 @@
       "source_location": "L18"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -68044,7 +68113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -68053,7 +68122,7 @@
       "source_location": "L65"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -68062,7 +68131,7 @@
       "source_location": "L20"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -68071,7 +68140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -68080,7 +68149,7 @@
       "source_location": "L16"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -68089,7 +68158,7 @@
       "source_location": "L60"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -68098,7 +68167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -68107,7 +68176,7 @@
       "source_location": "L45"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -68116,7 +68185,7 @@
       "source_location": "L19"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -68125,7 +68194,7 @@
       "source_location": "L128"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -68134,7 +68203,7 @@
       "source_location": "L40"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -68143,7 +68212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -68152,7 +68221,7 @@
       "source_location": "L24"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -68161,39 +68230,12 @@
       "source_location": "L20"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
       "norm_label": "color-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "currency_provider_currencyprovider",
-      "label": "CurrencyProvider()",
-      "norm_label": "currencyprovider()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "currency_provider_usestorecurrency",
-      "label": "useStoreCurrency()",
-      "norm_label": "usestorecurrency()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "label": "currency-provider.tsx",
-      "norm_label": "currency-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -68334,6 +68376,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "currency_provider_currencyprovider",
+      "label": "CurrencyProvider()",
+      "norm_label": "currencyprovider()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "currency_provider_usestorecurrency",
+      "label": "useStoreCurrency()",
+      "norm_label": "usestorecurrency()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
+      "label": "currency-provider.tsx",
+      "norm_label": "currency-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
       "norm_label": "serviceappointmentsview.test.tsx",
@@ -68341,7 +68410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -68350,7 +68419,7 @@
       "source_location": "L59"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -68359,7 +68428,7 @@
       "source_location": "L50"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -68368,7 +68437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -68377,7 +68446,7 @@
       "source_location": "L225"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -68386,7 +68455,7 @@
       "source_location": "L80"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -68395,7 +68464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -68404,7 +68473,7 @@
       "source_location": "L163"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -68413,7 +68482,7 @@
       "source_location": "L107"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
@@ -68422,7 +68491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -68431,7 +68500,7 @@
       "source_location": "L168"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -68440,7 +68509,7 @@
       "source_location": "L110"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -68449,7 +68518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -68458,7 +68527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -68467,7 +68536,7 @@
       "source_location": "L3"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -68476,7 +68545,7 @@
       "source_location": "L9"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -68485,7 +68554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -68494,7 +68563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -68503,7 +68572,7 @@
       "source_location": "L3"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -68512,7 +68581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -68521,7 +68590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -68530,7 +68599,7 @@
       "source_location": "L3"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -68539,7 +68608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -68548,7 +68617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -68557,7 +68626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -68566,39 +68635,12 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
       "norm_label": "tableskeleton()",
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "label": "transactions-skeleton.tsx",
-      "norm_label": "transactions-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "label": "transactions-skeleton.tsx",
-      "norm_label": "transactions-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "transactions_skeleton_transactionsskeleton",
-      "label": "TransactionsSkeleton()",
-      "norm_label": "transactionsskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3"
     },
     {
@@ -68730,6 +68772,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
+      "label": "transactions-skeleton.tsx",
+      "norm_label": "transactions-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
+      "label": "transactions-skeleton.tsx",
+      "norm_label": "transactions-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "transactions_skeleton_transactionsskeleton",
+      "label": "TransactionsSkeleton()",
+      "norm_label": "transactionsskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
       "norm_label": "notfound()",
@@ -68737,7 +68806,7 @@
       "source_location": "L4"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -68746,7 +68815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -68755,7 +68824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -68764,7 +68833,7 @@
       "source_location": "L120"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -68773,7 +68842,7 @@
       "source_location": "L36"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -68782,7 +68851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -68791,7 +68860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -68800,7 +68869,7 @@
       "source_location": "L23"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -68809,7 +68878,7 @@
       "source_location": "L41"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -68818,7 +68887,7 @@
       "source_location": "L20"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -68827,7 +68896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -68836,7 +68905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -68845,7 +68914,7 @@
       "source_location": "L30"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -68854,7 +68923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -68863,7 +68932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -68872,7 +68941,7 @@
       "source_location": "L9"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -68881,7 +68950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -68890,7 +68959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -68899,7 +68968,7 @@
       "source_location": "L38"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -68908,7 +68977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -68917,7 +68986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -68926,7 +68995,7 @@
       "source_location": "L20"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -68935,7 +69004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -68944,7 +69013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -68953,7 +69022,7 @@
       "source_location": "L12"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -68962,40 +69031,13 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
       "norm_label": "overlay-modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
-      "label": "skeleton.tsx",
-      "norm_label": "skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
-      "label": "skeleton.tsx",
-      "norm_label": "skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "skeleton_skeleton",
-      "label": "Skeleton()",
-      "norm_label": "skeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
-      "source_location": "L3"
     },
     {
       "community": 37,
@@ -69126,6 +69168,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
+      "label": "skeleton.tsx",
+      "norm_label": "skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
+      "label": "skeleton.tsx",
+      "norm_label": "skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "skeleton_skeleton",
+      "label": "Skeleton()",
+      "norm_label": "skeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
       "norm_label": "sonner.tsx",
@@ -69133,7 +69202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -69142,7 +69211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -69151,7 +69220,7 @@
       "source_location": "L6"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -69160,7 +69229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -69169,7 +69238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -69178,7 +69247,7 @@
       "source_location": "L3"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -69187,7 +69256,7 @@
       "source_location": "L44"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -69196,7 +69265,7 @@
       "source_location": "L19"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -69205,7 +69274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -69214,7 +69283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -69223,7 +69292,7 @@
       "source_location": "L159"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -69232,7 +69301,7 @@
       "source_location": "L195"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -69241,7 +69310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -69250,7 +69319,7 @@
       "source_location": "L22"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -69259,7 +69328,7 @@
       "source_location": "L45"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -69268,7 +69337,7 @@
       "source_location": "L24"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -69277,7 +69346,7 @@
       "source_location": "L38"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -69286,7 +69355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -69295,7 +69364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -69304,7 +69373,7 @@
       "source_location": "L23"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -69313,7 +69382,7 @@
       "source_location": "L51"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -69322,7 +69391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -69331,7 +69400,7 @@
       "source_location": "L54"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -69340,7 +69409,7 @@
       "source_location": "L282"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -69349,7 +69418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -69358,40 +69427,13 @@
       "source_location": "L12"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
       "norm_label": "useusercontext()",
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useauth_ts",
-      "label": "useAuth.ts",
-      "norm_label": "useauth.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useauth_ts",
-      "label": "useAuth.ts",
-      "norm_label": "useauth.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "useauth_useauth",
-      "label": "useAuth()",
-      "norm_label": "useauth()",
-      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
-      "source_location": "L4"
     },
     {
       "community": 38,
@@ -69522,6 +69564,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useauth_ts",
+      "label": "useAuth.ts",
+      "norm_label": "useauth.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useauth_ts",
+      "label": "useAuth.ts",
+      "norm_label": "useauth.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "useauth_useauth",
+      "label": "useAuth()",
+      "norm_label": "useauth()",
+      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
       "norm_label": "usegetactivestore.ts",
@@ -69529,7 +69598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -69538,7 +69607,7 @@
       "source_location": "L9"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -69547,7 +69616,7 @@
       "source_location": "L50"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -69556,7 +69625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -69565,7 +69634,7 @@
       "source_location": "L6"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -69574,7 +69643,7 @@
       "source_location": "L31"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -69583,7 +69652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -69592,7 +69661,7 @@
       "source_location": "L5"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -69601,7 +69670,7 @@
       "source_location": "L31"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -69610,7 +69679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -69619,7 +69688,7 @@
       "source_location": "L19"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -69628,7 +69697,7 @@
       "source_location": "L33"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -69637,7 +69706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "presentcommandtoast_getapprovalguidance",
       "label": "getApprovalGuidance()",
@@ -69646,7 +69715,7 @@
       "source_location": "L9"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -69655,7 +69724,7 @@
       "source_location": "L16"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -69664,7 +69733,7 @@
       "source_location": "L7"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -69673,7 +69742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -69682,7 +69751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "bootstrapregister_test_drawer",
       "label": "drawer()",
@@ -69691,7 +69760,7 @@
       "source_location": "L9"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "bootstrapregister_test_state",
       "label": "state()",
@@ -69700,7 +69769,7 @@
       "source_location": "L23"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -69709,7 +69778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -69718,7 +69787,7 @@
       "source_location": "L3"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -69727,7 +69796,7 @@
       "source_location": "L10"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -69736,7 +69805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -69745,7 +69814,7 @@
       "source_location": "L18"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -69754,40 +69823,13 @@
       "source_location": "L60"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
       "norm_label": "commandgateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L223"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "useregisterviewmodel_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L214"
     },
     {
       "community": 39,
@@ -69918,6 +69960,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L223"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "main_app",
       "label": "App()",
       "norm_label": "app()",
@@ -69925,7 +69994,7 @@
       "source_location": "L31"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -69934,7 +70003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -69943,7 +70012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -69952,7 +70021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -69961,7 +70030,7 @@
       "source_location": "L28"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -69970,7 +70039,7 @@
       "source_location": "L46"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "actioncolorreview_stories_swatch",
       "label": "Swatch()",
@@ -69979,7 +70048,7 @@
       "source_location": "L179"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "actioncolorreview_stories_tokenscope",
       "label": "TokenScope()",
@@ -69988,7 +70057,7 @@
       "source_location": "L168"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
       "label": "ActionColorReview.stories.tsx",
@@ -69997,7 +70066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -70006,7 +70075,7 @@
       "source_location": "L127"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -70015,7 +70084,7 @@
       "source_location": "L106"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -70024,7 +70093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -70033,7 +70102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -70042,7 +70111,7 @@
       "source_location": "L49"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -70051,7 +70120,7 @@
       "source_location": "L62"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -70060,7 +70129,7 @@
       "source_location": "L66"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -70069,7 +70138,7 @@
       "source_location": "L20"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -70078,7 +70147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -70087,7 +70156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -70096,7 +70165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -70105,7 +70174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -70114,7 +70183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -70123,7 +70192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -70132,7 +70201,7 @@
       "source_location": "L16"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -70141,7 +70210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -70150,40 +70219,13 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
       "norm_label": "manualchunks()",
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L26"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "vitest_setup_pointercapturestub",
-      "label": "pointerCaptureStub()",
-      "norm_label": "pointercapturestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "vitest_setup_pointerreleasestub",
-      "label": "pointerReleaseStub()",
-      "norm_label": "pointerreleasestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L24"
     },
     {
       "community": 4,
@@ -70593,6 +70635,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
       "norm_label": "logout()",
@@ -70600,7 +70669,7 @@
       "source_location": "L32"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -70609,7 +70678,7 @@
       "source_location": "L3"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -70618,7 +70687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -70627,7 +70696,7 @@
       "source_location": "L7"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -70636,7 +70705,7 @@
       "source_location": "L5"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -70645,7 +70714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -70654,7 +70723,7 @@
       "source_location": "L6"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -70663,7 +70732,7 @@
       "source_location": "L18"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -70672,7 +70741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -70681,7 +70750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -70690,7 +70759,7 @@
       "source_location": "L60"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "postransaction_getpostransaction",
       "label": "getPosTransaction()",
@@ -70699,7 +70768,7 @@
       "source_location": "L62"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -70708,7 +70777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -70717,7 +70786,7 @@
       "source_location": "L3"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -70726,7 +70795,7 @@
       "source_location": "L5"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -70735,7 +70804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -70744,7 +70813,7 @@
       "source_location": "L18"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -70753,7 +70822,7 @@
       "source_location": "L23"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -70762,7 +70831,7 @@
       "source_location": "L22"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -70771,7 +70840,7 @@
       "source_location": "L55"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -70780,7 +70849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -70789,7 +70858,7 @@
       "source_location": "L77"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -70798,7 +70867,7 @@
       "source_location": "L11"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -70807,7 +70876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -70816,7 +70885,7 @@
       "source_location": "L11"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -70825,39 +70894,12 @@
       "source_location": "L22"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
       "norm_label": "deliverysection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -70989,6 +71031,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
       "norm_label": "loadcheckoutstate()",
@@ -70996,7 +71065,7 @@
       "source_location": "L4"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -71005,7 +71074,7 @@
       "source_location": "L24"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -71014,7 +71083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -71023,7 +71092,7 @@
       "source_location": "L131"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -71032,7 +71101,7 @@
       "source_location": "L12"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -71041,7 +71110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -71050,7 +71119,7 @@
       "source_location": "L20"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -71059,7 +71128,7 @@
       "source_location": "L46"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -71068,7 +71137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -71077,7 +71146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -71086,7 +71155,7 @@
       "source_location": "L20"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -71095,7 +71164,7 @@
       "source_location": "L59"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -71104,7 +71173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -71113,7 +71182,7 @@
       "source_location": "L25"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -71122,7 +71191,7 @@
       "source_location": "L20"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -71131,7 +71200,7 @@
       "source_location": "L30"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -71140,7 +71209,7 @@
       "source_location": "L95"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -71149,7 +71218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -71158,7 +71227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -71167,7 +71236,7 @@
       "source_location": "L150"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -71176,7 +71245,7 @@
       "source_location": "L157"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -71185,7 +71254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -71194,7 +71263,7 @@
       "source_location": "L63"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -71203,7 +71272,7 @@
       "source_location": "L48"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -71212,7 +71281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -71221,40 +71290,13 @@
       "source_location": "L63"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
     },
     {
       "community": 42,
@@ -71385,6 +71427,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
       "norm_label": "navigationbarprovider()",
@@ -71392,7 +71461,7 @@
       "source_location": "L16"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -71401,7 +71470,7 @@
       "source_location": "L39"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -71410,7 +71479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -71419,7 +71488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -71428,7 +71497,7 @@
       "source_location": "L20"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -71437,7 +71506,7 @@
       "source_location": "L55"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -71446,7 +71515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -71455,7 +71524,7 @@
       "source_location": "L107"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -71464,7 +71533,7 @@
       "source_location": "L25"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -71473,7 +71542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -71482,7 +71551,7 @@
       "source_location": "L556"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -71491,7 +71560,7 @@
       "source_location": "L52"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -71500,7 +71569,7 @@
       "source_location": "L429"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -71509,7 +71578,7 @@
       "source_location": "L102"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -71518,7 +71587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -71527,7 +71596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -71536,7 +71605,7 @@
       "source_location": "L250"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -71545,7 +71614,7 @@
       "source_location": "L46"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -71554,7 +71623,7 @@
       "source_location": "L17"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -71563,7 +71632,7 @@
       "source_location": "L63"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -71572,7 +71641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -71581,7 +71650,7 @@
       "source_location": "L47"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -71590,7 +71659,7 @@
       "source_location": "L141"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -71599,7 +71668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -71608,7 +71677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -71617,40 +71686,13 @@
       "source_location": "L21"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
       "norm_label": "verifycheckoutsessionpayment()",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "index_money",
-      "label": "money()",
-      "norm_label": "money()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "index_paymentlabel",
-      "label": "paymentLabel()",
-      "norm_label": "paymentlabel()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 43,
@@ -71781,6 +71823,33 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "index_money",
+      "label": "money()",
+      "norm_label": "money()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "index_paymentlabel",
+      "label": "paymentLabel()",
+      "norm_label": "paymentlabel()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
       "norm_label": "signup.tsx",
@@ -71788,7 +71857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -71797,7 +71866,7 @@
       "source_location": "L161"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -71806,7 +71875,7 @@
       "source_location": "L66"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -71815,7 +71884,7 @@
       "source_location": "L11"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -71824,7 +71893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -71833,7 +71902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -71842,7 +71911,7 @@
       "source_location": "L16"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -71851,7 +71920,7 @@
       "source_location": "L10"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -71860,7 +71929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -71869,7 +71938,7 @@
       "source_location": "L17"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -71878,7 +71947,7 @@
       "source_location": "L11"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -71887,7 +71956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -71896,7 +71965,7 @@
       "source_location": "L48"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -71905,7 +71974,7 @@
       "source_location": "L42"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -71914,7 +71983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -71923,7 +71992,7 @@
       "source_location": "L16"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -71932,7 +72001,7 @@
       "source_location": "L10"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -71941,7 +72010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -71950,7 +72019,7 @@
       "source_location": "L19"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -71959,7 +72028,7 @@
       "source_location": "L13"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -71968,7 +72037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -71977,7 +72046,7 @@
       "source_location": "L16"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -71986,7 +72055,7 @@
       "source_location": "L10"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -71995,7 +72064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -72004,7 +72073,7 @@
       "source_location": "L20"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -72013,39 +72082,12 @@
       "source_location": "L14"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1578
-- Graph nodes: 4290
-- Graph edges: 3974
+- Graph nodes: 4298
+- Graph edges: 3986
 - Communities: 1506
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1578
-- Graph nodes: 4298
-- Graph edges: 3986
+- Graph nodes: 4300
+- Graph edges: 3988
 - Communities: 1506
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 76) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 77) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/AGENTS.md
+++ b/packages/athena-webapp/AGENTS.md
@@ -7,4 +7,4 @@
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing ownership across `src/` and `convex/`.
 - For product-copy changes, follow the repo guide at [../../docs/product-copy-tone.md](../../docs/product-copy-tone.md) and normalize operator-facing system text instead of surfacing raw backend phrasing.
-- When generated Convex client artifacts need to refresh, start `bunx convex dev` from `packages/athena-webapp`. Do not use `bunx convex codegen` in this repo's normal agent flow because local workspaces may not have `CONVEX_DEPLOYMENT` configured.
+- When generated Convex client artifacts need to refresh, run `bunx convex dev --once` from `packages/athena-webapp`. Plain `bunx convex dev` enters watch mode. Do not use `bunx convex codegen` in this repo's normal agent flow because local workspaces may not have `CONVEX_DEPLOYMENT` configured.

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -31,7 +31,7 @@ Behavior scenarios:
 
 - `athena-admin-shell-boot`
 
-Use this when stock adjustments, procurement recommendations, purchase-order lifecycle changes, or receiving route wiring move. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new stockOps function exports changed.
+Use this when stock adjustments, procurement recommendations, purchase-order lifecycle changes, or receiving route wiring move. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new stockOps function exports changed.
 
 ## Cash-controls workflow edits
 
@@ -47,7 +47,7 @@ Behavior scenarios:
 
 - `athena-admin-shell-boot`
 
-Use this when register-session, deposit, closeout, dashboard, operations-queue approval, or cash-controls route wiring changes. This is the confirmation slice for drawers opened from POS showing up in the dashboard and register-session detail views. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new Convex function exports changed.
+Use this when register-session, deposit, closeout, dashboard, operations-queue approval, or cash-controls route wiring changes. This is the confirmation slice for drawers opened from POS showing up in the dashboard and register-session detail views. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new Convex function exports changed.
 
 ## Service operations intake, catalog, appointments, and cases
 
@@ -104,7 +104,7 @@ Behavior scenarios:
 - `athena-convex-storefront-composition`
 - `athena-convex-storefront-failure-visibility`
 
-Use this when order updates, refunds, return-exchange execution, review moderation, feedback-request messaging, or customer-history presentation changes. It validates the migrated storefront command-result surfaces plus the operator-facing order, review, and customer-history views before broader package validation. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new storefront function exports changed.
+Use this when order updates, refunds, return-exchange execution, review moderation, feedback-request messaging, or customer-history presentation changes. It validates the migrated storefront command-result surfaces plus the operator-facing order, review, and customer-history views before broader package validation. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new storefront function exports changed.
 
 ## Workflow trace foundation, POS drawer gate, and trace-link edits
 

--- a/scripts/github-pr-merge.test.ts
+++ b/scripts/github-pr-merge.test.ts
@@ -57,7 +57,7 @@ describe("github-pr-merge", () => {
         "--repo",
         "kwam1na/athena",
         "--json",
-        "baseRefName,headRefName,headRepository,headRepositoryOwner,isDraft,number,state,url",
+        "baseRefName,headRefName,headRepository,headRepositoryOwner,id,isDraft,number,state,url",
       ],
       [
         "gh",
@@ -77,6 +77,54 @@ describe("github-pr-merge", () => {
       ],
     ]);
     expect(inputs[1]).toBe('{"merge_method":"squash"}\n');
+  });
+
+  it("arms auto-merge through GraphQL without merging immediately", async () => {
+    const calls: string[][] = [];
+    const runCommand: CommandRunner = async (command) => {
+      calls.push(command);
+
+      if (command[0] === "gh" && command[1] === "pr" && command[2] === "view") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            baseRefName: "main",
+            headRefName: "codex/auto",
+            headRepository: { nameWithOwner: "kwam1na/athena" },
+            headRepositoryOwner: { login: "kwam1na" },
+            id: "PR_kwDOExample",
+            isDraft: false,
+            number: 344,
+            state: "OPEN",
+            url: "https://github.com/kwam1na/athena/pull/344",
+          }),
+        };
+      }
+
+      return { exitCode: 0, stderr: "", stdout: "{}" };
+    };
+
+    const message = await mergePullRequest(
+      {
+        auto: true,
+        deleteBranch: true,
+        method: "squash",
+        prRef: "344",
+        repo: "kwam1na/athena",
+      },
+      runCommand
+    );
+
+    expect(message).toBe(
+      "Armed auto-merge for https://github.com/kwam1na/athena/pull/344 with squash."
+    );
+    expect(calls.map((call) => call.slice(0, 3))).toEqual([
+      ["gh", "pr", "view"],
+      ["gh", "api", "graphql"],
+    ]);
+    expect(calls[1]).toContain("pullRequestId=PR_kwDOExample");
+    expect(calls[1]).toContain("mergeMethod=SQUASH");
   });
 
   it("does not delete fork branches", async () => {
@@ -332,12 +380,14 @@ describe("github-pr-merge", () => {
     expect(
       parseArgs([
         "343",
+        "--auto",
         "--method",
         "rebase",
         "--delete-branch",
         "--repo=kwam1na/athena",
       ])
     ).toEqual({
+      auto: true,
       deleteBranch: true,
       method: "rebase",
       prRef: "343",
@@ -347,6 +397,7 @@ describe("github-pr-merge", () => {
 
   it("rejects invalid CLI options", () => {
     expect(() => parseArgs([])).toThrow("Usage:");
+    expect(() => parseArgs(["--help"])).toThrow();
     expect(() => parseArgs(["343", "--method"])).toThrow("--method requires a value");
     expect(() => parseArgs(["343", "--method", "octopus"])).toThrow(
       "Unsupported merge method"

--- a/scripts/github-pr-merge.ts
+++ b/scripts/github-pr-merge.ts
@@ -28,6 +28,7 @@ type PullRequestView = {
   headRepositoryOwner: {
     login: string;
   } | null;
+  id: string;
   isDraft: boolean;
   number: number;
   state: "OPEN" | "CLOSED" | "MERGED";
@@ -39,6 +40,7 @@ type RepoView = {
 };
 
 export type MergeOptions = {
+  auto?: boolean;
   deleteBranch: boolean;
   method: MergeMethod;
   prRef: string;
@@ -46,6 +48,19 @@ export type MergeOptions = {
 };
 
 const DEFAULT_METHOD: MergeMethod = "squash";
+const HELP_TEXT = `Usage: bun scripts/github-pr-merge.ts <pr-ref> [--auto] [--method squash|merge|rebase] [--delete-branch] [--repo owner/name]
+
+Merge or arm auto-merge for a GitHub pull request through GitHub APIs without
+checking out, pulling, or mutating local main.
+
+Options:
+  --auto             Arm GitHub auto-merge instead of merging immediately.
+  --method <method>  Merge method: squash, merge, or rebase. Default: squash.
+  --delete-branch    Delete the same-repo head branch after an immediate merge.
+                     Ignored with --auto because the remote merge happens later.
+  --repo <owner/repo> Select a repository instead of resolving the current repo.
+  -h, --help         Show this help.
+`;
 
 export async function mergePullRequest(
   options: MergeOptions,
@@ -64,6 +79,11 @@ export async function mergePullRequest(
 
   if (pr.isDraft) {
     throw new Error(`Pull request ${pr.url} is still a draft.`);
+  }
+
+  if (options.auto) {
+    await enablePullRequestAutoMerge(pr, options.method, runCommand);
+    return `Armed auto-merge for ${pr.url} with ${options.method}.`;
   }
 
   await ghJson(
@@ -93,6 +113,7 @@ export async function mergePullRequest(
 }
 
 export function parseArgs(args: string[]): MergeOptions {
+  let auto = false;
   let deleteBranch = false;
   let method: MergeMethod = DEFAULT_METHOD;
   let repo: string | undefined;
@@ -100,6 +121,15 @@ export function parseArgs(args: string[]): MergeOptions {
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+
+    if (arg === "-h" || arg === "--help") {
+      throw new HelpRequested();
+    }
+
+    if (arg === "--auto") {
+      auto = true;
+      continue;
+    }
 
     if (arg === "--delete-branch") {
       deleteBranch = true;
@@ -138,12 +168,10 @@ export function parseArgs(args: string[]): MergeOptions {
   }
 
   if (!prRef) {
-    throw new Error(
-      "Usage: bun scripts/github-pr-merge.ts <pr-ref> [--method squash|merge|rebase] [--delete-branch] [--repo owner/name]"
-    );
+    throw new Error(HELP_TEXT.trim());
   }
 
-  return { deleteBranch, method, prRef, repo };
+  return { ...(auto ? { auto } : {}), deleteBranch, method, prRef, repo };
 }
 
 async function resolveCurrentRepo(runCommand: CommandRunner) {
@@ -169,7 +197,7 @@ async function viewPullRequest(
       "--repo",
       repo,
       "--json",
-      "baseRefName,headRefName,headRepository,headRepositoryOwner,isDraft,number,state,url",
+      "baseRefName,headRefName,headRepository,headRepositoryOwner,id,isDraft,number,state,url",
     ],
     undefined,
     runCommand
@@ -191,6 +219,45 @@ async function deleteHeadBranch(
     ],
     undefined,
     runCommand
+  );
+}
+
+async function enablePullRequestAutoMerge(
+  pr: PullRequestView,
+  method: MergeMethod,
+  runCommand: CommandRunner
+) {
+  const query = `
+    mutation EnablePullRequestAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+      enablePullRequestAutoMerge(input: {
+        pullRequestId: $pullRequestId
+        mergeMethod: $mergeMethod
+      }) {
+        pullRequest {
+          url
+        }
+      }
+    }
+  `;
+
+  const result = await runCommand([
+    "gh",
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-f",
+    `pullRequestId=${pr.id}`,
+    "-f",
+    `mergeMethod=${method.toUpperCase()}`,
+  ]);
+
+  if (result.exitCode === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Failed to arm auto-merge for ${pr.url} with ${method}\n${result.stderr}`
   );
 }
 
@@ -248,6 +315,8 @@ export async function runProcess(
   return { exitCode, stdout, stderr };
 }
 
+class HelpRequested extends Error {}
+
 function requireValue(args: string[], index: number, flag: string) {
   const value = args[index];
   if (!value) {
@@ -268,6 +337,10 @@ if (import.meta.main) {
     const message = await mergePullRequest(parseArgs(Bun.argv.slice(2)));
     console.log(message);
   } catch (error) {
+    if (error instanceof HelpRequested) {
+      console.log(HELP_TEXT.trim());
+      process.exit(0);
+    }
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -267,7 +267,7 @@ describe("HARNESS_APP_REGISTRY", () => {
         { kind: "script", script: "build" },
       ],
       note:
-        "Use this when register-session, deposit, closeout, dashboard, operations-queue approval, or cash-controls route wiring changes. This is the confirmation slice for drawers opened from POS showing up in the dashboard and register-session detail views. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new Convex function exports changed.",
+        "Use this when register-session, deposit, closeout, dashboard, operations-queue approval, or cash-controls route wiring changes. This is the confirmation slice for drawers opened from POS showing up in the dashboard and register-session detail views. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new Convex function exports changed.",
       behaviorScenarios: ["athena-admin-shell-boot"],
     });
   });
@@ -558,7 +558,7 @@ describe("HARNESS_APP_REGISTRY", () => {
         { kind: "script", script: "build" },
       ],
       note:
-        "Use this when stock adjustments, procurement recommendations, purchase-order lifecycle changes, or receiving route wiring move. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new stockOps function exports changed.",
+        "Use this when stock adjustments, procurement recommendations, purchase-order lifecycle changes, or receiving route wiring move. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new stockOps function exports changed.",
       behaviorScenarios: ["athena-admin-shell-boot"],
     });
   });

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -311,7 +311,7 @@ export const HARNESS_APP_REGISTRY = [
         ],
         behaviorScenarios: ["athena-admin-shell-boot"],
         note:
-          "Use this when stock adjustments, procurement recommendations, purchase-order lifecycle changes, or receiving route wiring move. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new stockOps function exports changed.",
+          "Use this when stock adjustments, procurement recommendations, purchase-order lifecycle changes, or receiving route wiring move. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new stockOps function exports changed.",
       },
       {
         title: "Cash-controls workflow edits",
@@ -337,7 +337,7 @@ export const HARNESS_APP_REGISTRY = [
         ],
         behaviorScenarios: ["athena-admin-shell-boot"],
         note:
-          "Use this when register-session, deposit, closeout, dashboard, operations-queue approval, or cash-controls route wiring changes. This is the confirmation slice for drawers opened from POS showing up in the dashboard and register-session detail views. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new Convex function exports changed.",
+          "Use this when register-session, deposit, closeout, dashboard, operations-queue approval, or cash-controls route wiring changes. This is the confirmation slice for drawers opened from POS showing up in the dashboard and register-session detail views. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new Convex function exports changed.",
       },
       {
         title: "Service operations intake, catalog, appointments, and cases",
@@ -464,7 +464,7 @@ export const HARNESS_APP_REGISTRY = [
           "athena-convex-storefront-failure-visibility",
         ],
         note:
-          "Use this when order updates, refunds, return-exchange execution, review moderation, feedback-request messaging, or customer-history presentation changes. It validates the migrated storefront command-result surfaces plus the operator-facing order, review, and customer-history views before broader package validation. Start `bunx convex dev` from `packages/athena-webapp` before validation when generated client refs or new storefront function exports changed.",
+          "Use this when order updates, refunds, return-exchange execution, review moderation, feedback-request messaging, or customer-history presentation changes. It validates the migrated storefront command-result surfaces plus the operator-facing order, review, and customer-history views before broader package validation. Run `bunx convex dev --once` from `packages/athena-webapp` before validation when generated client refs or new storefront function exports changed.",
       },
       {
         title: "Workflow trace foundation, POS drawer gate, and trace-link edits",

--- a/scripts/harness-repo-validation.test.ts
+++ b/scripts/harness-repo-validation.test.ts
@@ -51,6 +51,7 @@ describe("collectHarnessRepoValidationSelection", () => {
     ]);
     expect(selection.selectedCommands).toEqual([
       "bun run harness:test",
+      "bun run test:coverage",
       "bun run harness:inferential-review",
     ]);
   });

--- a/scripts/harness-repo-validation.ts
+++ b/scripts/harness-repo-validation.ts
@@ -13,6 +13,7 @@ const HARNESS_REPO_VALIDATION_PATTERNS = [
 
 const HARNESS_REPO_VALIDATION_COMMANDS = [
   "bun run harness:test",
+  "bun run test:coverage",
   "bun run harness:inferential-review",
 ] as const;
 

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -440,6 +440,7 @@ describe("runHarnessReview", () => {
     expect(steps).toEqual([
       "harness:check",
       "bun run harness:test",
+      "bun run test:coverage",
       "bun run harness:inferential-review",
     ]);
   });
@@ -665,6 +666,7 @@ describe("runHarnessReview", () => {
     expect(steps).toEqual([
       "harness:check",
       "raw:bun run harness:test",
+      "raw:bun run test:coverage",
       "raw:bun run harness:inferential-review",
     ]);
   });
@@ -973,6 +975,7 @@ describe("runHarnessReview", () => {
     expect(steps).toEqual([
       "harness:check",
       "raw:bun run harness:test",
+      "raw:bun run test:coverage",
       "raw:bun run harness:inferential-review",
     ]);
   });

--- a/scripts/pre-commit-generated-artifacts.test.ts
+++ b/scripts/pre-commit-generated-artifacts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
 import {
+  TRACKED_CONVEX_GENERATED_ARTIFACTS,
   TRACKED_GENERATED_HARNESS_DOCS,
   TRACKED_GRAPHIFY_ARTIFACTS,
   runPreCommitGeneratedArtifacts,
@@ -15,6 +16,16 @@ describe("runPreCommitGeneratedArtifacts", () => {
     await runPreCommitGeneratedArtifacts("/repo", {
       runHarnessGenerate: async () => {
         steps.push("harness:generate");
+      },
+      hasConvexSourceChanges: async () => {
+        steps.push("convex:changed?");
+        return true;
+      },
+      refreshConvexGeneratedApi: async () => {
+        steps.push("convex:refresh");
+      },
+      verifyConvexGeneratedApi: async () => {
+        steps.push("convex:verify");
       },
       runGraphifyRebuild: async () => {
         steps.push("graphify:rebuild");
@@ -34,6 +45,10 @@ describe("runPreCommitGeneratedArtifacts", () => {
     expect(steps).toEqual([
       "harness:generate",
       `git add -- ${TRACKED_GENERATED_HARNESS_DOCS.join(" ")}`,
+      "convex:changed?",
+      "convex:refresh",
+      "convex:verify",
+      `git add -- ${TRACKED_CONVEX_GENERATED_ARTIFACTS.join(" ")}`,
       "graphify:rebuild",
       `git add -- ${TRACKED_GRAPHIFY_ARTIFACTS.join(" ")}`,
       "git add --update -- .",
@@ -45,6 +60,8 @@ describe("runPreCommitGeneratedArtifacts", () => {
 
     await runPreCommitGeneratedArtifacts("/repo", {
       runHarnessGenerate: async () => {},
+      hasConvexSourceChanges: async () => false,
+      verifyConvexGeneratedApi: async () => {},
       runGraphifyRebuild: async () => {},
       spawn(command) {
         commands.push(command);
@@ -60,6 +77,7 @@ describe("runPreCommitGeneratedArtifacts", () => {
 
     expect(commands).toEqual([
       ["git", "add", "--", ...TRACKED_GENERATED_HARNESS_DOCS],
+      ["git", "add", "--", ...TRACKED_CONVEX_GENERATED_ARTIFACTS],
       ["git", "add", "--", ...TRACKED_GRAPHIFY_ARTIFACTS],
       ["git", "add", "--update", "--", "."],
     ]);
@@ -70,6 +88,8 @@ describe("runPreCommitGeneratedArtifacts", () => {
 
     await runPreCommitGeneratedArtifacts("/repo", {
       runHarnessGenerate: async () => {},
+      hasConvexSourceChanges: async () => false,
+      verifyConvexGeneratedApi: async () => {},
       runGraphifyRebuild: async () => {},
       spawn(command) {
         commands.push(command);
@@ -91,6 +111,8 @@ describe("runPreCommitGeneratedArtifacts", () => {
 
     await runPreCommitGeneratedArtifacts("/repo", {
       runHarnessGenerate: async () => {},
+      hasConvexSourceChanges: async () => false,
+      verifyConvexGeneratedApi: async () => {},
       runGraphifyRebuild: async () => {},
       spawn(command) {
         commands.push(command);
@@ -113,6 +135,8 @@ describe("runPreCommitGeneratedArtifacts", () => {
     await expect(
       runPreCommitGeneratedArtifacts("/repo", {
         runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => false,
+        verifyConvexGeneratedApi: async () => {},
         runGraphifyRebuild: async () => {},
         spawn() {
           return {
@@ -127,16 +151,92 @@ describe("runPreCommitGeneratedArtifacts", () => {
     ).rejects.toThrow("git add harness docs failed");
   });
 
+  it("fails clearly when Convex generated API verification fails", async () => {
+    await expect(
+      runPreCommitGeneratedArtifacts("/repo", {
+        runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => false,
+        verifyConvexGeneratedApi: async () => {
+          throw new Error("convex generated api drift");
+        },
+        runGraphifyRebuild: async () => {},
+        spawn() {
+          return {
+            exited: Promise.resolve(0),
+            stderr: new Response("").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      })
+    ).rejects.toThrow("convex generated api drift");
+  });
+
+  it("fails clearly when Convex generated API refresh fails", async () => {
+    await expect(
+      runPreCommitGeneratedArtifacts("/repo", {
+        runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => true,
+        refreshConvexGeneratedApi: async () => {
+          throw new Error("convex refresh failed");
+        },
+        verifyConvexGeneratedApi: async () => {},
+        runGraphifyRebuild: async () => {},
+        spawn() {
+          return {
+            exited: Promise.resolve(0),
+            stderr: new Response("").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      })
+    ).rejects.toThrow("convex refresh failed");
+  });
+
+  it("fails clearly when staging repaired Convex generated API fails", async () => {
+    let spawnCount = 0;
+
+    await expect(
+      runPreCommitGeneratedArtifacts("/repo", {
+        runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => false,
+        verifyConvexGeneratedApi: async () => {},
+        runGraphifyRebuild: async () => {},
+        spawn() {
+          spawnCount += 1;
+          if (spawnCount === 1) {
+            return {
+              exited: Promise.resolve(0),
+              stderr: new Response("").body,
+            };
+          }
+          return {
+            exited: Promise.resolve(1),
+            stderr: new Response("git add convex failed").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      })
+    ).rejects.toThrow("git add convex failed");
+  });
+
   it("fails clearly when staging repaired graphify artifacts fails", async () => {
     let spawnCount = 0;
 
     await expect(
       runPreCommitGeneratedArtifacts("/repo", {
         runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => false,
+        verifyConvexGeneratedApi: async () => {},
         runGraphifyRebuild: async () => {},
         spawn() {
           spawnCount += 1;
-          if (spawnCount === 1) {
+          if (spawnCount < 3) {
             return {
               exited: Promise.resolve(0),
               stderr: new Response("").body,
@@ -160,10 +260,12 @@ describe("runPreCommitGeneratedArtifacts", () => {
     await expect(
       runPreCommitGeneratedArtifacts("/repo", {
         runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => false,
+        verifyConvexGeneratedApi: async () => {},
         runGraphifyRebuild: async () => {},
         spawn() {
           spawnCount += 1;
-          if (spawnCount < 3) {
+          if (spawnCount < 4) {
             return {
               exited: Promise.resolve(0),
               stderr: new Response("").body,
@@ -187,10 +289,12 @@ describe("runPreCommitGeneratedArtifacts", () => {
     await expect(
       runPreCommitGeneratedArtifacts("/repo", {
         runHarnessGenerate: async () => {},
+        hasConvexSourceChanges: async () => false,
+        verifyConvexGeneratedApi: async () => {},
         runGraphifyRebuild: async () => {},
         spawn() {
           spawnCount += 1;
-          if (spawnCount < 3) {
+          if (spawnCount < 4) {
             return {
               exited: Promise.resolve(0),
               stderr: new Response("").body,
@@ -208,6 +312,16 @@ describe("runPreCommitGeneratedArtifacts", () => {
     ).rejects.toThrow(
       "Failed to stage tracked working-tree changes (exit 1): git add --update -- ."
     );
+  });
+
+  it("keeps the tracked Convex generated API list aligned with repo outputs", () => {
+    expect(TRACKED_CONVEX_GENERATED_ARTIFACTS).toEqual([
+      path.join("packages", "athena-webapp", "convex", "_generated", "api.d.ts"),
+      path.join("packages", "athena-webapp", "convex", "_generated", "api.js"),
+      path.join("packages", "athena-webapp", "convex", "_generated", "dataModel.d.ts"),
+      path.join("packages", "athena-webapp", "convex", "_generated", "server.d.ts"),
+      path.join("packages", "athena-webapp", "convex", "_generated", "server.js"),
+    ]);
   });
 
   it("keeps the tracked graphify artifact list aligned with repo outputs", () => {

--- a/scripts/pre-commit-generated-artifacts.test.ts
+++ b/scripts/pre-commit-generated-artifacts.test.ts
@@ -1,3 +1,5 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -8,6 +10,36 @@ import {
   TRACKED_GRAPHIFY_ARTIFACTS,
   runPreCommitGeneratedArtifacts,
 } from "./pre-commit-generated-artifacts";
+
+async function withTempRepo<T>(callback: (repoDir: string) => Promise<T>) {
+  const repoDir = await mkdtemp(path.join(tmpdir(), "athena-pre-commit-"));
+
+  try {
+    return await callback(repoDir);
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
+}
+
+async function writeConvexApiFixture(
+  repoDir: string,
+  apiSource = 'import type * as catalog_items from "../catalog/items.js";\n'
+) {
+  const convexDir = path.join(
+    repoDir,
+    "packages",
+    "athena-webapp",
+    "convex"
+  );
+  await mkdir(path.join(convexDir, "catalog"), { recursive: true });
+  await mkdir(path.join(convexDir, "_generated"), { recursive: true });
+  await writeFile(path.join(convexDir, "catalog", "items.ts"), "export {};\n");
+  await writeFile(
+    path.join(convexDir, "catalog", "items.test.ts"),
+    "export {};\n"
+  );
+  await writeFile(path.join(convexDir, "_generated", "api.d.ts"), apiSource);
+}
 
 describe("runPreCommitGeneratedArtifacts", () => {
   it("regenerates harness docs and graphify artifacts before staging tracked outputs", async () => {
@@ -194,6 +226,149 @@ describe("runPreCommitGeneratedArtifacts", () => {
         },
       })
     ).rejects.toThrow("convex refresh failed");
+  });
+
+  it("refreshes the Convex generated API by default when source changed", async () => {
+    await withTempRepo(async (repoDir) => {
+      await writeConvexApiFixture(repoDir);
+      const commands: Array<{ command: string[]; cwd: string; stdout: string }> = [];
+
+      await runPreCommitGeneratedArtifacts(repoDir, {
+        runHarnessGenerate: async () => {},
+        runGraphifyRebuild: async () => {},
+        spawn(command, options) {
+          commands.push({ command, cwd: options.cwd, stdout: options.stdout });
+
+          if (command[0] === "git" && command[1] === "status") {
+            return {
+              exited: Promise.resolve(0),
+              stdout: new Response(
+                " M packages/athena-webapp/convex/catalog/items.ts\n"
+              ).body,
+              stderr: new Response("").body,
+            };
+          }
+
+          return {
+            exited: Promise.resolve(0),
+            stdout: new Response("").body,
+            stderr: new Response("").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      });
+
+      expect(commands).toContainEqual({
+        command: ["git", "status", "--porcelain", "--", "packages/athena-webapp/convex"],
+        cwd: repoDir,
+        stdout: "pipe",
+      });
+      expect(commands).toContainEqual({
+        command: ["bunx", "convex", "dev", "--once"],
+        cwd: path.join(repoDir, "packages", "athena-webapp"),
+        stdout: "inherit",
+      });
+    });
+  });
+
+  it("does not refresh the Convex generated API for generated-only drift", async () => {
+    await withTempRepo(async (repoDir) => {
+      await writeConvexApiFixture(repoDir);
+      const commands: string[] = [];
+
+      await runPreCommitGeneratedArtifacts(repoDir, {
+        runHarnessGenerate: async () => {},
+        runGraphifyRebuild: async () => {},
+        spawn(command, options) {
+          commands.push(command.join(" "));
+
+          if (command[0] === "git" && command[1] === "status") {
+            return {
+              exited: Promise.resolve(0),
+              stdout: new Response(
+                " M packages/athena-webapp/convex/_generated/api.d.ts\n"
+              ).body,
+              stderr: new Response("").body,
+            };
+          }
+
+          return {
+            exited: Promise.resolve(0),
+            stdout: new Response("").body,
+            stderr: new Response("").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      });
+
+      expect(commands).not.toContain("bunx convex dev --once");
+    });
+  });
+
+  it("fails when default Convex generated API verification misses a source module", async () => {
+    await withTempRepo(async (repoDir) => {
+      await writeConvexApiFixture(repoDir, "");
+
+      await expect(
+        runPreCommitGeneratedArtifacts(repoDir, {
+          runHarnessGenerate: async () => {},
+          runGraphifyRebuild: async () => {},
+          spawn(command) {
+            if (command[0] === "git" && command[1] === "status") {
+              return {
+                exited: Promise.resolve(0),
+                stdout: new Response("").body,
+                stderr: new Response("").body,
+              };
+            }
+
+            return {
+              exited: Promise.resolve(0),
+              stdout: new Response("").body,
+              stderr: new Response("").body,
+            };
+          },
+          logger: {
+            log() {},
+          },
+        })
+      ).rejects.toThrow(/catalog\/items[\s\S]+bunx convex dev --once/);
+    });
+  });
+
+  it("fails clearly when default Convex source inspection fails", async () => {
+    await withTempRepo(async (repoDir) => {
+      await writeConvexApiFixture(repoDir);
+
+      await expect(
+        runPreCommitGeneratedArtifacts(repoDir, {
+          runHarnessGenerate: async () => {},
+          runGraphifyRebuild: async () => {},
+          spawn(command) {
+            if (command[0] === "git" && command[1] === "status") {
+              return {
+                exited: Promise.resolve(1),
+                stdout: new Response("").body,
+                stderr: new Response("status failed").body,
+              };
+            }
+
+            return {
+              exited: Promise.resolve(0),
+              stdout: new Response("").body,
+              stderr: new Response("").body,
+            };
+          },
+          logger: {
+            log() {},
+          },
+        })
+      ).rejects.toThrow("status failed");
+    });
   });
 
   it("fails clearly when staging repaired Convex generated API fails", async () => {

--- a/scripts/pre-commit-generated-artifacts.ts
+++ b/scripts/pre-commit-generated-artifacts.ts
@@ -1,3 +1,6 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
 import { HARNESS_APP_REGISTRY } from "./harness-app-registry";
 import { writeGeneratedHarnessDocs } from "./harness-generate";
 import { TRACKED_GRAPHIFY_ARTIFACTS } from "./graphify-check";
@@ -9,19 +12,55 @@ const TRACKED_GENERATED_HARNESS_DOCS = [
   ),
 ].sort((left, right) => left.localeCompare(right));
 
+const TRACKED_CONVEX_GENERATED_ARTIFACTS = [
+  path.join("packages", "athena-webapp", "convex", "_generated", "api.d.ts"),
+  path.join("packages", "athena-webapp", "convex", "_generated", "api.js"),
+  path.join("packages", "athena-webapp", "convex", "_generated", "dataModel.d.ts"),
+  path.join("packages", "athena-webapp", "convex", "_generated", "server.d.ts"),
+  path.join("packages", "athena-webapp", "convex", "_generated", "server.js"),
+].sort((left, right) => left.localeCompare(right));
+
+const HELP_TEXT = `Usage: bun scripts/pre-commit-generated-artifacts.ts [--help]
+
+Refresh and verify tracked generated artifacts that must be committed with source changes:
+  - harness docs from the harness registry
+  - Convex generated API files under packages/athena-webapp/convex/_generated/
+  - graphify artifacts under graphify-out/
+  - tracked working-tree changes via git add --update
+
+Run this before committing or as part of the repo pre-push flow when generated
+outputs may drift.
+`;
+
+const CONVEX_DIR = path.join("packages", "athena-webapp", "convex");
+const CONVEX_GENERATED_API_PATH = path.join(
+  CONVEX_DIR,
+  "_generated",
+  "api.d.ts"
+);
+const CONVEX_API_MODULE_EXCEPTIONS = new Set([
+  "auth.config",
+  "schema",
+  "storeFront/customer",
+]);
+
 type SpawnedProcess = {
   exited: Promise<number>;
+  stdout?: ReadableStream | null;
   stderr?: ReadableStream | null;
 };
 
 type PreCommitGeneratedArtifactsLogger = Pick<Console, "log">;
 
 type PreCommitGeneratedArtifactsOptions = {
+  hasConvexSourceChanges?: (rootDir: string) => Promise<boolean>;
+  refreshConvexGeneratedApi?: (rootDir: string) => Promise<void>;
+  verifyConvexGeneratedApi?: (rootDir: string) => Promise<void>;
   runGraphifyRebuild?: (rootDir: string) => Promise<void>;
   runHarnessGenerate?: (rootDir: string) => Promise<void>;
   spawn?: (
     command: string[],
-    options: { cwd: string; stdout: "inherit"; stderr: "pipe" }
+    options: { cwd: string; stdout: "inherit" | "pipe"; stderr: "pipe" }
   ) => SpawnedProcess;
   logger?: PreCommitGeneratedArtifactsLogger;
 };
@@ -35,7 +74,7 @@ async function stageTrackedGeneratedArtifacts(
   const command = ["git", "add", "--", ...paths];
   const proc = spawn(command, {
     cwd: rootDir,
-    stdout: "inherit",
+    stdout: "pipe",
     stderr: "pipe",
   });
   const exitCode = await proc.exited;
@@ -78,6 +117,142 @@ async function stageTrackedWorkingTreeChanges(
   );
 }
 
+async function hasAthenaConvexSourceChanges(
+  rootDir: string,
+  spawn: NonNullable<PreCommitGeneratedArtifactsOptions["spawn"]>
+) {
+  const command = ["git", "status", "--porcelain", "--", CONVEX_DIR];
+  const proc = spawn(command, {
+    cwd: rootDir,
+    stdout: "inherit",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    const stderr = proc.stderr
+      ? (await new Response(proc.stderr).text()).trim()
+      : "";
+    throw new Error(
+      stderr ||
+        `Failed to inspect Convex source changes (exit ${exitCode}): ${command.join(" ")}`
+    );
+  }
+
+  const status = proc.stdout
+    ? await new Response(proc.stdout).text()
+    : "";
+
+  return status
+    .split("\n")
+    .some((line) => line && !line.includes(`${CONVEX_DIR}/_generated/`));
+}
+
+async function refreshAthenaConvexGeneratedApi(
+  rootDir: string,
+  spawn: NonNullable<PreCommitGeneratedArtifactsOptions["spawn"]>
+) {
+  const command = ["bunx", "convex", "dev", "--once"];
+  const proc = spawn(command, {
+    cwd: path.join(rootDir, "packages", "athena-webapp"),
+    stdout: "inherit",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+
+  if (exitCode === 0) {
+    return;
+  }
+
+  const stderr = proc.stderr
+    ? (await new Response(proc.stderr).text()).trim()
+    : "";
+  throw new Error(
+    stderr ||
+      `Failed to refresh Convex generated API (exit ${exitCode}): ${command.join(" ")}`
+  );
+}
+
+async function verifyAthenaConvexGeneratedApi(rootDir: string) {
+  const [sourceModules, generatedModules] = await Promise.all([
+    collectConvexSourceModules(path.join(rootDir, CONVEX_DIR)),
+    readGeneratedConvexApiModules(path.join(rootDir, CONVEX_GENERATED_API_PATH)),
+  ]);
+
+  const missingModules = sourceModules.filter(
+    (modulePath) => !generatedModules.has(modulePath)
+  );
+
+  if (missingModules.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      "Convex generated API is missing module references:",
+      ...missingModules.map((modulePath) => `  - ${modulePath}`),
+      "",
+      "Run `bunx convex dev --once` from packages/athena-webapp to refresh generated client artifacts, then rerun this command. Plain `bunx convex dev` enters watch mode.",
+    ].join("\n")
+  );
+}
+
+async function collectConvexSourceModules(convexDir: string) {
+  const modules = await collectConvexSourceModulesFromDir(convexDir, convexDir);
+  return modules
+    .filter((modulePath) => !CONVEX_API_MODULE_EXCEPTIONS.has(modulePath))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+async function collectConvexSourceModulesFromDir(rootDir: string, currentDir: string) {
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  const modules: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name === "_generated") {
+      continue;
+    }
+
+    const absolutePath = path.join(currentDir, entry.name);
+
+    if (entry.isDirectory()) {
+      modules.push(...(await collectConvexSourceModulesFromDir(rootDir, absolutePath)));
+      continue;
+    }
+
+    if (
+      !entry.isFile() ||
+      entry.name.endsWith(".test.ts") ||
+      (!entry.name.endsWith(".ts") && !entry.name.endsWith(".js"))
+    ) {
+      continue;
+    }
+
+    modules.push(
+      path
+        .relative(rootDir, absolutePath)
+        .replace(/\.(ts|js)$/, "")
+        .split(path.sep)
+        .join("/")
+    );
+  }
+
+  return modules;
+}
+
+async function readGeneratedConvexApiModules(apiPath: string) {
+  const apiSource = await readFile(apiPath, "utf8");
+  const modules = new Set<string>();
+  const importRegex = /^import type \* as \w+ from "\.\.\/(.+)\.js";$/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = importRegex.exec(apiSource))) {
+    modules.add(match[1]);
+  }
+
+  return modules;
+}
+
 export async function runPreCommitGeneratedArtifacts(
   rootDir: string,
   options: PreCommitGeneratedArtifactsOptions = {}
@@ -92,6 +267,14 @@ export async function runPreCommitGeneratedArtifacts(
       Bun.spawn(command, {
         ...spawnOptions,
       }));
+  const hasConvexSourceChanges =
+    options.hasConvexSourceChanges ??
+    ((sourceRootDir) => hasAthenaConvexSourceChanges(sourceRootDir, spawn));
+  const refreshConvexGeneratedApi =
+    options.refreshConvexGeneratedApi ??
+    ((refreshRootDir) => refreshAthenaConvexGeneratedApi(refreshRootDir, spawn));
+  const verifyConvexGeneratedApi =
+    options.verifyConvexGeneratedApi ?? verifyAthenaConvexGeneratedApi;
 
   logger.log("[pre-commit] Refreshing generated harness docs...");
   await generateHarnessDocs(rootDir);
@@ -100,6 +283,20 @@ export async function runPreCommitGeneratedArtifacts(
     spawn,
     TRACKED_GENERATED_HARNESS_DOCS,
     "harness doc"
+  );
+
+  logger.log("[pre-commit] Refreshing Convex generated API when source changed...");
+  if (await hasConvexSourceChanges(rootDir)) {
+    await refreshConvexGeneratedApi(rootDir);
+  }
+
+  logger.log("[pre-commit] Verifying Convex generated API coverage...");
+  await verifyConvexGeneratedApi(rootDir);
+  await stageTrackedGeneratedArtifacts(
+    rootDir,
+    spawn,
+    TRACKED_CONVEX_GENERATED_ARTIFACTS,
+    "Convex generated API"
   );
 
   logger.log("[pre-commit] Refreshing tracked graphify artifacts...");
@@ -115,9 +312,18 @@ export async function runPreCommitGeneratedArtifacts(
   await stageTrackedWorkingTreeChanges(rootDir, spawn);
 }
 
-export { TRACKED_GENERATED_HARNESS_DOCS, TRACKED_GRAPHIFY_ARTIFACTS };
+export {
+  TRACKED_CONVEX_GENERATED_ARTIFACTS,
+  TRACKED_GENERATED_HARNESS_DOCS,
+  TRACKED_GRAPHIFY_ARTIFACTS,
+};
 
 if (import.meta.main) {
+  if (Bun.argv.slice(2).some((arg) => arg === "-h" || arg === "--help")) {
+    console.log(HELP_TEXT.trim());
+    process.exit(0);
+  }
+
   runPreCommitGeneratedArtifacts(process.cwd()).catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`\n[pre-commit] BLOCKED: ${message}`);

--- a/scripts/pre-commit-generated-artifacts.ts
+++ b/scripts/pre-commit-generated-artifacts.ts
@@ -124,7 +124,7 @@ async function hasAthenaConvexSourceChanges(
   const command = ["git", "status", "--porcelain", "--", CONVEX_DIR];
   const proc = spawn(command, {
     cwd: rootDir,
-    stdout: "inherit",
+    stdout: "pipe",
     stderr: "pipe",
   });
   const exitCode = await proc.exited;


### PR DESCRIPTION
## Summary
- harden the agent delivery workflow around worktree-safe PR merging, generated artifact repairs, and pre-push validation blockers
- update the GitHub PR merge helper and tests for API-based immediate merge and GraphQL auto-merge arming
- refresh harness registry coverage, generated harness guidance, and graphify artifacts for the workflow changes

## Validation
- `bun test scripts/pre-commit-generated-artifacts.test.ts scripts/github-pr-merge.test.ts scripts/harness-app-registry.test.ts`
- `bun scripts/github-pr-merge.ts --help`
- `bun scripts/pre-commit-generated-artifacts.ts --help`
- `bun run graphify:rebuild`
- `git diff --check`
- `bun run pre-push:review` via push hook: passed