### PR TITLE
feat(pos): add fuzzy local catalog search

### DIFF
--- a/docs/solutions/harness/repo-coverage-policy-2026-05-02.md
+++ b/docs/solutions/harness/repo-coverage-policy-2026-05-02.md
@@ -12,6 +12,7 @@ tags:
   - pr-validation
   - vitest
   - bun-test
+  - ci-parity
 ---
 
 # Athena Coverage Policy Uses a Baseline Gate Until 100 Percent Is Feasible
@@ -36,6 +37,8 @@ The target policy remains 100 percent across lines, statements, functions, and b
 
 The baseline should match CI output. GitHub Actions installs dependencies with `bun install --frozen-lockfile`, and `bun run test:coverage` first runs `scripts/coverage-toolchain-parity.ts` so stale local installs or mismatched Vitest-family versions fail before coverage reports are generated.
 
+Remote CI can still diverge if local pre-push routing does not select the same coverage command for files that affect the repo harness itself. Repo-owned workflow changes under `scripts/`, package agent docs, GitHub workflow files, Husky hooks, and top-level repo wiring should route through `harness:review`, and that repo-level selection must include `bun run test:coverage`. A green `pre-push:review` is only merge-equivalent when it actually runs the same coverage gate that Actions will run for the touched surface.
+
 ## Exclusions
 
 Generated outputs, test files, route tree generation, coverage output, and Convex generated files stay excluded in the package coverage configs.
@@ -45,6 +48,7 @@ Generated outputs, test files, route tree generation, coverage output, and Conve
 ## Prevention
 
 - Run `bun run test:coverage` before merge-ready handoff when coverage policy or testable source changes.
+- Keep repo-owned harness validation selection wired to `bun run test:coverage`; otherwise script coverage regressions can pass local pre-push and fail only in GitHub Actions.
 - Keep Vitest-family coverage tooling on exact, aligned versions across the root, Athena webapp, and storefront webapp manifests.
 - Keep root script coverage file selection explicit so local `worktrees/` tests cannot change local-only coverage totals.
 - Keep `scripts/coverage-summary.ts` path-relative to `process.cwd()` so worktrees and CI read their own coverage artifacts.

--- a/docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md
+++ b/docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md
@@ -9,8 +9,9 @@ symptoms:
   - "Barcode scans waited on debounce and server lookup timing before adding an item"
   - "Active register product entry ran generic, barcode, and product-id searches as competing query paths"
   - "No-result and quick-add prompts depended on delayed server-search completion"
+  - "Short prefix input such as dura returned no local catalog results for Durable Lace Front"
 root_cause: per_input_server_search_on_register_hot_path
-resolution_type: refactor
+resolution_type: refactor_plus_local_fuzzy_matching
 severity: medium
 tags:
   - pos
@@ -18,6 +19,7 @@ tags:
   - catalog
   - barcode
   - quick-add
+  - fuzzy-search
 ---
 
 # Athena POS Register Search Uses A Local Catalog Index
@@ -45,6 +47,21 @@ but it must not become the durable inventory authority. Adding still goes
 through the POS add-item command so drawer, staff, session, inventory, and trace
 invariants stay at the command boundary.
 
+Local text ranking should be forgiving without turning into a broad semantic
+search. Keep exact identifier resolution first, then rank text tokens with a
+prefix-friendly fuzzy pass:
+
+- Ignore fuzzy matching for query tokens shorter than three characters.
+- Score direct token containment ahead of edit-distance matches so `dura`
+  finds `durable` predictably.
+- Use a cheap first-character or first-two-character overlap guard before
+  computing edit distance.
+- Use normalized Levenshtein similarity for typo tolerance, with stronger
+  scores for close matches and weaker scores for borderline matches.
+
+This keeps the register hot path local and deterministic while covering common
+operator input: prefixes, partial product names, and small typos.
+
 ## Quick Add
 
 Quick-add and no-results prompts should follow local catalog readiness, not a
@@ -62,6 +79,7 @@ command, and the next snapshot refresh should make the new SKU searchable.
   can see why the item was not auto-added.
 - Add tests for exact single-match auto-add, out-of-stock exact results, and
   product-id variant ambiguity whenever register search changes.
+- Add tests for prefix and typo matching whenever local text ranking changes.
 
 ## Related Issues
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4300 nodes · 3988 edges · 1506 communities detected
+- 4306 nodes · 4000 edges · 1506 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1604,112 +1604,112 @@ Cohesion: 0.11
 Nodes (2): isSkuReserved(), shouldDisable()
 
 ### Community 15 - "Community 15"
+Cohesion: 0.18
+Nodes (17): bestFuzzyTokenScore(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isProbablySameToken(), isRowAvailable(), levenshteinDistance(), normalizeIdentifier() (+9 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.18
 Nodes (15): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+7 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.17
 Nodes (15): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), containsDisallowedRawNumericParse(), containsTerm(), isAllowedDisplayConversion() (+7 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.25
 Nodes (16): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+8 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.12
 Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.13
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.17
 Nodes (9): expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), normalizeCustomerSnapshot(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), registerSessionMatchesIdentity(), resolveCustomerTraceStage() (+1 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.23
 Nodes (13): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listProductSkusForStockAdjustmentScopeWithCtx(), mapSubmitStockAdjustmentBatchError() (+5 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.18
 Nodes (9): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff(), runCustomerCorrection() (+1 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.18
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.35
 Nodes (13): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+5 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.15
 Nodes (2): formatTimelineRange(), formatTimelineTime()
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
-
-### Community 41 - "Community 41"
-Cohesion: 0.24
-Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isRowAvailable(), normalizeIdentifier(), normalizeSearchText(), parseCatalogSearchInput(), searchByText() (+2 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.18
@@ -1748,28 +1748,28 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 51 - "Community 51"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 52 - "Community 52"
 Cohesion: 0.25
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.24
 Nodes (4): hasCustomerDetails(), mapCatalogRowToProduct(), trimOptional(), useRegisterViewModel()
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 56 - "Community 56"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 57 - "Community 57"
 Cohesion: 0.18
@@ -2265,7 +2265,7 @@ Nodes (0):
 
 ### Community 180 - "Community 180"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.4
@@ -2276,16 +2276,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 183 - "Community 183"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+
+### Community 185 - "Community 185"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 186 - "Community 186"
 Cohesion: 0.4
@@ -2297,7 +2297,7 @@ Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.5
@@ -9714,5 +9714,5 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 14` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 17` be split into smaller, more focused modules?**
+- **Should `Community 18` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -844,6 +844,18 @@
       "weight": 1
     },
     {
+      "_src": "catalogsearch_bestfuzzytokenscore",
+      "_tgt": "catalogsearch_scorefuzzytokenmatch",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "catalogsearch_bestfuzzytokenscore",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L286",
+      "target": "catalogsearch_scorefuzzytokenmatch",
+      "weight": 1
+    },
+    {
       "_src": "catalogsearch_findexactmatches",
       "_tgt": "catalogsearch_firstnonempty",
       "confidence": "EXTRACTED",
@@ -877,6 +889,66 @@
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
       "source_location": "L178",
       "target": "catalogsearch_extractidentifierfromurl",
+      "weight": 1
+    },
+    {
+      "_src": "catalogsearch_scorefuzzytokenmatch",
+      "_tgt": "catalogsearch_isprobablysametoken",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "catalogsearch_scorefuzzytokenmatch",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L305",
+      "target": "catalogsearch_isprobablysametoken",
+      "weight": 1
+    },
+    {
+      "_src": "catalogsearch_scorefuzzytokenmatch",
+      "_tgt": "catalogsearch_levenshteindistance",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "catalogsearch_scorefuzzytokenmatch",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L309",
+      "target": "catalogsearch_levenshteindistance",
+      "weight": 1
+    },
+    {
+      "_src": "catalogsearch_scorequerytokenforentry",
+      "_tgt": "catalogsearch_bestfuzzytokenscore",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "catalogsearch_scorequerytokenforentry",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L269",
+      "target": "catalogsearch_bestfuzzytokenscore",
+      "weight": 1
+    },
+    {
+      "_src": "catalogsearch_scorequerytokenforentry",
+      "_tgt": "catalogsearch_scorefieldcontains",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "catalogsearch_scorequerytokenforentry",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L260",
+      "target": "catalogsearch_scorefieldcontains",
+      "weight": 1
+    },
+    {
+      "_src": "catalogsearch_scoresearchrow",
+      "_tgt": "catalogsearch_scorequerytokenforentry",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "catalogsearch_scoresearchrow",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L241",
+      "target": "catalogsearch_scorequerytokenforentry",
       "weight": 1
     },
     {
@@ -947,7 +1019,7 @@
       "relation": "calls",
       "source": "catalogsearch_normalizesearchtext",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L276",
+      "source_location": "L385",
       "target": "catalogsearch_tokenizesearchtext",
       "weight": 1
     },
@@ -29171,8 +29243,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L290",
+      "source_location": "L399",
       "target": "catalogsearch_addkey",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "_tgt": "catalogsearch_bestfuzzytokenscore",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L276",
+      "target": "catalogsearch_bestfuzzytokenscore",
       "weight": 1
     },
     {
@@ -29219,8 +29303,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L308",
+      "source_location": "L417",
       "target": "catalogsearch_firstnonempty",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "_tgt": "catalogsearch_isprobablysametoken",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L324",
+      "target": "catalogsearch_isprobablysametoken",
       "weight": 1
     },
     {
@@ -29231,8 +29327,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L286",
+      "source_location": "L395",
       "target": "catalogsearch_isrowavailable",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "_tgt": "catalogsearch_levenshteindistance",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L332",
+      "target": "catalogsearch_levenshteindistance",
       "weight": 1
     },
     {
@@ -29243,7 +29351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L258",
+      "source_location": "L367",
       "target": "catalogsearch_normalizeidentifier",
       "weight": 1
     },
@@ -29255,7 +29363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L262",
+      "source_location": "L371",
       "target": "catalogsearch_normalizesearchtext",
       "weight": 1
     },
@@ -29269,6 +29377,42 @@
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
       "source_location": "L171",
       "target": "catalogsearch_parsecatalogsearchinput",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "_tgt": "catalogsearch_scorefieldcontains",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L272",
+      "target": "catalogsearch_scorefieldcontains",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "_tgt": "catalogsearch_scorefuzzytokenmatch",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L293",
+      "target": "catalogsearch_scorefuzzytokenmatch",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "_tgt": "catalogsearch_scorequerytokenforentry",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L253",
+      "target": "catalogsearch_scorequerytokenforentry",
       "weight": 1
     },
     {
@@ -29315,7 +29459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L272",
+      "source_location": "L381",
       "target": "catalogsearch_tokenizesearchtext",
       "weight": 1
     },
@@ -57063,182 +57207,182 @@
     {
       "community": 15,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "id": "catalogsearch_addkey",
+      "label": "addKey()",
+      "norm_label": "addkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L399"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_bestfuzzytokenscore",
+      "label": "bestFuzzyTokenScore()",
+      "norm_label": "bestfuzzytokenscore()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_buildregistercatalogindex",
+      "label": "buildRegisterCatalogIndex()",
+      "norm_label": "buildregistercatalogindex()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_extractidentifierfromurl",
+      "label": "extractIdentifierFromUrl()",
+      "norm_label": "extractidentifierfromurl()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_findexactmatches",
+      "label": "findExactMatches()",
+      "norm_label": "findexactmatches()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_firstnonempty",
+      "label": "firstNonEmpty()",
+      "norm_label": "firstnonempty()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L417"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_isprobablysametoken",
+      "label": "isProbablySameToken()",
+      "norm_label": "isprobablysametoken()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L324"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_isrowavailable",
+      "label": "isRowAvailable()",
+      "norm_label": "isrowavailable()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L395"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_levenshteindistance",
+      "label": "levenshteinDistance()",
+      "norm_label": "levenshteindistance()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L332"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L367"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_normalizesearchtext",
+      "label": "normalizeSearchText()",
+      "norm_label": "normalizesearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_parsecatalogsearchinput",
+      "label": "parseCatalogSearchInput()",
+      "norm_label": "parsecatalogsearchinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_scorefieldcontains",
+      "label": "scoreFieldContains()",
+      "norm_label": "scorefieldcontains()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L272"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_scorefuzzytokenmatch",
+      "label": "scoreFuzzyTokenMatch()",
+      "norm_label": "scorefuzzytokenmatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_scorequerytokenforentry",
+      "label": "scoreQueryTokenForEntry()",
+      "norm_label": "scorequerytokenforentry()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_scoresearchrow",
+      "label": "scoreSearchRow()",
+      "norm_label": "scoresearchrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L234"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_searchbytext",
+      "label": "searchByText()",
+      "norm_label": "searchbytext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_searchregistercatalog",
+      "label": "searchRegisterCatalog()",
+      "norm_label": "searchregistercatalog()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "catalogsearch_tokenizesearchtext",
+      "label": "tokenizeSearchText()",
+      "norm_label": "tokenizesearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "label": "catalogSearch.ts",
+      "norm_label": "catalogsearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_capitalizewords",
-      "label": "capitalizeWords()",
-      "norm_label": "capitalizewords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_enablequery",
-      "label": "enableQuery()",
-      "norm_label": "enablequery()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_formatdate",
-      "label": "formatDate()",
-      "norm_label": "formatdate()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_formatuserid",
-      "label": "formatUserId()",
-      "norm_label": "formatuserid()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_getaddressstring",
-      "label": "getAddressString()",
-      "norm_label": "getaddressstring()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_geterrorforfield",
-      "label": "getErrorForField()",
-      "norm_label": "geterrorforfield()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_getrelativetime",
-      "label": "getRelativeTime()",
-      "norm_label": "getrelativetime()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_getstoredetails",
-      "label": "getStoreDetails()",
-      "norm_label": "getstoredetails()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_gettimeremaining",
-      "label": "getTimeRemaining()",
-      "norm_label": "gettimeremaining()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_slugtowords",
-      "label": "slugToWords()",
-      "norm_label": "slugtowords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_snakecasetowords",
-      "label": "snakeCaseToWords()",
-      "norm_label": "snakecasetowords()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "utils_toslug",
-      "label": "toSlug()",
-      "norm_label": "toslug()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L33"
     },
     {
       "community": 150,
@@ -57837,173 +57981,182 @@
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
-      "label": "registerSessions.ts",
-      "norm_label": "registersessions.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "id": "packages_athena_webapp_convex_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_assertregistersessionidentity",
-      "label": "assertRegisterSessionIdentity()",
-      "norm_label": "assertregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L61"
+      "id": "packages_athena_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_assertregistersessionmatchestransaction",
-      "label": "assertRegisterSessionMatchesTransaction()",
-      "norm_label": "assertregistersessionmatchestransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L71"
+      "id": "packages_storefront_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_assertvalidregistersessiontransition",
-      "label": "assertValidRegisterSessionTransition()",
-      "norm_label": "assertvalidregistersessiontransition()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L128"
+      "id": "utils_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L18"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildclosedregistersessionpatch",
-      "label": "buildClosedRegisterSessionPatch()",
-      "norm_label": "buildclosedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L297"
+      "id": "utils_capitalizewords",
+      "label": "capitalizeWords()",
+      "norm_label": "capitalizewords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L23"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "id": "utils_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_enablequery",
+      "label": "enableQuery()",
+      "norm_label": "enablequery()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_formatdate",
+      "label": "formatDate()",
+      "norm_label": "formatdate()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_formatuserid",
+      "label": "formatUserId()",
+      "norm_label": "formatuserid()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_getaddressstring",
+      "label": "getAddressString()",
+      "norm_label": "getaddressstring()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_geterrorforfield",
+      "label": "getErrorForField()",
+      "norm_label": "geterrorforfield()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "utils_getrelativetime",
+      "label": "getRelativeTime()",
+      "norm_label": "getrelativetime()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L93"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildregistersessioncloseoutpatch",
-      "label": "buildRegisterSessionCloseoutPatch()",
-      "norm_label": "buildregistersessioncloseoutpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L188"
+      "id": "utils_getstoredetails",
+      "label": "getStoreDetails()",
+      "norm_label": "getstoredetails()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L79"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiondepositpatch",
-      "label": "buildRegisterSessionDepositPatch()",
-      "norm_label": "buildregistersessiondepositpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L227"
+      "id": "utils_gettimeremaining",
+      "label": "getTimeRemaining()",
+      "norm_label": "gettimeremaining()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L67"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildregistersessionopeningfloatcorrectionpatch",
-      "label": "buildRegisterSessionOpeningFloatCorrectionPatch()",
-      "norm_label": "buildregistersessionopeningfloatcorrectionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L256"
+      "id": "utils_slugtowords",
+      "label": "slugToWords()",
+      "norm_label": "slugtowords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L31"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiontransactionpatch",
-      "label": "buildRegisterSessionTransactionPatch()",
-      "norm_label": "buildregistersessiontransactionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L147"
+      "id": "utils_snakecasetowords",
+      "label": "snakeCaseToWords()",
+      "norm_label": "snakecasetowords()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L46"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "registersessions_buildreopenedregistersessionpatch",
-      "label": "buildReopenedRegisterSessionPatch()",
-      "norm_label": "buildreopenedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_calculateregistersessioncashdelta",
-      "label": "calculateRegisterSessionCashDelta()",
-      "norm_label": "calculateregistersessioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_correctregistersessionopeningfloatwithctx",
-      "label": "correctRegisterSessionOpeningFloatWithCtx()",
-      "norm_label": "correctregistersessionopeningfloatwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L654"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_findconflictingregistersession",
-      "label": "findConflictingRegisterSession()",
-      "norm_label": "findconflictingregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L323"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_normalizeregistersessionidentity",
-      "label": "normalizeRegisterSessionIdentity()",
-      "norm_label": "normalizeregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_recordregistersessiondepositwithctx",
-      "label": "recordRegisterSessionDepositWithCtx()",
-      "norm_label": "recordregistersessiondepositwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L620"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_registersessionstatusset",
-      "label": "registerSessionStatusSet()",
-      "norm_label": "registersessionstatusset()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "registersessions_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L27"
+      "id": "utils_toslug",
+      "label": "toSlug()",
+      "norm_label": "toslug()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L33"
     },
     {
       "community": 160,
@@ -58485,173 +58638,173 @@
     {
       "community": 17,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
-      "label": "transactionRepository.ts",
-      "norm_label": "transactionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "label": "registerSessions.ts",
+      "norm_label": "registersessions.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_createpostransaction",
-      "label": "createPosTransaction()",
-      "norm_label": "createpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L152"
+      "id": "registersessions_assertregistersessionidentity",
+      "label": "assertRegisterSessionIdentity()",
+      "norm_label": "assertregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L61"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_createpostransactionitem",
-      "label": "createPosTransactionItem()",
-      "norm_label": "createpostransactionitem()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L159"
+      "id": "registersessions_assertregistersessionmatchestransaction",
+      "label": "assertRegisterSessionMatchesTransaction()",
+      "norm_label": "assertregistersessionmatchestransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L71"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getcashierbyid",
-      "label": "getCashierById()",
-      "norm_label": "getcashierbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L51"
+      "id": "registersessions_assertvalidregistersessiontransition",
+      "label": "assertValidRegisterSessionTransition()",
+      "norm_label": "assertvalidregistersessiontransition()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L128"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L58"
+      "id": "registersessions_buildclosedregistersessionpatch",
+      "label": "buildClosedRegisterSessionPatch()",
+      "norm_label": "buildclosedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L297"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getpossessionbyid",
-      "label": "getPosSessionById()",
-      "norm_label": "getpossessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L37"
+      "id": "registersessions_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L93"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getpostransactionbyid",
-      "label": "getPosTransactionById()",
-      "norm_label": "getpostransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L30"
+      "id": "registersessions_buildregistersessioncloseoutpatch",
+      "label": "buildRegisterSessionCloseoutPatch()",
+      "norm_label": "buildregistersessioncloseoutpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L188"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getproductskubyid",
-      "label": "getProductSkuById()",
-      "norm_label": "getproductskubyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L23"
+      "id": "registersessions_buildregistersessiondepositpatch",
+      "label": "buildRegisterSessionDepositPatch()",
+      "norm_label": "buildregistersessiondepositpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L227"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getregistersessionbyid",
-      "label": "getRegisterSessionById()",
-      "norm_label": "getregistersessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L44"
+      "id": "registersessions_buildregistersessionopeningfloatcorrectionpatch",
+      "label": "buildRegisterSessionOpeningFloatCorrectionPatch()",
+      "norm_label": "buildregistersessionopeningfloatcorrectionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L256"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_getstorebyid",
-      "label": "getStoreById()",
-      "norm_label": "getstorebyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L16"
+      "id": "registersessions_buildregistersessiontransactionpatch",
+      "label": "buildRegisterSessionTransactionPatch()",
+      "norm_label": "buildregistersessiontransactionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L147"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactions",
-      "label": "listCompletedTransactions()",
-      "norm_label": "listcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L101"
+      "id": "registersessions_buildreopenedregistersessionpatch",
+      "label": "buildReopenedRegisterSessionPatch()",
+      "norm_label": "buildreopenedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L214"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactionsforday",
-      "label": "listCompletedTransactionsForDay()",
-      "norm_label": "listcompletedtransactionsforday()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L131"
+      "id": "registersessions_calculateregistersessioncashdelta",
+      "label": "calculateRegisterSessionCashDelta()",
+      "norm_label": "calculateregistersessioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L115"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L76"
+      "id": "registersessions_correctregistersessionopeningfloatwithctx",
+      "label": "correctRegisterSessionOpeningFloatWithCtx()",
+      "norm_label": "correctregistersessionopeningfloatwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L654"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionitems",
-      "label": "listTransactionItems()",
-      "norm_label": "listtransactionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L65"
+      "id": "registersessions_findconflictingregistersession",
+      "label": "findConflictingRegisterSession()",
+      "norm_label": "findconflictingregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L323"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionsbystore",
-      "label": "listTransactionsByStore()",
-      "norm_label": "listtransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L87"
+      "id": "registersessions_normalizeregistersessionidentity",
+      "label": "normalizeRegisterSessionIdentity()",
+      "norm_label": "normalizeregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L54"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_patchpossession",
-      "label": "patchPosSession()",
-      "norm_label": "patchpossession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L182"
+      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_patchpostransaction",
-      "label": "patchPosTransaction()",
-      "norm_label": "patchpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L174"
+      "id": "registersessions_recordregistersessiondepositwithctx",
+      "label": "recordRegisterSessionDepositWithCtx()",
+      "norm_label": "recordregistersessiondepositwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L620"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_patchproductsku",
-      "label": "patchProductSku()",
-      "norm_label": "patchproductsku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L166"
+      "id": "registersessions_registersessionstatusset",
+      "label": "registerSessionStatusSet()",
+      "norm_label": "registersessionstatusset()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L11"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "transactionrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L6"
+      "id": "registersessions_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L27"
     },
     {
       "community": 170,
@@ -59106,221 +59259,176 @@
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_ancestorchain",
-      "label": "ancestorChain()",
-      "norm_label": "ancestorchain()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L197"
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
+      "label": "transactionRepository.ts",
+      "norm_label": "transactionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L1"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparses",
-      "label": "collectRawMoneyParses()",
-      "norm_label": "collectrawmoneyparses()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L394"
+      "id": "transactionrepository_createpostransaction",
+      "label": "createPosTransaction()",
+      "norm_label": "createpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L152"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
-      "label": "collectRawMoneyParsesFromSource()",
-      "norm_label": "collectrawmoneyparsesfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L321"
+      "id": "transactionrepository_createpostransactionitem",
+      "label": "createPosTransactionItem()",
+      "norm_label": "createpostransactionitem()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L159"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
-      "label": "collectRawNumericHelperNames()",
-      "norm_label": "collectrawnumerichelpernames()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L295"
+      "id": "transactionrepository_getcashierbyid",
+      "label": "getCashierById()",
+      "norm_label": "getcashierbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L51"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L105"
+      "id": "transactionrepository_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L58"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
-      "label": "containsDisallowedRawNumericParse()",
-      "norm_label": "containsdisallowedrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L260"
+      "id": "transactionrepository_getpossessionbyid",
+      "label": "getPosSessionById()",
+      "norm_label": "getpossessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L37"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsterm",
-      "label": "containsTerm()",
-      "norm_label": "containsterm()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L149"
+      "id": "transactionrepository_getpostransactionbyid",
+      "label": "getPosTransactionById()",
+      "norm_label": "getpostransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L30"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isalloweddisplayconversion",
-      "label": "isAllowedDisplayConversion()",
-      "norm_label": "isalloweddisplayconversion()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L239"
+      "id": "transactionrepository_getproductskubyid",
+      "label": "getProductSkuById()",
+      "norm_label": "getproductskubyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L23"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowednumericrounding",
-      "label": "isAllowedNumericRounding()",
-      "norm_label": "isallowednumericrounding()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L249"
+      "id": "transactionrepository_getregistersessionbyid",
+      "label": "getRegisterSessionById()",
+      "norm_label": "getregistersessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L44"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowedpercentagebranch",
-      "label": "isAllowedPercentageBranch()",
-      "norm_label": "isallowedpercentagebranch()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L225"
+      "id": "transactionrepository_getstorebyid",
+      "label": "getStoreById()",
+      "norm_label": "getstorebyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L16"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_israwnumericparse",
-      "label": "isRawNumericParse()",
-      "norm_label": "israwnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_nearestcontextnode",
-      "label": "nearestContextNode()",
-      "norm_label": "nearestcontextnode()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_nodeline",
-      "label": "nodeLine()",
-      "norm_label": "nodeline()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "moneyentryaudit_test_readwebappfile",
-      "label": "readWebappFile()",
-      "norm_label": "readwebappfile()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "id": "transactionrepository_listcompletedtransactions",
+      "label": "listCompletedTransactions()",
+      "norm_label": "listcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
       "source_location": "L101"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_referencesmoney",
-      "label": "referencesMoney()",
-      "norm_label": "referencesmoney()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L154"
+      "id": "transactionrepository_listcompletedtransactionsforday",
+      "label": "listCompletedTransactionsForDay()",
+      "norm_label": "listcompletedtransactionsforday()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L131"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
-      "label": "referencesOnlyNonMoneyNumericContext()",
-      "norm_label": "referencesonlynonmoneynumericcontext()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L168"
+      "id": "transactionrepository_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L76"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_returnsrawnumericparse",
-      "label": "returnsRawNumericParse()",
-      "norm_label": "returnsrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L275"
+      "id": "transactionrepository_listtransactionitems",
+      "label": "listTransactionItems()",
+      "norm_label": "listtransactionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L65"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "moneyentryaudit_test_reviewedreason",
-      "label": "reviewedReason()",
-      "norm_label": "reviewedreason()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L172"
+      "id": "transactionrepository_listtransactionsbystore",
+      "label": "listTransactionsByStore()",
+      "norm_label": "listtransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L87"
     },
     {
       "community": 18,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
-      "label": "moneyEntryAudit.test.ts",
-      "norm_label": "moneyentryaudit.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L1"
+      "id": "transactionrepository_patchpossession",
+      "label": "patchPosSession()",
+      "norm_label": "patchpossession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "transactionrepository_patchpostransaction",
+      "label": "patchPosTransaction()",
+      "norm_label": "patchpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "transactionrepository_patchproductsku",
+      "label": "patchProductSku()",
+      "norm_label": "patchproductsku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L166"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "transactionrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L6"
     },
     {
       "community": 180,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -59329,7 +59437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -59338,7 +59446,7 @@
       "source_location": "L30"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -59347,7 +59455,7 @@
       "source_location": "L8"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -59356,7 +59464,7 @@
       "source_location": "L49"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -59365,7 +59473,7 @@
       "source_location": "L66"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -59374,7 +59482,7 @@
       "source_location": "L20"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -59383,7 +59491,7 @@
       "source_location": "L50"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -59392,7 +59500,7 @@
       "source_location": "L342"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -59401,7 +59509,7 @@
       "source_location": "L322"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -59410,7 +59518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -59419,7 +59527,7 @@
       "source_location": "L61"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -59428,7 +59536,7 @@
       "source_location": "L57"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -59437,7 +59545,7 @@
       "source_location": "L98"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -59446,7 +59554,7 @@
       "source_location": "L134"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -59455,7 +59563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -59464,7 +59572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -59473,7 +59581,7 @@
       "source_location": "L38"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -59482,7 +59590,7 @@
       "source_location": "L64"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -59491,7 +59599,7 @@
       "source_location": "L135"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -59500,7 +59608,7 @@
       "source_location": "L43"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_getapprovalrequestcopy",
       "label": "getApprovalRequestCopy()",
@@ -59509,7 +59617,7 @@
       "source_location": "L63"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_getdefaultworkflow",
       "label": "getDefaultWorkflow()",
@@ -59518,7 +59626,7 @@
       "source_location": "L54"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_if",
       "label": "if()",
@@ -59527,7 +59635,7 @@
       "source_location": "L579"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueueview_setdecisioningapprovalrequestid",
       "label": "setDecisioningApprovalRequestId()",
@@ -59536,7 +59644,7 @@
       "source_location": "L638"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -59545,7 +59653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -59554,7 +59662,7 @@
       "source_location": "L58"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -59563,7 +59671,7 @@
       "source_location": "L63"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -59572,7 +59680,7 @@
       "source_location": "L50"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -59581,7 +59689,7 @@
       "source_location": "L53"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -59590,7 +59698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -59599,7 +59707,7 @@
       "source_location": "L140"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -59608,7 +59716,7 @@
       "source_location": "L177"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -59617,7 +59725,7 @@
       "source_location": "L195"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -59626,7 +59734,7 @@
       "source_location": "L45"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -59635,7 +59743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -59644,7 +59752,7 @@
       "source_location": "L92"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -59653,7 +59761,7 @@
       "source_location": "L307"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -59662,7 +59770,7 @@
       "source_location": "L70"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -59671,12 +59779,57 @@
       "source_location": "L50"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -59727,164 +59880,173 @@
     {
       "community": 19,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
-      "label": "staffCredentials.ts",
-      "norm_label": "staffcredentials.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "id": "moneyentryaudit_test_ancestorchain",
+      "label": "ancestorChain()",
+      "norm_label": "ancestorchain()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparses",
+      "label": "collectRawMoneyParses()",
+      "norm_label": "collectrawmoneyparses()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
+      "label": "collectRawMoneyParsesFromSource()",
+      "norm_label": "collectrawmoneyparsesfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L321"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
+      "label": "collectRawNumericHelperNames()",
+      "norm_label": "collectrawnumerichelpernames()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
+      "label": "containsDisallowedRawNumericParse()",
+      "norm_label": "containsdisallowedrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsterm",
+      "label": "containsTerm()",
+      "norm_label": "containsterm()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isalloweddisplayconversion",
+      "label": "isAllowedDisplayConversion()",
+      "norm_label": "isalloweddisplayconversion()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowednumericrounding",
+      "label": "isAllowedNumericRounding()",
+      "norm_label": "isallowednumericrounding()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowedpercentagebranch",
+      "label": "isAllowedPercentageBranch()",
+      "norm_label": "isallowedpercentagebranch()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_israwnumericparse",
+      "label": "isRawNumericParse()",
+      "norm_label": "israwnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nearestcontextnode",
+      "label": "nearestContextNode()",
+      "norm_label": "nearestcontextnode()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nodeline",
+      "label": "nodeLine()",
+      "norm_label": "nodeline()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_readwebappfile",
+      "label": "readWebappFile()",
+      "norm_label": "readwebappfile()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesmoney",
+      "label": "referencesMoney()",
+      "norm_label": "referencesmoney()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
+      "label": "referencesOnlyNonMoneyNumericContext()",
+      "norm_label": "referencesonlynonmoneynumericcontext()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_returnsrawnumericparse",
+      "label": "returnsRawNumericParse()",
+      "norm_label": "returnsrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_reviewedreason",
+      "label": "reviewedReason()",
+      "norm_label": "reviewedreason()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
+      "label": "moneyEntryAudit.test.ts",
+      "norm_label": "moneyentryaudit.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_assertstaffprofilereadyforcredential",
-      "label": "assertStaffProfileReadyForCredential()",
-      "norm_label": "assertstaffprofilereadyforcredential()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
-      "label": "authenticateStaffCredentialForApprovalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L566"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
-      "label": "authenticateStaffCredentialForTerminalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L505"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialwithctx",
-      "label": "authenticateStaffCredentialWithCtx()",
-      "norm_label": "authenticatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_createstaffcredentialwithctx",
-      "label": "createStaffCredentialWithCtx()",
-      "norm_label": "createstaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getactiverolesforstaffprofile",
-      "label": "getActiveRolesForStaffProfile()",
-      "norm_label": "getactiverolesforstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyid",
-      "label": "getCredentialById()",
-      "norm_label": "getcredentialbyid()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyusername",
-      "label": "getCredentialByUsername()",
-      "norm_label": "getcredentialbyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
-      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
-      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
-      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
-      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_invalidstaffcredentialsresult",
-      "label": "invalidStaffCredentialsResult()",
-      "norm_label": "invalidstaffcredentialsresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
-      "label": "listStaffCredentialsByStoreWithCtx()",
-      "norm_label": "liststaffcredentialsbystorewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_normalizeusername",
-      "label": "normalizeUsername()",
-      "norm_label": "normalizeusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_requirenonemptyusername",
-      "label": "requireNonEmptyUsername()",
-      "norm_label": "requirenonemptyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_staffauthorizationfailedresult",
-      "label": "staffAuthorizationFailedResult()",
-      "norm_label": "staffauthorizationfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_staffpreconditionfailedresult",
-      "label": "staffPreconditionFailedResult()",
-      "norm_label": "staffpreconditionfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_updatestaffcredentialwithctx",
-      "label": "updateStaffCredentialWithCtx()",
-      "norm_label": "updatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L319"
     },
     {
       "community": 190,
@@ -60636,164 +60798,164 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "customerrepository_createposcustomer",
-      "label": "createPosCustomer()",
-      "norm_label": "createposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_ensurecustomerprofilefromsources",
-      "label": "ensureCustomerProfileFromSources()",
-      "norm_label": "ensurecustomerprofilefromsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findcustomerbyemail",
-      "label": "findCustomerByEmail()",
-      "norm_label": "findcustomerbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findcustomerbyphone",
-      "label": "findCustomerByPhone()",
-      "norm_label": "findcustomerbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findguestbyemail",
-      "label": "findGuestByEmail()",
-      "norm_label": "findguestbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findguestbyphone",
-      "label": "findGuestByPhone()",
-      "norm_label": "findguestbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findposcustomerbyguest",
-      "label": "findPosCustomerByGuest()",
-      "norm_label": "findposcustomerbyguest()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findposcustomerbystorefrontuser",
-      "label": "findPosCustomerByStoreFrontUser()",
-      "norm_label": "findposcustomerbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyemail",
-      "label": "findStoreFrontUserByEmail()",
-      "norm_label": "findstorefrontuserbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyphone",
-      "label": "findStoreFrontUserByPhone()",
-      "norm_label": "findstorefrontuserbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_getguestbyid",
-      "label": "getGuestById()",
-      "norm_label": "getguestbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_getposcustomerbyid",
-      "label": "getPosCustomerById()",
-      "norm_label": "getposcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_getstorefrontuserbyid",
-      "label": "getStoreFrontUserById()",
-      "norm_label": "getstorefrontuserbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_listactivecustomersforstore",
-      "label": "listActiveCustomersForStore()",
-      "norm_label": "listactivecustomersforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_listcompletedtransactionsforcustomer",
-      "label": "listCompletedTransactionsForCustomer()",
-      "norm_label": "listcompletedtransactionsforcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_patchposcustomer",
-      "label": "patchPosCustomer()",
-      "norm_label": "patchposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "customerrepository_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
-      "label": "customerRepository.ts",
-      "norm_label": "customerrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
+      "label": "staffCredentials.ts",
+      "norm_label": "staffcredentials.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_assertstaffprofilereadyforcredential",
+      "label": "assertStaffProfileReadyForCredential()",
+      "norm_label": "assertstaffprofilereadyforcredential()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
+      "label": "authenticateStaffCredentialForApprovalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L566"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
+      "label": "authenticateStaffCredentialForTerminalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L505"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialwithctx",
+      "label": "authenticateStaffCredentialWithCtx()",
+      "norm_label": "authenticatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L415"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_createstaffcredentialwithctx",
+      "label": "createStaffCredentialWithCtx()",
+      "norm_label": "createstaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getactiverolesforstaffprofile",
+      "label": "getActiveRolesForStaffProfile()",
+      "norm_label": "getactiverolesforstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyid",
+      "label": "getCredentialById()",
+      "norm_label": "getcredentialbyid()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyusername",
+      "label": "getCredentialByUsername()",
+      "norm_label": "getcredentialbyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
+      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
+      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
+      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
+      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_invalidstaffcredentialsresult",
+      "label": "invalidStaffCredentialsResult()",
+      "norm_label": "invalidstaffcredentialsresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
+      "label": "listStaffCredentialsByStoreWithCtx()",
+      "norm_label": "liststaffcredentialsbystorewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_normalizeusername",
+      "label": "normalizeUsername()",
+      "norm_label": "normalizeusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_requirenonemptyusername",
+      "label": "requireNonEmptyUsername()",
+      "norm_label": "requirenonemptyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_staffauthorizationfailedresult",
+      "label": "staffAuthorizationFailedResult()",
+      "norm_label": "staffauthorizationfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_staffpreconditionfailedresult",
+      "label": "staffPreconditionFailedResult()",
+      "norm_label": "staffpreconditionfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_updatestaffcredentialwithctx",
+      "label": "updateStaffCredentialWithCtx()",
+      "norm_label": "updatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L319"
     },
     {
       "community": 200,
@@ -61248,163 +61410,163 @@
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_calculatepromocodevalue",
-      "label": "calculatePromoCodeValue()",
-      "norm_label": "calculatepromocodevalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447"
+      "id": "customerrepository_createposcustomer",
+      "label": "createPosCustomer()",
+      "norm_label": "createposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L57"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_checkadjustedavailability",
-      "label": "checkAdjustedAvailability()",
-      "norm_label": "checkadjustedavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990"
+      "id": "customerrepository_ensurecustomerprofilefromsources",
+      "label": "ensureCustomerProfileFromSources()",
+      "norm_label": "ensurecustomerprofilefromsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L240"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_checkifitemshavechanged",
-      "label": "checkIfItemsHaveChanged()",
-      "norm_label": "checkifitemshavechanged()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L50"
+      "id": "customerrepository_findcustomerbyemail",
+      "label": "findCustomerByEmail()",
+      "norm_label": "findcustomerbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L27"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_createonlineorder",
-      "label": "createOnlineOrder()",
-      "norm_label": "createonlineorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765"
+      "id": "customerrepository_findcustomerbyphone",
+      "label": "findCustomerByPhone()",
+      "norm_label": "findcustomerbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L42"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_createpatchobject",
-      "label": "createPatchObject()",
-      "norm_label": "createpatchobject()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651"
+      "id": "customerrepository_findguestbyemail",
+      "label": "findGuestByEmail()",
+      "norm_label": "findguestbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L186"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_createsessionitems",
-      "label": "createSessionItems()",
-      "norm_label": "createsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102"
+      "id": "customerrepository_findguestbyphone",
+      "label": "findGuestByPhone()",
+      "norm_label": "findguestbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L222"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_fetchproductskus",
-      "label": "fetchProductSkus()",
-      "norm_label": "fetchproductskus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979"
+      "id": "customerrepository_findposcustomerbyguest",
+      "label": "findPosCustomerByGuest()",
+      "norm_label": "findposcustomerbyguest()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L154"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_findbestvaluepromocode",
-      "label": "findBestValuePromoCode()",
-      "norm_label": "findbestvaluepromocode()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495"
+      "id": "customerrepository_findposcustomerbystorefrontuser",
+      "label": "findPosCustomerByStoreFrontUser()",
+      "norm_label": "findposcustomerbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L142"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_handleexistingsession",
-      "label": "handleExistingSession()",
-      "norm_label": "handleexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161"
+      "id": "customerrepository_findstorefrontuserbyemail",
+      "label": "findStoreFrontUserByEmail()",
+      "norm_label": "findstorefrontuserbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L168"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_handleordercreation",
-      "label": "handleOrderCreation()",
-      "norm_label": "handleordercreation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734"
+      "id": "customerrepository_findstorefrontuserbyphone",
+      "label": "findStoreFrontUserByPhone()",
+      "norm_label": "findstorefrontuserbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L204"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_handleplaceorder",
-      "label": "handlePlaceOrder()",
-      "norm_label": "handleplaceorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698"
+      "id": "customerrepository_getguestbyid",
+      "label": "getGuestById()",
+      "norm_label": "getguestbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L135"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L40"
+      "id": "customerrepository_getposcustomerbyid",
+      "label": "getPosCustomerById()",
+      "norm_label": "getposcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L20"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_retrieveactivecheckoutsession",
-      "label": "retrieveActiveCheckoutSession()",
-      "norm_label": "retrieveactivecheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951"
+      "id": "customerrepository_getstorefrontuserbyid",
+      "label": "getStoreFrontUserById()",
+      "norm_label": "getstorefrontuserbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L128"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_updateavailability",
-      "label": "updateAvailability()",
-      "norm_label": "updateavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140"
+      "id": "customerrepository_listactivecustomersforstore",
+      "label": "listActiveCustomersForStore()",
+      "norm_label": "listactivecustomersforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L8"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_updateexistingsession",
-      "label": "updateExistingSession()",
-      "norm_label": "updateexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020"
+      "id": "customerrepository_listcompletedtransactionsforcustomer",
+      "label": "listCompletedTransactionsForCustomer()",
+      "norm_label": "listcompletedtransactionsforcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L94"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_updateproductavailability",
-      "label": "updateProductAvailability()",
-      "norm_label": "updateproductavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123"
+      "id": "customerrepository_patchposcustomer",
+      "label": "patchPosCustomer()",
+      "norm_label": "patchposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L64"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "checkoutsession_validateexistingdiscount",
-      "label": "validateExistingDiscount()",
-      "norm_label": "validateexistingdiscount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321"
+      "id": "customerrepository_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L72"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
+      "label": "customerRepository.ts",
+      "norm_label": "customerrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
       "source_location": "L1"
     },
     {
@@ -61842,164 +62004,164 @@
     {
       "community": 22,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "id": "checkoutsession_calculatepromocodevalue",
+      "label": "calculatePromoCodeValue()",
+      "norm_label": "calculatepromocodevalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1447"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_checkadjustedavailability",
+      "label": "checkAdjustedAvailability()",
+      "norm_label": "checkadjustedavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L990"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_checkifitemshavechanged",
+      "label": "checkIfItemsHaveChanged()",
+      "norm_label": "checkifitemshavechanged()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_createonlineorder",
+      "label": "createOnlineOrder()",
+      "norm_label": "createonlineorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_createpatchobject",
+      "label": "createPatchObject()",
+      "norm_label": "createpatchobject()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L651"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_createsessionitems",
+      "label": "createSessionItems()",
+      "norm_label": "createsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1102"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_fetchproductskus",
+      "label": "fetchProductSkus()",
+      "norm_label": "fetchproductskus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L979"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_findbestvaluepromocode",
+      "label": "findBestValuePromoCode()",
+      "norm_label": "findbestvaluepromocode()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1495"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_handleexistingsession",
+      "label": "handleExistingSession()",
+      "norm_label": "handleexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1161"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_handleordercreation",
+      "label": "handleOrderCreation()",
+      "norm_label": "handleordercreation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L734"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_handleplaceorder",
+      "label": "handlePlaceOrder()",
+      "norm_label": "handleplaceorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L698"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_retrieveactivecheckoutsession",
+      "label": "retrieveActiveCheckoutSession()",
+      "norm_label": "retrieveactivecheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L951"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_updateavailability",
+      "label": "updateAvailability()",
+      "norm_label": "updateavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1140"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_updateexistingsession",
+      "label": "updateExistingSession()",
+      "norm_label": "updateexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1020"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_updateproductavailability",
+      "label": "updateProductAvailability()",
+      "norm_label": "updateproductavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1123"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_validateexistingdiscount",
+      "label": "validateExistingDiscount()",
+      "norm_label": "validateexistingdiscount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1321"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L212"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopekey",
-      "label": "getCountScopeKey()",
-      "norm_label": "getcountscopekey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L200"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L204"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L247"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getskudetailentries",
-      "label": "getSkuDetailEntries()",
-      "norm_label": "getskudetailentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L251"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L958"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
-      "label": "normalizeStockAdjustmentSearch()",
-      "norm_label": "normalizestockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L268"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_parsecountscopekeys",
-      "label": "parseCountScopeKeys()",
-      "norm_label": "parsecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L272"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L239"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L309"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "label": "rowMatchesStockAdjustmentSearch()",
-      "norm_label": "rowmatchesstockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L285"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_serializecountscopekeys",
-      "label": "serializeCountScopeKeys()",
-      "norm_label": "serializecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L281"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L948"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L234"
     },
     {
       "community": 220,
@@ -62364,164 +62526,164 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L212"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L208"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopekey",
+      "label": "getCountScopeKey()",
+      "norm_label": "getcountscopekey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L200"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L204"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L247"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L251"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L958"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "label": "normalizeStockAdjustmentSearch()",
+      "norm_label": "normalizestockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L268"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_parsecountscopekeys",
+      "label": "parseCountScopeKeys()",
+      "norm_label": "parsecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L272"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L239"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L309"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
+      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "label": "rowMatchesStockAdjustmentSearch()",
+      "norm_label": "rowmatchesstockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L285"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
+      "id": "stockadjustmentworkspace_serializecountscopekeys",
+      "label": "serializeCountScopeKeys()",
+      "norm_label": "serializecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L281"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L948"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L1"
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L234"
     },
     {
       "community": 230,
@@ -62886,154 +63048,163 @@
     {
       "community": 24,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
     },
     {
@@ -63399,154 +63570,154 @@
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -63912,154 +64083,154 @@
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1"
     },
     {
@@ -64425,145 +64596,154 @@
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_buildcashcontrolsdashboardsnapshot",
-      "label": "buildCashControlsDashboardSnapshot()",
-      "norm_label": "buildcashcontrolsdashboardsnapshot()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L226"
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_buildregistersessiondeposittargetid",
-      "label": "buildRegisterSessionDepositTargetId()",
-      "norm_label": "buildregistersessiondeposittargetid()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L186"
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_buildregistersessionsummary",
-      "label": "buildRegisterSessionSummary()",
-      "norm_label": "buildregistersessionsummary()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L193"
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_collectstaffprofileids",
-      "label": "collectStaffProfileIds()",
-      "norm_label": "collectstaffprofileids()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L372"
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_iscashcontroldepositallocation",
-      "label": "isCashControlDepositAllocation()",
-      "norm_label": "iscashcontroldepositallocation()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L142"
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_listregistersessionsfordashboard",
-      "label": "listRegisterSessionsForDashboard()",
-      "norm_label": "listregistersessionsfordashboard()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L290"
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_listregistersessiontimeline",
-      "label": "listRegisterSessionTimeline()",
-      "norm_label": "listregistersessiontimeline()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L346"
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_listregistersessiontransactions",
-      "label": "listRegisterSessionTransactions()",
-      "norm_label": "listregistersessiontransactions()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L359"
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_listsessiondeposits",
-      "label": "listSessionDeposits()",
-      "norm_label": "listsessiondeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L332"
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L152"
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_liststoredeposits",
-      "label": "listStoreDeposits()",
-      "norm_label": "liststoredeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L318"
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_listterminalnames",
-      "label": "listTerminalNames()",
-      "norm_label": "listterminalnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L301"
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L120"
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_sumdepositsbysession",
-      "label": "sumDepositsBySession()",
-      "norm_label": "sumdepositsbysession()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L169"
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "deposits_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L115"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
-      "label": "deposits.ts",
-      "norm_label": "deposits.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1"
     },
     {
@@ -64929,146 +65109,146 @@
     {
       "community": 28,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "id": "deposits_buildcashcontrolsdashboardsnapshot",
+      "label": "buildCashControlsDashboardSnapshot()",
+      "norm_label": "buildcashcontrolsdashboardsnapshot()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_buildregistersessiondeposittargetid",
+      "label": "buildRegisterSessionDepositTargetId()",
+      "norm_label": "buildregistersessiondeposittargetid()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_buildregistersessionsummary",
+      "label": "buildRegisterSessionSummary()",
+      "norm_label": "buildregistersessionsummary()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_collectstaffprofileids",
+      "label": "collectStaffProfileIds()",
+      "norm_label": "collectstaffprofileids()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_iscashcontroldepositallocation",
+      "label": "isCashControlDepositAllocation()",
+      "norm_label": "iscashcontroldepositallocation()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_listregistersessionsfordashboard",
+      "label": "listRegisterSessionsForDashboard()",
+      "norm_label": "listregistersessionsfordashboard()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_listregistersessiontimeline",
+      "label": "listRegisterSessionTimeline()",
+      "norm_label": "listregistersessiontimeline()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_listregistersessiontransactions",
+      "label": "listRegisterSessionTransactions()",
+      "norm_label": "listregistersessiontransactions()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L359"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_listsessiondeposits",
+      "label": "listSessionDeposits()",
+      "norm_label": "listsessiondeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L332"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_liststoredeposits",
+      "label": "listStoreDeposits()",
+      "norm_label": "liststoredeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_listterminalnames",
+      "label": "listTerminalNames()",
+      "norm_label": "listterminalnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L301"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_sumdepositsbysession",
+      "label": "sumDepositsBySession()",
+      "norm_label": "sumdepositsbysession()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "deposits_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
+      "label": "deposits.ts",
+      "norm_label": "deposits.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_expirepossessionnow",
-      "label": "expirePosSessionNow()",
-      "norm_label": "expirepossessionnow()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L368"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_loadsessioncustomer",
-      "label": "loadSessionCustomer()",
-      "norm_label": "loadsessioncustomer()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L353"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_usererrorfromsessioncommandfailure",
-      "label": "userErrorFromSessionCommandFailure()",
-      "norm_label": "usererrorfromsessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_usererrorfromvalidationmessage",
-      "label": "userErrorFromValidationMessage()",
-      "norm_label": "usererrorfromvalidationmessage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "possessions_validatesessiondrawerbinding",
-      "label": "validateSessionDrawerBinding()",
-      "norm_label": "validatesessiondrawerbinding()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L131"
     },
     {
       "community": 280,
@@ -65433,146 +65613,146 @@
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L252"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_getstockadjustmentscopekey",
-      "label": "getStockAdjustmentScopeKey()",
-      "norm_label": "getstockadjustmentscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
-      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
-      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L735"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L788"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L538"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
-      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
-      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L457"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_expirepossessionnow",
+      "label": "expirePosSessionNow()",
+      "norm_label": "expirepossessionnow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L368"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_loadsessioncustomer",
+      "label": "loadSessionCustomer()",
+      "norm_label": "loadsessioncustomer()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L353"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L379"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "possessions_validatesessiondrawerbinding",
+      "label": "validateSessionDrawerBinding()",
+      "norm_label": "validatesessiondrawerbinding()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L131"
     },
     {
       "community": 290,
@@ -66189,145 +66369,145 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L204"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L95"
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L128"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L85"
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L158"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L262"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L101"
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L252"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L144"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L174"
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L148"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L381"
+      "id": "adjustments_getstockadjustmentscopekey",
+      "label": "getStockAdjustmentScopeKey()",
+      "norm_label": "getstockadjustmentscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L71"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L288"
+      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
+      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
+      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L75"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L240"
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L735"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L347"
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L268"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L409"
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L788"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L201"
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L538"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L109"
+      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
+      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
+      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L457"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L147"
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L66"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L1"
     },
     {
@@ -66603,145 +66783,145 @@
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror",
-      "label": "CheckoutSessionError",
-      "norm_label": "checkoutsessionerror",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L64"
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L69"
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L95"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_createcheckoutsession",
-      "label": "createCheckoutSession()",
-      "norm_label": "createcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L184"
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L85"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_defaultcheckoutactionmessage",
-      "label": "defaultCheckoutActionMessage()",
-      "norm_label": "defaultcheckoutactionmessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L135"
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_getactivecheckoutsession",
-      "label": "getActiveCheckoutSession()",
-      "norm_label": "getactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L204"
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L5"
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_getcheckoutactionerrormessage",
-      "label": "getCheckoutActionErrorMessage()",
-      "norm_label": "getcheckoutactionerrormessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
       "source_location": "L147"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "label": "getCheckoutErrorMessageFromPayload()",
-      "norm_label": "getcheckouterrormessagefrompayload()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutsession",
-      "label": "getCheckoutSession()",
-      "norm_label": "getcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_getpendingcheckoutsessions",
-      "label": "getPendingCheckoutSessions()",
-      "norm_label": "getpendingcheckoutsessions()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_parsecheckoutresponse",
-      "label": "parseCheckoutResponse()",
-      "norm_label": "parsecheckoutresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_parsejson",
-      "label": "parseJson()",
-      "norm_label": "parsejson()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_updatecheckoutsession",
-      "label": "updateCheckoutSession()",
-      "norm_label": "updatecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "checkoutsession_verifycheckoutsessionpayment",
-      "label": "verifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L274"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
       "source_location": "L1"
     },
     {
@@ -67017,145 +67197,145 @@
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_addgroupederror",
-      "label": "addGroupedError()",
-      "norm_label": "addgroupederror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L102"
+      "id": "checkoutsession_checkoutsessionerror",
+      "label": "CheckoutSessionError",
+      "norm_label": "checkoutsessionerror",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L64"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_collectlivesurfaceentries",
-      "label": "collectLiveSurfaceEntries()",
-      "norm_label": "collectlivesurfaceentries()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L145"
+      "id": "checkoutsession_checkoutsessionerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L69"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L57"
+      "id": "checkoutsession_createcheckoutsession",
+      "label": "createCheckoutSession()",
+      "norm_label": "createcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L184"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_formatgroupederrors",
-      "label": "formatGroupedErrors()",
-      "norm_label": "formatgroupederrors()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L351"
+      "id": "checkoutsession_defaultcheckoutactionmessage",
+      "label": "defaultCheckoutActionMessage()",
+      "norm_label": "defaultcheckoutactionmessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L135"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_formatmissingvalidationpatherror",
-      "label": "formatMissingValidationPathError()",
-      "norm_label": "formatmissingvalidationpatherror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L116"
+      "id": "checkoutsession_getactivecheckoutsession",
+      "label": "getActiveCheckoutSession()",
+      "norm_label": "getactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L204"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66"
+      "id": "checkoutsession_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L5"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_infergroupfromerror",
-      "label": "inferGroupFromError()",
-      "norm_label": "infergroupfromerror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L126"
+      "id": "checkoutsession_getcheckoutactionerrormessage",
+      "label": "getCheckoutActionErrorMessage()",
+      "norm_label": "getcheckoutactionerrormessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L147"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_loadaudittarget",
-      "label": "loadAuditTarget()",
-      "norm_label": "loadaudittarget()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "harness_audit_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "checkoutsession_getcheckouterrormessagefrompayload",
+      "label": "getCheckoutErrorMessageFromPayload()",
+      "norm_label": "getcheckouterrormessagefrompayload()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L39"
+      "id": "checkoutsession_getcheckoutsession",
+      "label": "getCheckoutSession()",
+      "norm_label": "getcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L226"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L90"
+      "id": "checkoutsession_getpendingcheckoutsessions",
+      "label": "getPendingCheckoutSessions()",
+      "norm_label": "getpendingcheckoutsessions()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L215"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L86"
+      "id": "checkoutsession_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L78"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_runharnessaudit",
-      "label": "runHarnessAudit()",
-      "norm_label": "runharnessaudit()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L366"
+      "id": "checkoutsession_parsecheckoutresponse",
+      "label": "parseCheckoutResponse()",
+      "norm_label": "parsecheckoutresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L115"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "harness_audit_shouldskipsurfaceentry",
-      "label": "shouldSkipSurfaceEntry()",
-      "norm_label": "shouldskipsurfaceentry()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L131"
+      "id": "checkoutsession_parsejson",
+      "label": "parseJson()",
+      "norm_label": "parsejson()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L81"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "scripts_harness_audit_ts",
-      "label": "harness-audit.ts",
-      "norm_label": "harness-audit.ts",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "checkoutsession_updatecheckoutsession",
+      "label": "updateCheckoutSession()",
+      "norm_label": "updatecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "checkoutsession_verifycheckoutsessionpayment",
+      "label": "verifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -67431,137 +67611,146 @@
     {
       "community": 33,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L1"
+      "id": "harness_audit_addgroupederror",
+      "label": "addGroupedError()",
+      "norm_label": "addgroupederror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L102"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_clearpaymentediting",
-      "label": "clearPaymentEditing()",
-      "norm_label": "clearpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L155"
+      "id": "harness_audit_collectlivesurfaceentries",
+      "label": "collectLiveSurfaceEntries()",
+      "norm_label": "collectlivesurfaceentries()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L145"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L399"
+      "id": "harness_audit_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L57"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L48"
+      "id": "harness_audit_formatgroupederrors",
+      "label": "formatGroupedErrors()",
+      "norm_label": "formatgroupederrors()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L351"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L59"
+      "id": "harness_audit_formatmissingvalidationpatherror",
+      "label": "formatMissingValidationPathError()",
+      "norm_label": "formatmissingvalidationpatherror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L116"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L196"
+      "id": "harness_audit_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleclearpayments",
-      "label": "handleClearPayments()",
-      "norm_label": "handleclearpayments()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L214"
+      "id": "harness_audit_infergroupfromerror",
+      "label": "inferGroupFromError()",
+      "norm_label": "infergroupfromerror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L126"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L219"
+      "id": "harness_audit_loadaudittarget",
+      "label": "loadAuditTarget()",
+      "norm_label": "loadaudittarget()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L174"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L161"
+      "id": "harness_audit_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L43"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L148"
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L98"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L330"
+      "id": "harness_audit_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L39"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_paidtotalbadge",
-      "label": "PaidTotalBadge()",
-      "norm_label": "paidtotalbadge()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L70"
+      "id": "harness_audit_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L90"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
-      "label": "resetPaymentCollectionControls()",
-      "norm_label": "resetpaymentcollectioncontrols()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L209"
+      "id": "harness_audit_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L86"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentediting",
-      "label": "setPaymentEditing()",
-      "norm_label": "setpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L139"
+      "id": "harness_audit_runharnessaudit",
+      "label": "runHarnessAudit()",
+      "norm_label": "runharnessaudit()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L366"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentsexpanded",
-      "label": "setPaymentsExpanded()",
-      "norm_label": "setpaymentsexpanded()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "label": "shouldSkipSurfaceEntry()",
+      "norm_label": "shouldskipsurfaceentry()",
+      "source_file": "scripts/harness-audit.ts",
       "source_location": "L131"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "scripts_harness_audit_ts",
+      "label": "harness-audit.ts",
+      "norm_label": "harness-audit.ts",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L1"
     },
     {
       "community": 330,
@@ -67836,137 +68025,137 @@
     {
       "community": 34,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_authenticatecorrectionstaff",
-      "label": "authenticateCorrectionStaff()",
-      "norm_label": "authenticatecorrectionstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L383"
+      "id": "paymentsaddedlist_clearpaymentediting",
+      "label": "clearPaymentEditing()",
+      "norm_label": "clearpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L155"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_exitcorrectionworkflow",
-      "label": "exitCorrectionWorkflow()",
-      "norm_label": "exitcorrectionworkflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L407"
+      "id": "paymentsaddedlist_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L399"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_formatcorrectioneventtype",
-      "label": "formatCorrectionEventType()",
-      "norm_label": "formatcorrectioneventtype()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L85"
+      "id": "paymentsaddedlist_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L48"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorychange",
-      "label": "formatCorrectionHistoryChange()",
-      "norm_label": "formatcorrectionhistorychange()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L136"
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L59"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorymeta",
-      "label": "formatCorrectionHistoryMeta()",
-      "norm_label": "formatcorrectionhistorymeta()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L103"
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L196"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorytitle",
-      "label": "formatCorrectionHistoryTitle()",
-      "norm_label": "formatcorrectionhistorytitle()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L91"
+      "id": "paymentsaddedlist_handleclearpayments",
+      "label": "handleClearPayments()",
+      "norm_label": "handleclearpayments()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L214"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L112"
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L219"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_getcorrectionhistorychangeparts",
-      "label": "getCorrectionHistoryChangeParts()",
-      "norm_label": "getcorrectionhistorychangeparts()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L157"
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L161"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_gettransactioncorrectionhistory",
-      "label": "getTransactionCorrectionHistory()",
-      "norm_label": "gettransactioncorrectionhistory()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L177"
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L148"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_ismanagerstaff",
-      "label": "isManagerStaff()",
-      "norm_label": "ismanagerstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L132"
+      "id": "paymentsaddedlist_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L330"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_requestcorrectionsubmit",
-      "label": "requestCorrectionSubmit()",
-      "norm_label": "requestcorrectionsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L537"
+      "id": "paymentsaddedlist_paidtotalbadge",
+      "label": "PaidTotalBadge()",
+      "norm_label": "paidtotalbadge()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L70"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_requiresinlinemanagerproof",
-      "label": "requiresInlineManagerProof()",
-      "norm_label": "requiresinlinemanagerproof()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L122"
+      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
+      "label": "resetPaymentCollectionControls()",
+      "norm_label": "resetpaymentcollectioncontrols()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L209"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_runcustomercorrection",
-      "label": "runCustomerCorrection()",
-      "norm_label": "runcustomercorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L414"
+      "id": "paymentsaddedlist_setpaymentediting",
+      "label": "setPaymentEditing()",
+      "norm_label": "setpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L139"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "transactionview_runpaymentmethodcorrection",
-      "label": "runPaymentMethodCorrection()",
-      "norm_label": "runpaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L452"
+      "id": "paymentsaddedlist_setpaymentsexpanded",
+      "label": "setPaymentsExpanded()",
+      "norm_label": "setpaymentsexpanded()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L131"
     },
     {
       "community": 340,
@@ -68241,137 +68430,137 @@
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_attachredislogging",
-      "label": "attachRedisLogging()",
-      "norm_label": "attachredislogging()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L53"
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_createapp",
-      "label": "createApp()",
-      "norm_label": "createapp()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L321"
+      "id": "transactionview_authenticatecorrectionstaff",
+      "label": "authenticateCorrectionStaff()",
+      "norm_label": "authenticatecorrectionstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L383"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_createhandlers",
-      "label": "createHandlers()",
-      "norm_label": "createhandlers()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L213"
+      "id": "transactionview_exitcorrectionworkflow",
+      "label": "exitCorrectionWorkflow()",
+      "norm_label": "exitcorrectionworkflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L407"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_createredisclient",
-      "label": "createRedisClient()",
-      "norm_label": "createredisclient()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L41"
+      "id": "transactionview_formatcorrectioneventtype",
+      "label": "formatCorrectionEventType()",
+      "norm_label": "formatcorrectioneventtype()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L85"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_createrediscluster",
-      "label": "createRedisCluster()",
-      "norm_label": "createrediscluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L32"
+      "id": "transactionview_formatcorrectionhistorychange",
+      "label": "formatCorrectionHistoryChange()",
+      "norm_label": "formatcorrectionhistorychange()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L136"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_deletekeysindividually",
-      "label": "deleteKeysIndividually()",
-      "norm_label": "deletekeysindividually()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L96"
+      "id": "transactionview_formatcorrectionhistorymeta",
+      "label": "formatCorrectionHistoryMeta()",
+      "norm_label": "formatcorrectionhistorymeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L103"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_invalidateacrosscluster",
-      "label": "invalidateAcrossCluster()",
-      "norm_label": "invalidateacrosscluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
+      "id": "transactionview_formatcorrectionhistorytitle",
+      "label": "formatCorrectionHistoryTitle()",
+      "norm_label": "formatcorrectionhistorytitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "transactionview_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L112"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_invalidateacrossclusterwithpipeline",
-      "label": "invalidateAcrossClusterWithPipeline()",
-      "norm_label": "invalidateacrossclusterwithpipeline()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L135"
+      "id": "transactionview_getcorrectionhistorychangeparts",
+      "label": "getCorrectionHistoryChangeParts()",
+      "norm_label": "getcorrectionhistorychangeparts()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L157"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_runconnectionprobe",
-      "label": "runConnectionProbe()",
-      "norm_label": "runconnectionprobe()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L176"
+      "id": "transactionview_gettransactioncorrectionhistory",
+      "label": "getTransactionCorrectionHistory()",
+      "norm_label": "gettransactioncorrectionhistory()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_scannodeforpattern",
-      "label": "scanNodeForPattern()",
-      "norm_label": "scannodeforpattern()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L72"
+      "id": "transactionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L132"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_serializeredisvalue",
-      "label": "serializeRedisValue()",
-      "norm_label": "serializeredisvalue()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L68"
+      "id": "transactionview_requestcorrectionsubmit",
+      "label": "requestCorrectionSubmit()",
+      "norm_label": "requestcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L537"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_shouldusecluster",
-      "label": "shouldUseCluster()",
-      "norm_label": "shouldusecluster()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L26"
+      "id": "transactionview_requiresinlinemanagerproof",
+      "label": "requiresInlineManagerProof()",
+      "norm_label": "requiresinlinemanagerproof()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L122"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_startserver",
-      "label": "startServer()",
-      "norm_label": "startserver()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L340"
+      "id": "transactionview_runcustomercorrection",
+      "label": "runCustomerCorrection()",
+      "norm_label": "runcustomercorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L414"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "app_valkeyendpointfromenv",
-      "label": "valkeyEndpointFromEnv()",
-      "norm_label": "valkeyendpointfromenv()",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L19"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_js",
-      "label": "app.js",
-      "norm_label": "app.js",
-      "source_file": "packages/valkey-proxy-server/app.js",
-      "source_location": "L1"
+      "id": "transactionview_runpaymentmethodcorrection",
+      "label": "runPaymentMethodCorrection()",
+      "norm_label": "runpaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L452"
     },
     {
       "community": 350,
@@ -68646,127 +68835,136 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L254"
+      "id": "app_attachredislogging",
+      "label": "attachRedisLogging()",
+      "norm_label": "attachredislogging()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L53"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L258"
+      "id": "app_createapp",
+      "label": "createApp()",
+      "norm_label": "createapp()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L321"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L246"
+      "id": "app_createhandlers",
+      "label": "createHandlers()",
+      "norm_label": "createhandlers()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L213"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
-      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
-      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L142"
+      "id": "app_createredisclient",
+      "label": "createRedisClient()",
+      "norm_label": "createredisclient()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L41"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_buildregistersessioncloseoutreview",
-      "label": "buildRegisterSessionCloseoutReview()",
-      "norm_label": "buildregistersessioncloseoutreview()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L308"
+      "id": "app_createrediscluster",
+      "label": "createRedisCluster()",
+      "norm_label": "createrediscluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L32"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
-      "label": "buildRegisterSessionVarianceApprovalRequirement()",
-      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L362"
+      "id": "app_deletekeysindividually",
+      "label": "deleteKeysIndividually()",
+      "norm_label": "deletekeysindividually()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L96"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_cancelpendingapprovalifneeded",
-      "label": "cancelPendingApprovalIfNeeded()",
-      "norm_label": "cancelpendingapprovalifneeded()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L495"
+      "id": "app_invalidateacrosscluster",
+      "label": "invalidateAcrossCluster()",
+      "norm_label": "invalidateacrosscluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L112"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_getcashcontrolsconfig",
-      "label": "getCashControlsConfig()",
-      "norm_label": "getcashcontrolsconfig()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L289"
+      "id": "app_invalidateacrossclusterwithpipeline",
+      "label": "invalidateAcrossClusterWithPipeline()",
+      "norm_label": "invalidateacrossclusterwithpipeline()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L135"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_listregistersessionsforcloseout",
-      "label": "listRegisterSessionsForCloseout()",
-      "norm_label": "listregistersessionsforcloseout()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L413"
+      "id": "app_runconnectionprobe",
+      "label": "runConnectionProbe()",
+      "norm_label": "runconnectionprobe()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L176"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L443"
+      "id": "app_scannodeforpattern",
+      "label": "scanNodeForPattern()",
+      "norm_label": "scannodeforpattern()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L72"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L267"
+      "id": "app_serializeredisvalue",
+      "label": "serializeRedisValue()",
+      "norm_label": "serializeredisvalue()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L68"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
-      "label": "staffProfileCanReviewCloseoutVariance()",
-      "norm_label": "staffprofilecanreviewcloseoutvariance()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L460"
+      "id": "app_shouldusecluster",
+      "label": "shouldUseCluster()",
+      "norm_label": "shouldusecluster()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L26"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "closeouts_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L262"
+      "id": "app_startserver",
+      "label": "startServer()",
+      "norm_label": "startserver()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L340"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
-      "label": "closeouts.ts",
-      "norm_label": "closeouts.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "id": "app_valkeyendpointfromenv",
+      "label": "valkeyEndpointFromEnv()",
+      "norm_label": "valkeyendpointfromenv()",
+      "source_file": "packages/valkey-proxy-server/app.js",
+      "source_location": "L19"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_app_js",
+      "label": "app.js",
+      "norm_label": "app.js",
+      "source_file": "packages/valkey-proxy-server/app.js",
       "source_location": "L1"
     },
     {
@@ -69042,128 +69240,128 @@
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "closeouts_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
+      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
+      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_buildregistersessioncloseoutreview",
+      "label": "buildRegisterSessionCloseoutReview()",
+      "norm_label": "buildregistersessioncloseoutreview()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
+      "label": "buildRegisterSessionVarianceApprovalRequirement()",
+      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L362"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_cancelpendingapprovalifneeded",
+      "label": "cancelPendingApprovalIfNeeded()",
+      "norm_label": "cancelpendingapprovalifneeded()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L495"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_getcashcontrolsconfig",
+      "label": "getCashControlsConfig()",
+      "norm_label": "getcashcontrolsconfig()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_listregistersessionsforcloseout",
+      "label": "listRegisterSessionsForCloseout()",
+      "norm_label": "listregistersessionsforcloseout()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L413"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L443"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
+      "label": "staffProfileCanReviewCloseoutVariance()",
+      "norm_label": "staffprofilecanreviewcloseoutvariance()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L460"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "closeouts_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
+      "label": "closeouts.ts",
+      "norm_label": "closeouts.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L292"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L367"
     },
     {
       "community": 370,
@@ -69438,128 +69636,128 @@
     {
       "community": 38,
       "file_type": "code",
-      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
-      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
-      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_applypaymentmethodcorrection",
-      "label": "applyPaymentMethodCorrection()",
-      "norm_label": "applypaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
-      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
-      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
-      "label": "consumePaymentMethodCorrectionApprovalProof()",
-      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_correcttransactioncustomer",
-      "label": "correctTransactionCustomer()",
-      "norm_label": "correcttransactioncustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_correcttransactionpaymentmethod",
-      "label": "correctTransactionPaymentMethod()",
-      "norm_label": "correcttransactionpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
-      "label": "createPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_getpaymentmethodcashcontribution",
-      "label": "getPaymentMethodCashContribution()",
-      "norm_label": "getpaymentmethodcashcontribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L539"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
-      "label": "requireRegisterSessionAllowsPaymentCorrection()",
-      "norm_label": "requireregistersessionallowspaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L180"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
-      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
-      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L547"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "correcttransaction_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
-      "label": "correctTransaction.ts",
-      "norm_label": "correcttransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L292"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L367"
     },
     {
       "community": 380,
@@ -69834,128 +70032,128 @@
     {
       "community": 39,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
-      "label": "RegisterSessionsView.tsx",
-      "norm_label": "registersessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
+      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_applypaymentmethodcorrection",
+      "label": "applyPaymentMethodCorrection()",
+      "norm_label": "applypaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L282"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
+      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
+      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
+      "label": "consumePaymentMethodCorrectionApprovalProof()",
+      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactioncustomer",
+      "label": "correctTransactionCustomer()",
+      "norm_label": "correcttransactioncustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactionpaymentmethod",
+      "label": "correctTransactionPaymentMethod()",
+      "norm_label": "correcttransactionpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "label": "createPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_getpaymentmethodcashcontribution",
+      "label": "getPaymentMethodCashContribution()",
+      "norm_label": "getpaymentmethodcashcontribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L539"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "label": "requireRegisterSessionAllowsPaymentCorrection()",
+      "norm_label": "requireregistersessionallowspaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L180"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
+      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L547"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "correcttransaction_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "label": "correctTransaction.ts",
+      "norm_label": "correcttransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formatduration",
-      "label": "formatDuration()",
-      "norm_label": "formatduration()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formatsessioncode",
-      "label": "formatSessionCode()",
-      "norm_label": "formatsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L142"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinedate",
-      "label": "formatTimelineDate()",
-      "norm_label": "formattimelinedate()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinelabel",
-      "label": "formatTimelineLabel()",
-      "norm_label": "formattimelinelabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinerange",
-      "label": "formatTimelineRange()",
-      "norm_label": "formattimelinerange()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinetime",
-      "label": "formatTimelineTime()",
-      "norm_label": "formattimelinetime()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_getstaffname",
-      "label": "getStaffName()",
-      "norm_label": "getstaffname()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L136"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_getvariancecaption",
-      "label": "getVarianceCaption()",
-      "norm_label": "getvariancecaption()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "registersessionsview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L120"
     },
     {
       "community": 390,
@@ -70509,128 +70707,128 @@
     {
       "community": 40,
       "file_type": "code",
-      "id": "mtnmomoview_cleanundefinedfields",
-      "label": "cleanUndefinedFields()",
-      "norm_label": "cleanundefinedfields()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_clonereceivingaccount",
-      "label": "cloneReceivingAccount()",
-      "norm_label": "clonereceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_createemptyreceivingaccount",
-      "label": "createEmptyReceivingAccount()",
-      "norm_label": "createemptyreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_getstatusbadgevariant",
-      "label": "getStatusBadgeVariant()",
-      "norm_label": "getstatusbadgevariant()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_handleaddaccount",
-      "label": "handleAddAccount()",
-      "norm_label": "handleaddaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_handlemakeprimary",
-      "label": "handleMakePrimary()",
-      "norm_label": "handlemakeprimary()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_handleremoveaccount",
-      "label": "handleRemoveAccount()",
-      "norm_label": "handleremoveaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L188"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_hasreceivingaccountdetails",
-      "label": "hasReceivingAccountDetails()",
-      "norm_label": "hasreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_normalizeprimaryaccounts",
-      "label": "normalizePrimaryAccounts()",
-      "norm_label": "normalizeprimaryaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_topatchreceivingaccounts",
-      "label": "toPatchReceivingAccounts()",
-      "norm_label": "topatchreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_trimtoundefined",
-      "label": "trimToUndefined()",
-      "norm_label": "trimtoundefined()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "mtnmomoview_updateaccount",
-      "label": "updateAccount()",
-      "norm_label": "updateaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
-      "label": "MtnMomoView.tsx",
-      "norm_label": "mtnmomoview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
+      "label": "RegisterSessionsView.tsx",
+      "norm_label": "registersessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formatduration",
+      "label": "formatDuration()",
+      "norm_label": "formatduration()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formatsessioncode",
+      "label": "formatSessionCode()",
+      "norm_label": "formatsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L142"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formattimelinedate",
+      "label": "formatTimelineDate()",
+      "norm_label": "formattimelinedate()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formattimelinelabel",
+      "label": "formatTimelineLabel()",
+      "norm_label": "formattimelinelabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formattimelinerange",
+      "label": "formatTimelineRange()",
+      "norm_label": "formattimelinerange()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formattimelinetime",
+      "label": "formatTimelineTime()",
+      "norm_label": "formattimelinetime()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_getstaffname",
+      "label": "getStaffName()",
+      "norm_label": "getstaffname()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L136"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_getvariancecaption",
+      "label": "getVarianceCaption()",
+      "norm_label": "getvariancecaption()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L128"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "registersessionsview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L120"
     },
     {
       "community": 400,
@@ -70905,127 +71103,127 @@
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_addkey",
-      "label": "addKey()",
-      "norm_label": "addkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L290"
+      "id": "mtnmomoview_cleanundefinedfields",
+      "label": "cleanUndefinedFields()",
+      "norm_label": "cleanundefinedfields()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L52"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_buildregistercatalogindex",
-      "label": "buildRegisterCatalogIndex()",
-      "norm_label": "buildregistercatalogindex()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L66"
+      "id": "mtnmomoview_clonereceivingaccount",
+      "label": "cloneReceivingAccount()",
+      "norm_label": "clonereceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L27"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_extractidentifierfromurl",
-      "label": "extractIdentifierFromUrl()",
-      "norm_label": "extractidentifierfromurl()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L187"
+      "id": "mtnmomoview_createemptyreceivingaccount",
+      "label": "createEmptyReceivingAccount()",
+      "norm_label": "createemptyreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L35"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_findexactmatches",
-      "label": "findExactMatches()",
-      "norm_label": "findexactmatches()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L153"
+      "id": "mtnmomoview_getstatusbadgevariant",
+      "label": "getStatusBadgeVariant()",
+      "norm_label": "getstatusbadgevariant()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_firstnonempty",
-      "label": "firstNonEmpty()",
-      "norm_label": "firstnonempty()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L308"
+      "id": "mtnmomoview_handleaddaccount",
+      "label": "handleAddAccount()",
+      "norm_label": "handleaddaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_isrowavailable",
-      "label": "isRowAvailable()",
-      "norm_label": "isrowavailable()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L286"
+      "id": "mtnmomoview_handlemakeprimary",
+      "label": "handleMakePrimary()",
+      "norm_label": "handlemakeprimary()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L159"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L258"
+      "id": "mtnmomoview_handleremoveaccount",
+      "label": "handleRemoveAccount()",
+      "norm_label": "handleremoveaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_normalizesearchtext",
-      "label": "normalizeSearchText()",
-      "norm_label": "normalizesearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L262"
+      "id": "mtnmomoview_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L188"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_parsecatalogsearchinput",
-      "label": "parseCatalogSearchInput()",
-      "norm_label": "parsecatalogsearchinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L171"
+      "id": "mtnmomoview_hasreceivingaccountdetails",
+      "label": "hasReceivingAccountDetails()",
+      "norm_label": "hasreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L64"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_scoresearchrow",
-      "label": "scoreSearchRow()",
-      "norm_label": "scoresearchrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L234"
+      "id": "mtnmomoview_normalizeprimaryaccounts",
+      "label": "normalizePrimaryAccounts()",
+      "norm_label": "normalizeprimaryaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L77"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_searchbytext",
-      "label": "searchByText()",
-      "norm_label": "searchbytext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L208"
+      "id": "mtnmomoview_topatchreceivingaccounts",
+      "label": "toPatchReceivingAccounts()",
+      "norm_label": "topatchreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_searchregistercatalog",
-      "label": "searchRegisterCatalog()",
-      "norm_label": "searchregistercatalog()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L110"
+      "id": "mtnmomoview_trimtoundefined",
+      "label": "trimToUndefined()",
+      "norm_label": "trimtoundefined()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L47"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "catalogsearch_tokenizesearchtext",
-      "label": "tokenizeSearchText()",
-      "norm_label": "tokenizesearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L272"
+      "id": "mtnmomoview_updateaccount",
+      "label": "updateAccount()",
+      "norm_label": "updateaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L141"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
-      "label": "catalogSearch.ts",
-      "norm_label": "catalogsearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
+      "label": "MtnMomoView.tsx",
+      "norm_label": "mtnmomoview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1"
     },
     {
@@ -74433,101 +74631,101 @@
     {
       "community": 51,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L116"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L283"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L318"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L74"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L55"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L46"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L16"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 510,
@@ -74712,100 +74910,100 @@
     {
       "community": 52,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16"
     },
     {
       "community": 52,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -74991,101 +75189,101 @@
     {
       "community": 53,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 53,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 53,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
     },
     {
       "community": 53,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 53,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 53,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 530,
@@ -75270,101 +75468,101 @@
     {
       "community": 54,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "label": "useRegisterViewModel.ts",
+      "norm_label": "useregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
       "source_location": "L1"
     },
     {
       "community": 54,
       "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
+      "id": "useregisterviewmodel_canoperateregister",
+      "label": "canOperateRegister()",
+      "norm_label": "canoperateregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L171"
     },
     {
       "community": 54,
       "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "useregisterviewmodel_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "useregisterviewmodel_createpaymentid",
+      "label": "createPaymentId()",
+      "norm_label": "createpaymentid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "useregisterviewmodel_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapcatalogrowtoproduct",
+      "label": "mapCatalogRowToProduct()",
+      "norm_label": "mapcatalogrowtoproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "useregisterviewmodel_normalizeexactinput",
+      "label": "normalizeExactInput()",
+      "norm_label": "normalizeexactinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "useregisterviewmodel_presentoperatorerror",
+      "label": "presentOperatorError()",
+      "norm_label": "presentoperatorerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
       "source_location": "L122"
     },
     {
       "community": 54,
       "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
+      "id": "useregisterviewmodel_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L117"
     },
     {
       "community": 54,
       "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
+      "id": "useregisterviewmodel_useregisterviewmodel",
+      "label": "useRegisterViewModel()",
+      "norm_label": "useregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L180"
     },
     {
       "community": 540,
@@ -75549,101 +75747,101 @@
     {
       "community": 55,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
-      "label": "useRegisterViewModel.ts",
-      "norm_label": "useregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_canoperateregister",
-      "label": "canOperateRegister()",
-      "norm_label": "canoperateregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_createpaymentid",
-      "label": "createPaymentId()",
-      "norm_label": "createpaymentid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapcatalogrowtoproduct",
-      "label": "mapCatalogRowToProduct()",
-      "norm_label": "mapcatalogrowtoproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_normalizeexactinput",
-      "label": "normalizeExactInput()",
-      "norm_label": "normalizeexactinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_presentoperatorerror",
-      "label": "presentOperatorError()",
-      "norm_label": "presentoperatorerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "useregisterviewmodel_useregisterviewmodel",
-      "label": "useRegisterViewModel()",
-      "norm_label": "useregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L180"
     },
     {
       "community": 550,
@@ -75828,101 +76026,101 @@
     {
       "community": 56,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 560,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1578
-- Graph nodes: 4300
-- Graph edges: 3988
+- Graph nodes: 4306
+- Graph edges: 4000
 - Communities: 1506
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `storeConfigV2.ts` (27 edges, Community 5) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `cycleCountDrafts.ts` (21 edges, Community 9) - [`packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts`](../../../packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts)
 - `sessionCommands.ts` (20 edges, Community 12) - [`packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts)
-- `expenseSessionCommands.ts` (19 edges, Community 13) - [`packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts)
+- `catalogSearch.ts` (19 edges, Community 15) - [`packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 10) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 31) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 32) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 10) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 36) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 77) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 35) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 36) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 36) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 36) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts
@@ -146,6 +146,42 @@ describe("catalogSearch", () => {
     expect(result.results[0]?.productSkuId).toBe("sku-belt");
   });
 
+  it("returns prefix fuzzy matches from the local text index", () => {
+    const result = searchRegisterCatalog(
+      buildRegisterCatalogIndex([
+        ...rows,
+        {
+          productId: "product-durable-lace",
+          productSkuId: "sku-durable-lace",
+          name: "Durable Lace Front",
+          sku: "DLF-20",
+          barcode: "444555666777",
+          category: "Wigs",
+          description: "Long-wear frontal wig",
+          quantityAvailable: 3,
+          price: 250,
+          size: "M",
+          color: "Natural",
+          length: 20,
+        },
+      ]),
+      "dura",
+    );
+
+    expect(result.intent).toBe("text");
+    expect(result.results[0]?.productSkuId).toBe("sku-durable-lace");
+  });
+
+  it("returns typo-tolerant fuzzy matches from the local text index", () => {
+    const result = searchRegisterCatalog(
+      buildRegisterCatalogIndex(rows),
+      "lether",
+    );
+
+    expect(result.intent).toBe("text");
+    expect(result.results[0]?.productSkuId).toBe("sku-belt");
+  });
+
   it("returns no results for unmatched text", () => {
     const result = searchRegisterCatalog(
       buildRegisterCatalogIndex(rows),

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
@@ -238,21 +238,130 @@ function scoreSearchRow(
   let score = 0;
 
   for (const token of queryTokens) {
-    if (!entry.tokens.has(token)) {
+    const tokenScore = scoreQueryTokenForEntry(entry, token);
+
+    if (tokenScore === 0) {
       continue;
     }
 
-    score += 1;
-
-    if (entry.normalizedFields.name.includes(token)) score += 8;
-    if (entry.normalizedFields.sku.includes(token)) score += 6;
-    if (entry.normalizedFields.barcode.includes(token)) score += 6;
-    if (entry.normalizedFields.category.includes(token)) score += 4;
-    if (entry.normalizedFields.attributes.includes(token)) score += 3;
-    if (entry.normalizedFields.description.includes(token)) score += 2;
+    score += tokenScore;
   }
 
   return score;
+}
+
+function scoreQueryTokenForEntry(
+  entry: RegisterCatalogIndex["searchableRows"][number],
+  token: string,
+): number {
+  if (entry.tokens.has(token)) {
+    return (
+      1 +
+      scoreFieldContains(entry.normalizedFields.name, token, 8) +
+      scoreFieldContains(entry.normalizedFields.sku, token, 6) +
+      scoreFieldContains(entry.normalizedFields.barcode, token, 6) +
+      scoreFieldContains(entry.normalizedFields.category, token, 4) +
+      scoreFieldContains(entry.normalizedFields.attributes, token, 3) +
+      scoreFieldContains(entry.normalizedFields.description, token, 2)
+    );
+  }
+
+  return bestFuzzyTokenScore(entry.tokens, token);
+}
+
+function scoreFieldContains(field: string, token: string, score: number): number {
+  return field.includes(token) ? score : 0;
+}
+
+function bestFuzzyTokenScore(tokens: Set<string>, queryToken: string): number {
+  if (queryToken.length < 3) {
+    return 0;
+  }
+
+  let bestScore = 0;
+
+  for (const candidateToken of tokens) {
+    bestScore = Math.max(
+      bestScore,
+      scoreFuzzyTokenMatch(candidateToken, queryToken),
+    );
+  }
+
+  return bestScore;
+}
+
+function scoreFuzzyTokenMatch(candidateToken: string, queryToken: string): number {
+  if (candidateToken.length < 3) {
+    return 0;
+  }
+
+  if (
+    candidateToken.includes(queryToken) ||
+    queryToken.includes(candidateToken)
+  ) {
+    return 5;
+  }
+
+  if (!isProbablySameToken(candidateToken, queryToken)) {
+    return 0;
+  }
+
+  const distance = levenshteinDistance(candidateToken, queryToken);
+  const maxLength = Math.max(candidateToken.length, queryToken.length);
+  const similarity = 1 - distance / maxLength;
+
+  if (similarity >= 0.78) {
+    return 4;
+  }
+
+  if (similarity >= 0.68) {
+    return 2;
+  }
+
+  return 0;
+}
+
+function isProbablySameToken(candidateToken: string, queryToken: string): boolean {
+  return (
+    candidateToken[0] === queryToken[0] ||
+    candidateToken.includes(queryToken.slice(0, 2)) ||
+    queryToken.includes(candidateToken.slice(0, 2))
+  );
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+
+  if (left.length === 0) {
+    return right.length;
+  }
+
+  if (right.length === 0) {
+    return left.length;
+  }
+
+  let previousRow = Array.from({ length: right.length + 1 }, (_, index) => index);
+
+  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+    const currentRow = [leftIndex + 1];
+
+    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+      const insertionCost = currentRow[rightIndex] + 1;
+      const deletionCost = previousRow[rightIndex + 1] + 1;
+      const substitutionCost =
+        previousRow[rightIndex] + (left[leftIndex] === right[rightIndex] ? 0 : 1);
+
+      currentRow.push(
+        Math.min(insertionCost, deletionCost, substitutionCost),
+      );
+    }
+
+    previousRow = currentRow;
+  }
+
+  return previousRow[right.length];
 }
 
 function normalizeIdentifier(value: unknown): string {


### PR DESCRIPTION
## Summary

- Add prefix-friendly fuzzy matching to the POS register local catalog index after exact identifier resolution
- Cover prefix and typo searches with catalog-search tests so inputs like `dura` and `lether` still find relevant products
- Update solution docs for POS local catalog search and the repo coverage/CI parity lesson from the previous PR

## Why

The POS register search path is operator-facing and local-first. It should tolerate short product-name prefixes and small typos without falling back to per-keystroke server search or weakening exact barcode/SKU/product-id behavior.

## Validation

- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/catalogSearch.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bun run graphify:rebuild`
- `git diff --check HEAD~1..HEAD`
- `bun run pre-push:review`
