### PR TITLE
fix(pos): tighten receipt and quick-add presentation

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4306 nodes · 4000 edges · 1506 communities detected
+- 4308 nodes · 4002 edges · 1506 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1912,108 +1912,108 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 92 - "Community 92"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 93 - "Community 93"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 94 - "Community 94"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 93 - "Community 93"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 94 - "Community 94"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 95 - "Community 95"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 96 - "Community 96"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.43
 Nodes (4): assertRegisterNumberIsAvailable(), mapRegisterTerminalError(), normalizeRegisterNumber(), registerTerminal()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.33
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 117 - "Community 117"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 118 - "Community 118"
 Cohesion: 0.29
@@ -2024,72 +2024,72 @@ Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 120 - "Community 120"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 121 - "Community 121"
 Cohesion: 0.48
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 126 - "Community 126"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 127 - "Community 127"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 128 - "Community 128"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 129 - "Community 129"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 130 - "Community 130"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 136 - "Community 136"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 137 - "Community 137"
 Cohesion: 0.33
@@ -2265,7 +2265,7 @@ Nodes (0):
 
 ### Community 180 - "Community 180"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.4
@@ -2276,16 +2276,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 183 - "Community 183"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 184 - "Community 184"
 Cohesion: 0.5
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.4
@@ -2297,7 +2297,7 @@ Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 189 - "Community 189"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -8735,7 +8735,7 @@
       "relation": "calls",
       "source": "ordersummary_test_getbalanceduelabel",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L63",
+      "source_location": "L67",
       "target": "ordersummary_test_getbalanceduepanel",
       "weight": 1
     },
@@ -23195,7 +23195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L36",
+      "source_location": "L40",
       "target": "ordersummary_test_getbalancedueamount",
       "weight": 1
     },
@@ -23207,7 +23207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L53",
+      "source_location": "L57",
       "target": "ordersummary_test_getbalanceduelabel",
       "weight": 1
     },
@@ -23219,7 +23219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L62",
+      "source_location": "L66",
       "target": "ordersummary_test_getbalanceduepanel",
       "weight": 1
     },
@@ -23231,8 +23231,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L32",
+      "source_location": "L36",
       "target": "ordersummary_test_stripwhitespace",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "_tgt": "ordersummary_formatreceiptwebsite",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L30",
+      "target": "ordersummary_formatreceiptwebsite",
       "weight": 1
     },
     {
@@ -23243,7 +23255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L418",
+      "source_location": "L457",
       "target": "ordersummary_formatstoredamount",
       "weight": 1
     },
@@ -23255,7 +23267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L285",
+      "source_location": "L323",
       "target": "ordersummary_handlecompletetransaction",
       "weight": 1
     },
@@ -23267,7 +23279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L318",
+      "source_location": "L356",
       "target": "ordersummary_handleeditingpaymentidchange",
       "weight": 1
     },
@@ -23279,7 +23291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L308",
+      "source_location": "L346",
       "target": "ordersummary_handleselectedpaymentmethodchange",
       "weight": 1
     },
@@ -23291,8 +23303,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L302",
+      "source_location": "L340",
       "target": "ordersummary_handlestartnewtransaction",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "_tgt": "ordersummary_parsereceiptlocation",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L36",
+      "target": "ordersummary_parsereceiptlocation",
       "weight": 1
     },
     {
@@ -23639,7 +23663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L229",
+      "source_location": "L234",
       "target": "productentry_handleclearsearch",
       "weight": 1
     },
@@ -23651,7 +23675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L234",
+      "source_location": "L239",
       "target": "productentry_handleopenquickadd",
       "weight": 1
     },
@@ -23663,7 +23687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L263",
+      "source_location": "L272",
       "target": "productentry_handlequickaddsubmit",
       "weight": 1
     },
@@ -23675,7 +23699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L254",
+      "source_location": "L263",
       "target": "productentry_resetquickaddform",
       "weight": 1
     },
@@ -23999,7 +24023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L115",
+      "source_location": "L117",
       "target": "searchresultssection_handlequickaddproductshortcut",
       "weight": 1
     },
@@ -24011,7 +24035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L82",
+      "source_location": "L84",
       "target": "searchresultssection_handlequickaddvariantshortcut",
       "weight": 1
     },
@@ -38039,7 +38063,7 @@
       "relation": "calls",
       "source": "productentry_handleclearsearch",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L343",
+      "source_location": "L352",
       "target": "productentry_handlequickaddsubmit",
       "weight": 1
     },
@@ -38051,7 +38075,7 @@
       "relation": "calls",
       "source": "productentry_resetquickaddform",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L341",
+      "source_location": "L350",
       "target": "productentry_handlequickaddsubmit",
       "weight": 1
     },
@@ -47771,7 +47795,7 @@
       "relation": "calls",
       "source": "useexpenseregisterviewmodel_getcashierdisplayname",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L623",
+      "source_location": "L624",
       "target": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "weight": 1
     },
@@ -49044,64 +49068,64 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontraceevent",
-      "label": "buildExpenseSessionTraceEvent()",
-      "norm_label": "buildexpensesessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L150"
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontracerecord",
-      "label": "buildExpenseSessionTraceRecord()",
-      "norm_label": "buildexpensesessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L101"
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L71"
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessiontracing_createexpensesessiontracerecorder",
-      "label": "createExpenseSessionTraceRecorder()",
-      "norm_label": "createexpensesessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L293"
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
-      "label": "recordExpenseSessionTraceBestEffort()",
-      "norm_label": "recordexpensesessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L266"
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L258"
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
-      "label": "expenseSessionTracing.ts",
-      "norm_label": "expensesessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
       "source_location": "L1"
     },
     {
@@ -49197,65 +49221,65 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L1"
+      "id": "expensesessiontracing_buildexpensesessiontraceevent",
+      "label": "buildExpenseSessionTraceEvent()",
+      "norm_label": "buildexpensesessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L150"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "terminals_assertregisternumberisavailable",
-      "label": "assertRegisterNumberIsAvailable()",
-      "norm_label": "assertregisternumberisavailable()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L47"
+      "id": "expensesessiontracing_buildexpensesessiontracerecord",
+      "label": "buildExpenseSessionTraceRecord()",
+      "norm_label": "buildexpensesessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L101"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "terminals_deleteterminal",
-      "label": "deleteTerminal()",
-      "norm_label": "deleteterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "terminals_mapregisterterminalerror",
-      "label": "mapRegisterTerminalError()",
-      "norm_label": "mapregisterterminalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "terminals_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "terminals_registerterminal",
-      "label": "registerTerminal()",
-      "norm_label": "registerterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "id": "expensesessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
       "source_location": "L71"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "terminals_updateterminal",
-      "label": "updateTerminal()",
-      "norm_label": "updateterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L134"
+      "id": "expensesessiontracing_createexpensesessiontracerecorder",
+      "label": "createExpenseSessionTraceRecorder()",
+      "norm_label": "createexpensesessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
+      "label": "recordExpenseSessionTraceBestEffort()",
+      "norm_label": "recordexpensesessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
+      "label": "expenseSessionTracing.ts",
+      "norm_label": "expensesessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L1"
     },
     {
       "community": 1010,
@@ -49350,65 +49374,65 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
       "source_location": "L1"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L95"
+      "id": "terminals_assertregisternumberisavailable",
+      "label": "assertRegisterNumberIsAvailable()",
+      "norm_label": "assertregisternumberisavailable()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L47"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L122"
+      "id": "terminals_deleteterminal",
+      "label": "deleteTerminal()",
+      "norm_label": "deleteterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L169"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L66"
+      "id": "terminals_mapregisterterminalerror",
+      "label": "mapRegisterTerminalError()",
+      "norm_label": "mapregisterterminalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L30"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerprofileidforposcustomer",
-      "label": "getCustomerProfileIdForPosCustomer()",
-      "norm_label": "getcustomerprofileidforposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
+      "id": "terminals_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L25"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L75"
+      "id": "terminals_registerterminal",
+      "label": "registerTerminal()",
+      "norm_label": "registerterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L71"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L27"
+      "id": "terminals_updateterminal",
+      "label": "updateTerminal()",
+      "norm_label": "updateterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L134"
     },
     {
       "community": 1020,
@@ -49503,65 +49527,65 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
-      "label": "sessionRepository.ts",
-      "norm_label": "sessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
       "source_location": "L1"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessionrepository_getactivesessionforregisterstate",
-      "label": "getActiveSessionForRegisterState()",
-      "norm_label": "getactivesessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L18"
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L95"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessionrepository_listheldsessionsforregisterstate",
-      "label": "listHeldSessionsForRegisterState()",
-      "norm_label": "listheldsessionsforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L26"
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L122"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessionrepository_matchesregisteridentity",
-      "label": "matchesRegisterIdentity()",
-      "norm_label": "matchesregisteridentity()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L119"
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L66"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessionrepository_querysessionsbystatus",
-      "label": "querySessionsByStatus()",
-      "norm_label": "querysessionsbystatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L33"
+      "id": "searchcustomers_getcustomerprofileidforposcustomer",
+      "label": "getCustomerProfileIdForPosCustomer()",
+      "norm_label": "getcustomerprofileidforposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessionrepository_selectregisterstatelookupstrategy",
-      "label": "selectRegisterStateLookupStrategy()",
-      "norm_label": "selectregisterstatelookupstrategy()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L83"
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L75"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessionrepository_summarizeregisterstatesessions",
-      "label": "summarizeRegisterStateSessions()",
-      "norm_label": "summarizeregisterstatesessions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L97"
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L27"
     },
     {
       "community": 1030,
@@ -49656,65 +49680,65 @@
     {
       "community": 104,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
+      "label": "sessionRepository.ts",
+      "norm_label": "sessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "sessionrepository_getactivesessionforregisterstate",
+      "label": "getActiveSessionForRegisterState()",
+      "norm_label": "getactivesessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "sessionrepository_listheldsessionsforregisterstate",
+      "label": "listHeldSessionsForRegisterState()",
+      "norm_label": "listheldsessionsforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "sessionrepository_matchesregisteridentity",
+      "label": "matchesRegisterIdentity()",
+      "norm_label": "matchesregisteridentity()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "sessionrepository_querysessionsbystatus",
+      "label": "querySessionsByStatus()",
+      "norm_label": "querysessionsbystatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "sessionrepository_selectregisterstatelookupstrategy",
+      "label": "selectRegisterStateLookupStrategy()",
+      "norm_label": "selectregisterstatelookupstrategy()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "sessionrepository_summarizeregisterstatesessions",
+      "label": "summarizeRegisterStateSessions()",
+      "norm_label": "summarizeregisterstatesessions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 1040,
@@ -49809,64 +49833,64 @@
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L45"
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L104"
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L21"
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L33"
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L14"
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L57"
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1"
     },
     {
@@ -49962,64 +49986,64 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L45"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L104"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L21"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L33"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L14"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L57"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -50115,65 +50139,65 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L61"
     },
     {
       "community": 1070,
@@ -50268,65 +50292,65 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L61"
     },
     {
       "community": 1080,
@@ -50421,64 +50445,64 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L61"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L85"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L206"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L214"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L51"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L221"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -50772,65 +50796,65 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "stockadjustment_hashighstockadjustmentvariance",
-      "label": "hasHighStockAdjustmentVariance()",
-      "norm_label": "hashighstockadjustmentvariance()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
     },
     {
       "community": 1100,
@@ -50925,65 +50949,65 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L404"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L181"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L231"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L275"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L259"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1110,
@@ -51078,65 +51102,65 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "posregisterview_cartcountsummary",
-      "label": "CartCountSummary()",
-      "norm_label": "cartcountsummary()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L152"
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "posregisterview_cashierauthworkspace",
-      "label": "CashierAuthWorkspace()",
-      "norm_label": "cashierauthworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L114"
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L181"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L431"
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L253"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L73"
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L231"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "posregisterview_registersetupresolvingworkspace",
-      "label": "RegisterSetupResolvingWorkspace()",
-      "norm_label": "registersetupresolvingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L146"
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L41"
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L259"
     },
     {
       "community": 1120,
@@ -51231,65 +51255,65 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
+      "id": "posregisterview_cartcountsummary",
+      "label": "CartCountSummary()",
+      "norm_label": "cartcountsummary()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L431"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L73"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
+      "id": "posregisterview_registersetupresolvingworkspace",
+      "label": "RegisterSetupResolvingWorkspace()",
+      "norm_label": "registersetupresolvingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L146"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L41"
     },
     {
       "community": 1130,
@@ -51384,65 +51408,65 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 1140,
@@ -51537,65 +51561,65 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexregistercatalog",
-      "label": "useConvexRegisterCatalog()",
-      "norm_label": "useconvexregistercatalog()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1150,
@@ -51690,64 +51714,64 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L40"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L107"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L78"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L139"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
+      "id": "cataloggateway_useconvexregistercatalog",
+      "label": "useConvexRegisterCatalog()",
+      "norm_label": "useconvexregistercatalog()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L69"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
     },
     {
@@ -51843,65 +51867,65 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
     },
     {
       "community": 1170,
@@ -52491,65 +52515,65 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createpackage",
-      "label": "createPackage()",
-      "norm_label": "createpackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
-      "label": "installFixtureToolchain()",
-      "norm_label": "installfixturetoolchain()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
-      "label": "linkWorkspacePackage()",
-      "norm_label": "linkworkspacepackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writefixturemanifests",
-      "label": "writeFixtureManifests()",
-      "norm_label": "writefixturemanifests()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writejson",
-      "label": "writeJson()",
-      "norm_label": "writejson()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "scripts_coverage_toolchain_parity_test_ts",
-      "label": "coverage-toolchain-parity.test.ts",
-      "norm_label": "coverage-toolchain-parity.test.ts",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1200,
@@ -52644,65 +52668,65 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "coverage_toolchain_parity_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_createpackage",
+      "label": "createPackage()",
+      "norm_label": "createpackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
+      "label": "installFixtureToolchain()",
+      "norm_label": "installfixturetoolchain()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
+      "label": "linkWorkspacePackage()",
+      "norm_label": "linkworkspacepackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writefixturemanifests",
+      "label": "writeFixtureManifests()",
+      "norm_label": "writefixturemanifests()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writejson",
+      "label": "writeJson()",
+      "norm_label": "writejson()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "scripts_coverage_toolchain_parity_test_ts",
+      "label": "coverage-toolchain-parity.test.ts",
+      "norm_label": "coverage-toolchain-parity.test.ts",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
     },
     {
       "community": 1210,
@@ -52797,65 +52821,65 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1220,
@@ -52950,64 +52974,64 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -53103,55 +53127,64 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -53247,56 +53280,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1250,
@@ -53391,56 +53424,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L1"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L42"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1260,
@@ -53535,56 +53568,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
     },
     {
       "community": 1270,
@@ -53679,56 +53712,56 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
     },
     {
       "community": 1280,
@@ -53823,55 +53856,55 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -54147,55 +54180,55 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -54291,56 +54324,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
     },
     {
       "community": 1310,
@@ -54435,56 +54468,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1320,
@@ -54579,55 +54612,55 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "analyticsview_activecheckoutsessions",
-      "label": "ActiveCheckoutSessions()",
-      "norm_label": "activecheckoutsessions()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L89"
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "analyticsview_formatmetric",
-      "label": "formatMetric()",
-      "norm_label": "formatmetric()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L22"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "analyticsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L154"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "analyticsview_storefrontsignalcard",
-      "label": "StorefrontSignalCard()",
-      "norm_label": "storefrontsignalcard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L26"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "analyticsview_storevisitors",
-      "label": "StoreVisitors()",
-      "norm_label": "storevisitors()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L59"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "label": "AnalyticsView.tsx",
-      "norm_label": "analyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -54723,56 +54756,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "analyticsview_activecheckoutsessions",
+      "label": "ActiveCheckoutSessions()",
+      "norm_label": "activecheckoutsessions()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "analyticsview_formatmetric",
+      "label": "formatMetric()",
+      "norm_label": "formatmetric()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "analyticsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L154"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "analyticsview_storefrontsignalcard",
+      "label": "StorefrontSignalCard()",
+      "norm_label": "storefrontsignalcard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "analyticsview_storevisitors",
+      "label": "StoreVisitors()",
+      "norm_label": "storevisitors()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
+      "label": "AnalyticsView.tsx",
+      "norm_label": "analyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1340,
@@ -54867,56 +54900,56 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1350,
@@ -55011,55 +55044,55 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
-      "label": "CashControlsHeaderSkeleton()",
-      "norm_label": "cashcontrolsheaderskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L83"
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L373"
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L544"
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_metriccardskeleton",
-      "label": "MetricCardSkeleton()",
-      "norm_label": "metriccardskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L97"
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L266"
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
     },
     {
@@ -55155,55 +55188,55 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
+      "id": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
+      "label": "CashControlsHeaderSkeleton()",
+      "norm_label": "cashcontrolsheaderskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L83"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
+      "id": "cashcontrolsdashboard_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L373"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
+      "id": "cashcontrolsdashboard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L544"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
+      "id": "cashcontrolsdashboard_metriccardskeleton",
+      "label": "MetricCardSkeleton()",
+      "norm_label": "metriccardskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L97"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
+      "id": "cashcontrolsdashboard_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L266"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
       "source_location": "L1"
     },
     {
@@ -55299,55 +55332,55 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "ordersummary_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L418"
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L285"
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "ordersummary_handleeditingpaymentidchange",
-      "label": "handleEditingPaymentIdChange()",
-      "norm_label": "handleeditingpaymentidchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L318"
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "ordersummary_handleselectedpaymentmethodchange",
-      "label": "handleSelectedPaymentMethodChange()",
-      "norm_label": "handleselectedpaymentmethodchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L308"
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "ordersummary_handlestartnewtransaction",
-      "label": "handleStartNewTransaction()",
-      "norm_label": "handlestartnewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L302"
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
     },
     {
@@ -59430,366 +59463,6 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_getapprovalrequestcopy",
-      "label": "getApprovalRequestCopy()",
-      "norm_label": "getapprovalrequestcopy()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_getdefaultworkflow",
-      "label": "getDefaultWorkflow()",
-      "norm_label": "getdefaultworkflow()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L579"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "operationsqueueview_setdecisioningapprovalrequestid",
-      "label": "setDecisioningApprovalRequestId()",
-      "norm_label": "setdecisioningapprovalrequestid()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L638"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 185,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -59797,7 +59470,7 @@
       "source_location": "L30"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -59806,7 +59479,7 @@
       "source_location": "L43"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -59815,7 +59488,7 @@
       "source_location": "L106"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -59824,12 +59497,372 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_getapprovalrequestcopy",
+      "label": "getApprovalRequestCopy()",
+      "norm_label": "getapprovalrequestcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_getdefaultworkflow",
+      "label": "getDefaultWorkflow()",
+      "norm_label": "getdefaultworkflow()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L579"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "operationsqueueview_setdecisioningapprovalrequestid",
+      "label": "setDecisioningApprovalRequestId()",
+      "norm_label": "setdecisioningapprovalrequestid()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L638"
+    },
+    {
+      "community": 185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -59839,7 +59872,7 @@
       "label": "getBalanceDueAmount()",
       "norm_label": "getbalancedueamount()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L36"
+      "source_location": "L40"
     },
     {
       "community": 189,
@@ -59848,7 +59881,7 @@
       "label": "getBalanceDueLabel()",
       "norm_label": "getbalanceduelabel()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L53"
+      "source_location": "L57"
     },
     {
       "community": 189,
@@ -59857,7 +59890,7 @@
       "label": "getBalanceDuePanel()",
       "norm_label": "getbalanceduepanel()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L62"
+      "source_location": "L66"
     },
     {
       "community": 189,
@@ -59866,7 +59899,7 @@
       "label": "stripWhitespace()",
       "norm_label": "stripwhitespace()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L32"
+      "source_location": "L36"
     },
     {
       "community": 189,
@@ -60109,7 +60142,7 @@
       "label": "handleClearSearch()",
       "norm_label": "handleclearsearch()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L229"
+      "source_location": "L234"
     },
     {
       "community": 191,
@@ -60118,7 +60151,7 @@
       "label": "handleOpenQuickAdd()",
       "norm_label": "handleopenquickadd()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L234"
+      "source_location": "L239"
     },
     {
       "community": 191,
@@ -60127,7 +60160,7 @@
       "label": "handleQuickAddSubmit()",
       "norm_label": "handlequickaddsubmit()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L263"
+      "source_location": "L272"
     },
     {
       "community": 191,
@@ -60136,7 +60169,7 @@
       "label": "resetQuickAddForm()",
       "norm_label": "resetquickaddform()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L254"
+      "source_location": "L263"
     },
     {
       "community": 192,
@@ -68173,7 +68206,7 @@
       "label": "handleQuickAddProductShortcut()",
       "norm_label": "handlequickaddproductshortcut()",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L115"
+      "source_location": "L117"
     },
     {
       "community": 340,
@@ -68182,7 +68215,7 @@
       "label": "handleQuickAddVariantShortcut()",
       "norm_label": "handlequickaddvariantshortcut()",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L82"
+      "source_location": "L84"
     },
     {
       "community": 341,
@@ -85341,74 +85374,74 @@
     {
       "community": 91,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "label": "welcome-offer-modal.tsx",
-      "norm_label": "welcome-offer-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "id": "ordersummary_formatreceiptwebsite",
+      "label": "formatReceiptWebsite()",
+      "norm_label": "formatreceiptwebsite()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L457"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L323"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "ordersummary_handleeditingpaymentidchange",
+      "label": "handleEditingPaymentIdChange()",
+      "norm_label": "handleeditingpaymentidchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L356"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "ordersummary_handleselectedpaymentmethodchange",
+      "label": "handleSelectedPaymentMethodChange()",
+      "norm_label": "handleselectedpaymentmethodchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L346"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "ordersummary_handlestartnewtransaction",
+      "label": "handleStartNewTransaction()",
+      "norm_label": "handlestartnewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L340"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "ordersummary_parsereceiptlocation",
+      "label": "parseReceiptLocation()",
+      "norm_label": "parsereceiptlocation()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlecolorchange",
-      "label": "handleColorChange()",
-      "norm_label": "handlecolorchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlenumberchange",
-      "label": "handleNumberChange()",
-      "norm_label": "handlenumberchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleselectchange",
-      "label": "handleSelectChange()",
-      "norm_label": "handleselectchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleswitchchange",
-      "label": "handleSwitchChange()",
-      "norm_label": "handleswitchchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "welcome_offer_modal_updateimages",
-      "label": "updateImages()",
-      "norm_label": "updateimages()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L100"
     },
     {
       "community": 910,
@@ -85503,74 +85536,74 @@
     {
       "community": 92,
       "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
+      "label": "welcome-offer-modal.tsx",
+      "norm_label": "welcome-offer-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlecolorchange",
+      "label": "handleColorChange()",
+      "norm_label": "handlecolorchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlenumberchange",
+      "label": "handleNumberChange()",
+      "norm_label": "handlenumberchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleselectchange",
+      "label": "handleSelectChange()",
+      "norm_label": "handleselectchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleswitchchange",
+      "label": "handleSwitchChange()",
+      "norm_label": "handleswitchchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "welcome_offer_modal_updateimages",
+      "label": "updateImages()",
+      "norm_label": "updateimages()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L100"
     },
     {
       "community": 920,
@@ -85665,74 +85698,74 @@
     {
       "community": 93,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_getbaseurl",
+      "id": "bag_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
     },
     {
       "community": 930,
@@ -85827,74 +85860,74 @@
     {
       "community": 94,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L1"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
     },
     {
       "community": 940,
@@ -85989,74 +86022,74 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
     },
     {
       "community": 950,
@@ -86151,65 +86184,74 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "expensesessions_expensesessionerror",
-      "label": "expenseSessionError()",
-      "norm_label": "expensesessionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "label": "listExpenseSessionsByStatusBefore()",
-      "norm_label": "listexpensesessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "expensesessions_loadexpensesessionitems",
-      "label": "loadExpenseSessionItems()",
-      "norm_label": "loadexpensesessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "expensesessions_mapexpensesessionvalidationerror",
-      "label": "mapExpenseSessionValidationError()",
-      "norm_label": "mapexpensesessionvalidationerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "expensesessions_recordexpensesessionlifecycletrace",
-      "label": "recordExpenseSessionLifecycleTrace()",
-      "norm_label": "recordexpensesessionlifecycletrace()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
-      "label": "userErrorFromExpenseSessionCommandFailure()",
-      "norm_label": "usererrorfromexpensesessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "label": "expenseSessions.ts",
-      "norm_label": "expensesessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
     },
     {
       "community": 960,
@@ -86304,64 +86346,64 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L76"
+      "id": "expensesessions_expensesessionerror",
+      "label": "expenseSessionError()",
+      "norm_label": "expensesessionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L47"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L190"
+      "id": "expensesessions_listexpensesessionsbystatusbefore",
+      "label": "listExpenseSessionsByStatusBefore()",
+      "norm_label": "listexpensesessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L163"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_loadexpensesessionitems",
+      "label": "loadExpenseSessionItems()",
+      "norm_label": "loadexpensesessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L114"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L239"
+      "id": "expensesessions_mapexpensesessionvalidationerror",
+      "label": "mapExpenseSessionValidationError()",
+      "norm_label": "mapexpensesessionvalidationerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L95"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L20"
+      "id": "expensesessions_recordexpensesessionlifecycletrace",
+      "label": "recordExpenseSessionLifecycleTrace()",
+      "norm_label": "recordexpensesessionlifecycletrace()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L139"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
+      "label": "userErrorFromExpenseSessionCommandFailure()",
+      "norm_label": "usererrorfromexpensesessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
+      "label": "expenseSessions.ts",
+      "norm_label": "expensesessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1"
     },
     {
@@ -86457,64 +86499,64 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1"
     },
     {
@@ -86610,64 +86652,64 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1578
-- Graph nodes: 4306
-- Graph edges: 4000
+- Graph nodes: 4308
+- Graph edges: 4002
 - Communities: 1506
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -6,18 +6,22 @@ import { render as renderEmail } from "@react-email/components";
 import { currencyFormatter } from "~/shared/currencyFormatter";
 import { OrderSummary } from "./OrderSummary";
 
+const mockStoreState = vi.hoisted(() => ({
+  activeStore: {
+    _id: "store-1",
+    currency: "GHS",
+    name: "Wig Club",
+    config: {},
+  } as Record<string, any>,
+}));
+
 vi.mock("@react-email/components", () => ({
   render: vi.fn().mockResolvedValue("<receipt />"),
 }));
 
 vi.mock("~/src/hooks/useGetActiveStore", () => ({
   default: () => ({
-    activeStore: {
-      _id: "store-1",
-      currency: "GHS",
-      name: "Wig Club",
-      config: {},
-    },
+    activeStore: mockStoreState.activeStore,
   }),
 }));
 
@@ -66,6 +70,12 @@ function getBalanceDuePanel() {
 describe("OrderSummary completed transaction summary", () => {
   beforeEach(() => {
     vi.mocked(renderEmail).mockClear();
+    mockStoreState.activeStore = {
+      _id: "store-1",
+      currency: "GHS",
+      name: "Wig Club",
+      config: {},
+    };
   });
 
   it("does not render the tax line in the completed sale totals", () => {
@@ -258,6 +268,72 @@ describe("OrderSummary completed transaction summary", () => {
     ]);
   });
 
+  it("prints receipt header contact fields from grouped store configuration", async () => {
+    const user = userEvent.setup();
+    mockStoreState.activeStore = {
+      _id: "store-1",
+      currency: "GHS",
+      name: "Wig Club",
+      config: {
+        contact: {
+          phoneNumber: "+233 55 555 5555",
+          location: "2 Jungle Avenue, East Legon, Accra, Ghana",
+        },
+      },
+    };
+
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404928"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          completedAt: new Date("2026-04-25T18:08:00.000Z"),
+          cartItems: [],
+          customerInfo: undefined,
+          subtotal: 1000,
+          tax: 0,
+          total: 1000,
+          payments: [
+            { id: "payment-1", method: "cash", amount: 1000, timestamp: 1 },
+          ],
+        }}
+        isTransactionCompleted
+        presentation="rail"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Print receipt/i }));
+
+    await waitFor(() => {
+      expect(renderEmail).toHaveBeenCalled();
+    });
+
+    const receiptElement = vi.mocked(renderEmail).mock.calls[0][0] as {
+      props: {
+        storeContact: {
+          street?: string;
+          city?: string;
+          state?: string;
+          zipCode?: string;
+          country?: string;
+          phone?: string;
+          website?: string;
+        };
+      };
+    };
+
+    expect(receiptElement.props.storeContact).toMatchObject({
+      street: "2 Jungle Avenue",
+      city: "East Legon",
+      state: "Accra",
+      country: "Ghana",
+      phone: "+233 55 555 5555",
+      website: "localhost:5174",
+    });
+    expect(receiptElement.props.storeContact.zipCode).toBeUndefined();
+  });
+
   it("reflects a draft amount equal to balance due as zero remaining", async () => {
     const user = userEvent.setup();
 
@@ -398,9 +474,7 @@ describe("OrderSummary completed transaction summary", () => {
     expect(screen.getByText("Balance due")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cash" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Card" })).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Mobile Money" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Mobile Money" })).toBeDisabled();
     expect(
       screen.queryByRole("button", { name: "Complete Sale" }),
     ).not.toBeInTheDocument();
@@ -517,9 +591,9 @@ describe("OrderSummary completed transaction summary", () => {
 
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onRemovePayment).toHaveBeenCalledWith("payment-1");
-    expect(
-      onPaymentsExpandedChange.mock.invocationCallOrder[0],
-    ).toBeLessThan(onRemovePayment.mock.invocationCallOrder[0]);
+    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeLessThan(
+      onRemovePayment.mock.invocationCallOrder[0],
+    );
   });
 
   it("collapses payment-summary state before clearing all payments", async () => {
@@ -567,9 +641,9 @@ describe("OrderSummary completed transaction summary", () => {
 
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onClearPayments).toHaveBeenCalled();
-    expect(
-      onPaymentsExpandedChange.mock.invocationCallOrder[0],
-    ).toBeLessThan(onClearPayments.mock.invocationCallOrder[0]);
+    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeLessThan(
+      onClearPayments.mock.invocationCallOrder[0],
+    );
   });
 
   it("reports payment edit mode synchronously when editing starts and ends", async () => {
@@ -669,9 +743,9 @@ describe("OrderSummary completed transaction summary", () => {
 
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onEditingPaymentChange).toHaveBeenCalledWith(false);
-    expect(
-      onPaymentsExpandedChange.mock.invocationCallOrder[0],
-    ).toBeLessThan(onEditingPaymentChange.mock.invocationCallOrder[0]);
+    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeLessThan(
+      onEditingPaymentChange.mock.invocationCallOrder[0],
+    );
   });
 
   it("collapses expanded payments before saving an edit that leaves the sale fully paid", async () => {
@@ -718,9 +792,9 @@ describe("OrderSummary completed transaction summary", () => {
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onUpdatePayment).toHaveBeenCalledWith("payment-1", 1700);
     expect(onEditingPaymentChange).toHaveBeenCalledWith(false);
-    expect(
-      onPaymentsExpandedChange.mock.invocationCallOrder[0],
-    ).toBeLessThan(onUpdatePayment.mock.invocationCallOrder[0]);
+    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeLessThan(
+      onUpdatePayment.mock.invocationCallOrder[0],
+    );
     expect(onUpdatePayment.mock.invocationCallOrder[0]).toBeLessThan(
       onEditingPaymentChange.mock.invocationCallOrder[0],
     );

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -17,6 +17,7 @@ import {
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { usePrint } from "~/src/hooks/usePrint";
 import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 import { capitalizeWords, cn } from "~/src/lib/utils";
 import config from "~/src/config";
 import PosReceiptEmail from "~/convex/emails/PosReceiptEmail";
@@ -25,6 +26,43 @@ import { currencyFormatter } from "~/shared/currencyFormatter";
 import { PaymentView, type SelectedPaymentMethod } from "./PaymentView";
 import { PaymentsAddedList } from "./PaymentsAddedList";
 import type { CartItem, Payment } from "./types";
+
+function formatReceiptWebsite(url: string) {
+  return url.replace(/^https?:\/\//, (protocol) =>
+    protocol === "https://" ? "www." : "",
+  );
+}
+
+function parseReceiptLocation(location?: string) {
+  const parts =
+    location
+      ?.split(",")
+      .map((part) => part.trim())
+      .filter(Boolean) ?? [];
+
+  if (parts.length === 0) {
+    return {};
+  }
+
+  const [street, city, third, fourth, ...rest] = parts;
+
+  if (parts.length === 4) {
+    return {
+      street,
+      city,
+      state: third,
+      country: fourth,
+    };
+  }
+
+  return {
+    street,
+    city,
+    state: third,
+    zipCode: fourth,
+    country: rest.join(", ") || undefined,
+  };
+}
 
 interface OrderSummaryProps {
   cartItems: CartItem[];
@@ -376,9 +414,10 @@ export function OrderSummary({
             )
           : undefined;
 
-      const storeContact = activeStore.config?.contactInfo;
-      const [street, city, addressState, zipCode, country] =
-        storeContact?.location?.split(",") || [];
+      const storeContact = getStoreConfigV2(activeStore).contact;
+      const { street, city, state, zipCode, country } = parseReceiptLocation(
+        storeContact.location,
+      );
 
       const receiptHTML = await render(
         <PosReceiptEmail
@@ -392,11 +431,11 @@ export function OrderSummary({
               ? {
                   street,
                   city,
-                  state: addressState,
+                  state,
                   zipCode,
                   country,
                   phone: storeContact?.phoneNumber,
-                  website: config.storeFrontUrl.replace("https://", "wwww."),
+                  website: formatReceiptWebsite(config.storeFrontUrl),
                 }
               : undefined
           }

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -14,7 +14,10 @@ import { Product } from "./types";
 import { usePOSQuickAddProductSku } from "@/hooks/usePOSProducts";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { currencyFormatter } from "~/convex/utils";
-import { extractBarcodeFromInput, isUrlOrBarcode } from "@/lib/pos/barcodeUtils";
+import {
+  extractBarcodeFromInput,
+  isUrlOrBarcode,
+} from "@/lib/pos/barcodeUtils";
 import {
   forwardRef,
   useCallback,
@@ -45,6 +48,7 @@ interface ProductEntryProps extends ProductSearchInputProps {
   searchResults: Product[];
   isSearchLoading: boolean;
   isSearchReady: boolean;
+  canQuickAddProduct?: boolean;
   showSearchInput?: boolean;
   containerClassName?: string;
   lookupPanelClassName?: string;
@@ -183,6 +187,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       searchResults,
       isSearchLoading,
       isSearchReady,
+      canQuickAddProduct = false,
       showSearchInput = true,
       containerClassName,
       lookupPanelClassName,
@@ -232,6 +237,10 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
 
     const isAddingVariant = Boolean(quickAddSourceProduct?.productId);
     const handleOpenQuickAdd = (selectedProduct?: Product) => {
+      if (!canQuickAddProduct) {
+        return;
+      }
+
       const rawQuery = productSearchQuery.trim();
       const extractedQuery = extractBarcodeFromInput(rawQuery).value.trim();
       const lookupCode = isLikelyBarcode(extractedQuery)
@@ -382,7 +391,9 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
                 formatter={formatter}
                 onClearSearch={handleClearSearch}
                 onQuickAddProduct={
-                  isSearchReady ? handleOpenQuickAdd : undefined
+                  isSearchReady && canQuickAddProduct
+                    ? handleOpenQuickAdd
+                    : undefined
                 }
                 quickAddQuery={isSearchReady ? productSearchQuery : ""}
                 quickAddShortcutDisabled={isQuickAddOpen}

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.tsx
@@ -19,6 +19,8 @@ interface SearchResultsSectionProps {
 }
 
 const SEARCH_RESULTS_LOADING_ROWS = 4;
+const searchResultsViewportClassName =
+  "max-h-[586px] space-y-1 overflow-y-auto scrollbar-hide";
 
 function SearchResultsLoadingSkeleton() {
   return (
@@ -134,7 +136,7 @@ export function SearchResultsSection({
 
   if (isLoading) {
     return (
-      <div className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}>
+      <div className={cn(searchResultsViewportClassName, className)}>
         <span className="sr-only">Searching products…</span>
         <SearchResultsLoadingSkeleton />
       </div>
@@ -143,7 +145,7 @@ export function SearchResultsSection({
 
   if (products.length === 0) {
     return (
-      <div className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}>
+      <div className={cn(searchResultsViewportClassName, className)}>
         <div className="flex h-full flex-col items-center justify-center py-8 text-center text-gray-500">
           <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-3">
             <Search className="w-6 h-6 text-gray-400" />
@@ -176,7 +178,7 @@ export function SearchResultsSection({
   }
 
   return (
-    <div className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}>
+    <div className={cn(searchResultsViewportClassName, className)}>
       <div className="space-y-8 py-8">
         {products.map((product: Product) => (
           <ProductCard

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -633,6 +633,9 @@ export function POSRegisterView({
                       searchResults={viewModel.productEntry.searchResults}
                       isSearchLoading={viewModel.productEntry.isSearchLoading}
                       isSearchReady={viewModel.productEntry.isSearchReady}
+                      canQuickAddProduct={
+                        viewModel.productEntry.canQuickAddProduct
+                      }
                       showSearchInput={false}
                       containerClassName="h-full min-h-0"
                       lookupPanelClassName="flex h-full min-h-0 flex-col overflow-hidden"

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -584,6 +584,7 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
       searchResults: entrySearchResults,
       isSearchLoading: isProductEntrySearchLoading,
       isSearchReady: true,
+      canQuickAddProduct: false,
     },
     cart: {
       items: store.cart.items,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -42,6 +42,7 @@ export interface RegisterProductEntryState {
   searchResults: Product[];
   isSearchLoading: boolean;
   isSearchReady: boolean;
+  canQuickAddProduct: boolean;
 }
 
 export interface RegisterCartState {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -468,6 +468,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.sessionPanel?.canClearSale).toBe(true);
     expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
     expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
+    expect(result.current.productEntry.canQuickAddProduct).toBe(true);
     expect(result.current.authDialog?.open).toBe(false);
   });
 
@@ -1580,6 +1581,7 @@ describe("useRegisterViewModel", () => {
       result.current.closeoutControl?.canShowOpeningFloatCorrection,
     ).toBe(false);
     expect(result.current.closeoutControl?.canCorrectOpeningFloat).toBe(false);
+    expect(result.current.productEntry.canQuickAddProduct).toBe(false);
   });
 
   it("binds a preserved active POS session after drawer recovery without clearing checkout state", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -2337,6 +2337,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       searchResults: registerSearchProducts,
       isSearchLoading: isRegisterSearchLoading,
       isSearchReady: isRegisterCatalogReady,
+      canQuickAddProduct: isCashierManager,
     },
     cart: {
       items: activeCartItems,


### PR DESCRIPTION
## Summary
- Fix POS printed receipt headers to read grouped store config contact fields, normalize location text, and format storefront URLs consistently.
- Thread manager-only quick-add visibility through register presentation state while keeping expense register quick-add disabled.
- Hide the POS search results vertical scrollbar using the existing utility and refresh graphify artifacts.

## Validation
- `bun run --filter '@athena/webapp' test -- src/components/pos/OrderSummary.test.tsx src/components/pos/SearchResultsSection.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- `git diff --check`
- `bun run pre-push:review`
- normal `git push` pre-push hook rerun