### PR TITLE
fix(stock-ops): account for POS holds in availability

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4362 nodes · 4071 edges · 1514 communities detected
+- 4365 nodes · 4076 edges · 1514 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1644,40 +1644,40 @@ Cohesion: 0.11
 Nodes (0):
 
 ### Community 23 - "Community 23"
+Cohesion: 0.2
+Nodes (15): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listInventorySnapshotWithCtx(), listProductSkusForStockAdjustmentScopeWithCtx() (+7 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.12
-Nodes (4): getInventoryItemDisplayName(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
-
 ### Community 25 - "Community 25"
+Cohesion: 0.13
+Nodes (6): formatInventoryNumber(), getInventoryItemDisplayName(), getSkuDetailEntries(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
+
+### Community 26 - "Community 26"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.24
 Nodes (15): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired(), readActiveInventoryHoldDetailsForSession() (+7 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.13
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
-
-### Community 31 - "Community 31"
-Cohesion: 0.23
-Nodes (13): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listProductSkusForStockAdjustmentScopeWithCtx(), mapSubmitStockAdjustmentBatchError() (+5 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.27
@@ -2032,16 +2032,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 120 - "Community 120"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 121 - "Community 121"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 122 - "Community 122"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 123 - "Community 123"
 Cohesion: 0.48
@@ -2264,20 +2264,20 @@ Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 179 - "Community 179"
 Cohesion: 0.6
-Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 180 - "Community 180"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.6
+Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 181 - "Community 181"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.4
@@ -2296,16 +2296,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 186 - "Community 186"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.5
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 188 - "Community 188"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.4
@@ -2317,23 +2317,23 @@ Nodes (0):
 
 ### Community 191 - "Community 191"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 192 - "Community 192"
+Cohesion: 0.4
+Nodes (1): Header()
+
+### Community 193 - "Community 193"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 195 - "Community 195"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 196 - "Community 196"
 Cohesion: 0.4
@@ -2352,32 +2352,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 201 - "Community 201"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 204 - "Community 204"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 205 - "Community 205"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 206 - "Community 206"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.4
@@ -2388,56 +2388,56 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 209 - "Community 209"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 210 - "Community 210"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 211 - "Community 211"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 214 - "Community 214"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 216 - "Community 216"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 217 - "Community 217"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
-
-### Community 221 - "Community 221"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.5
@@ -2448,12 +2448,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 224 - "Community 224"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 225 - "Community 225"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 225 - "Community 225"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.5
@@ -2464,64 +2464,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 228 - "Community 228"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 229 - "Community 229"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 235 - "Community 235"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 237 - "Community 237"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 238 - "Community 238"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 241 - "Community 241"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 242 - "Community 242"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11,8 +11,20 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentsourceid",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L217",
+      "source_location": "L223",
       "target": "adjustments_applystockadjustmentbatchwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "adjustments_listinventorysnapshotwithctx",
+      "_tgt": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L410",
+      "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
     {
@@ -23,7 +35,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L308",
+      "source_location": "L314",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -35,7 +47,7 @@
       "relation": "calls",
       "source": "adjustments_buildresolvedstockadjustmentstatus",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L321",
+      "source_location": "L327",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -47,7 +59,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentdecisioneventtype",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L338",
+      "source_location": "L344",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -59,7 +71,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L351",
+      "source_location": "L357",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -71,7 +83,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L348",
+      "source_location": "L354",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -83,7 +95,7 @@
       "relation": "calls",
       "source": "adjustments_mapsubmitstockadjustmentbatcherror",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L795",
+      "source_location": "L851",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -95,7 +107,7 @@
       "relation": "calls",
       "source": "adjustments_submitstockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L793",
+      "source_location": "L849",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -107,7 +119,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L694",
+      "source_location": "L750",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -119,7 +131,7 @@
       "relation": "calls",
       "source": "adjustments_assertdistinctstockadjustmentlineitems",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L554",
+      "source_location": "L610",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -131,7 +143,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L650",
+      "source_location": "L706",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -143,7 +155,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L542",
+      "source_location": "L598",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -155,7 +167,7 @@
       "relation": "calls",
       "source": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L487",
+      "source_location": "L543",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -16811,8 +16823,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L32",
+      "source_location": "L173",
       "target": "adjustments_test_createapprovaldecisionmutationctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "_tgt": "adjustments_test_createinventorysnapshotqueryctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L33",
+      "target": "adjustments_test_createinventorysnapshotqueryctx",
       "weight": 1
     },
     {
@@ -16823,7 +16847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L177",
+      "source_location": "L318",
       "target": "adjustments_test_createsubmissionmutationctx",
       "weight": 1
     },
@@ -16835,7 +16859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L28",
+      "source_location": "L29",
       "target": "adjustments_test_getsource",
       "weight": 1
     },
@@ -16847,7 +16871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L204",
+      "source_location": "L210",
       "target": "adjustments_applystockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -16859,7 +16883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L128",
+      "source_location": "L134",
       "target": "adjustments_assertdistinctstockadjustmentlineitems",
       "weight": 1
     },
@@ -16871,7 +16895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L158",
+      "source_location": "L164",
       "target": "adjustments_assertnormalizedlineitem",
       "weight": 1
     },
@@ -16883,7 +16907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L262",
+      "source_location": "L268",
       "target": "adjustments_buildresolvedstockadjustmentstatus",
       "weight": 1
     },
@@ -16895,7 +16919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L252",
+      "source_location": "L258",
       "target": "adjustments_buildstockadjustmentdecisioneventtype",
       "weight": 1
     },
@@ -16907,7 +16931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L144",
+      "source_location": "L150",
       "target": "adjustments_buildstockadjustmentsourceid",
       "weight": 1
     },
@@ -16919,7 +16943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L148",
+      "source_location": "L154",
       "target": "adjustments_buildstockadjustmenttitle",
       "weight": 1
     },
@@ -16931,8 +16955,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L71",
+      "source_location": "L77",
       "target": "adjustments_getstockadjustmentscopekey",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "_tgt": "adjustments_listinventorysnapshotwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L397",
+      "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
     {
@@ -16943,7 +16979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L75",
+      "source_location": "L81",
       "target": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "weight": 1
     },
@@ -16955,8 +16991,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L735",
+      "source_location": "L791",
       "target": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "_tgt": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L368",
+      "target": "adjustments_readactiveheldquantitiesforstockopssnapshot",
       "weight": 1
     },
     {
@@ -16967,7 +17015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L268",
+      "source_location": "L274",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -16979,7 +17027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L788",
+      "source_location": "L844",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -16991,7 +17039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L538",
+      "source_location": "L594",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -17003,7 +17051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L457",
+      "source_location": "L513",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -17015,7 +17063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L66",
+      "source_location": "L72",
       "target": "adjustments_trimoptional",
       "weight": 1
     },
@@ -21827,7 +21875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49",
+      "source_location": "L50",
       "target": "pageheader_simplepageheader",
       "weight": 1
     },
@@ -21839,7 +21887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66",
+      "source_location": "L67",
       "target": "pageheader_viewheader",
       "weight": 1
     },
@@ -22559,7 +22607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L212",
+      "source_location": "L214",
       "target": "stockadjustmentworkspace_buildcyclecountdrafts",
       "weight": 1
     },
@@ -22571,7 +22619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L208",
+      "source_location": "L210",
       "target": "stockadjustmentworkspace_buildmanualdrafts",
       "weight": 1
     },
@@ -22583,7 +22631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L228",
+      "source_location": "L230",
       "target": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
       "weight": 1
     },
@@ -22595,7 +22643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L243",
+      "source_location": "L245",
       "target": "stockadjustmentworkspace_formatinventorynumber",
       "weight": 1
     },
@@ -22607,7 +22655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L200",
+      "source_location": "L202",
       "target": "stockadjustmentworkspace_getcountscopekey",
       "weight": 1
     },
@@ -22619,7 +22667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L204",
+      "source_location": "L206",
       "target": "stockadjustmentworkspace_getcountscopelabel",
       "weight": 1
     },
@@ -22631,7 +22679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L247",
+      "source_location": "L249",
       "target": "stockadjustmentworkspace_getinventoryitemdisplayname",
       "weight": 1
     },
@@ -22643,7 +22691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L251",
+      "source_location": "L253",
       "target": "stockadjustmentworkspace_getskudetailentries",
       "weight": 1
     },
@@ -22655,7 +22703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L958",
+      "source_location": "L984",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -22667,7 +22715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L268",
+      "source_location": "L278",
       "target": "stockadjustmentworkspace_normalizestockadjustmentsearch",
       "weight": 1
     },
@@ -22679,7 +22727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L272",
+      "source_location": "L282",
       "target": "stockadjustmentworkspace_parsecountscopekeys",
       "weight": 1
     },
@@ -22691,7 +22739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L239",
+      "source_location": "L241",
       "target": "stockadjustmentworkspace_pluralize",
       "weight": 1
     },
@@ -22703,7 +22751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L309",
+      "source_location": "L319",
       "target": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
       "weight": 1
     },
@@ -22715,7 +22763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L285",
+      "source_location": "L295",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -22727,7 +22775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L281",
+      "source_location": "L291",
       "target": "stockadjustmentworkspace_serializecountscopekeys",
       "weight": 1
     },
@@ -22739,7 +22787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L948",
+      "source_location": "L974",
       "target": "stockadjustmentworkspace_setdraftvalue",
       "weight": 1
     },
@@ -22751,7 +22799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L234",
+      "source_location": "L236",
       "target": "stockadjustmentworkspace_trimoptional",
       "weight": 1
     },
@@ -24539,7 +24587,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L198",
+      "source_location": "L199",
       "target": "possessionsview_formatexpiry",
       "weight": 1
     },
@@ -24551,7 +24599,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L224",
+      "source_location": "L225",
       "target": "possessionsview_formatholddetails",
       "weight": 1
     },
@@ -24563,7 +24611,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L155",
+      "source_location": "L156",
       "target": "possessionsview_formatregisterlabel",
       "weight": 1
     },
@@ -24575,7 +24623,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L126",
+      "source_location": "L127",
       "target": "possessionsview_formatstatuslabel",
       "weight": 1
     },
@@ -24587,7 +24635,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L188",
+      "source_location": "L189",
       "target": "possessionsview_getcartcount",
       "weight": 1
     },
@@ -24599,7 +24647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L184",
+      "source_location": "L185",
       "target": "possessionsview_getcustomerlabel",
       "weight": 1
     },
@@ -24611,7 +24659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L146",
+      "source_location": "L147",
       "target": "possessionsview_getoperatorlabel",
       "weight": 1
     },
@@ -24623,7 +24671,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L165",
+      "source_location": "L166",
       "target": "possessionsview_getregisterlabel",
       "weight": 1
     },
@@ -24635,7 +24683,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L135",
+      "source_location": "L136",
       "target": "possessionsview_getsessioncode",
       "weight": 1
     },
@@ -24647,7 +24695,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L142",
+      "source_location": "L143",
       "target": "possessionsview_getsessionid",
       "weight": 1
     },
@@ -24659,7 +24707,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L118",
+      "source_location": "L119",
       "target": "possessionsview_getsessions",
       "weight": 1
     },
@@ -24671,7 +24719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L258",
+      "source_location": "L259",
       "target": "possessionsview_getstatusbadgeclass",
       "weight": 1
     },
@@ -38591,7 +38639,7 @@
       "relation": "calls",
       "source": "possessionsview_formatregisterlabel",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L173",
+      "source_location": "L174",
       "target": "possessionsview_getregisterlabel",
       "weight": 1
     },
@@ -46792,6 +46840,18 @@
       "weight": 1
     },
     {
+      "_src": "stockadjustmentworkspace_getskudetailentries",
+      "_tgt": "stockadjustmentworkspace_formatinventorynumber",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "stockadjustmentworkspace_formatinventorynumber",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L269",
+      "target": "stockadjustmentworkspace_getskudetailentries",
+      "weight": 1
+    },
+    {
       "_src": "stockadjustmentworkspace_handledraftchange",
       "_tgt": "stockadjustmentworkspace_setdraftvalue",
       "confidence": "EXTRACTED",
@@ -46799,7 +46859,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_setdraftvalue",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L959",
+      "source_location": "L985",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -46811,7 +46871,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_getinventoryitemdisplayname",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L293",
+      "source_location": "L303",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -53352,65 +53412,65 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1200,
@@ -53505,65 +53565,65 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1210,
@@ -53658,65 +53718,65 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1220,
@@ -60165,6 +60225,51 @@
     {
       "community": 178,
       "file_type": "code",
+      "id": "adjustments_test_createapprovaldecisionmutationctx",
+      "label": "createApprovalDecisionMutationCtx()",
+      "norm_label": "createapprovaldecisionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "adjustments_test_createinventorysnapshotqueryctx",
+      "label": "createInventorySnapshotQueryCtx()",
+      "norm_label": "createinventorysnapshotqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "adjustments_test_createsubmissionmutationctx",
+      "label": "createSubmissionMutationCtx()",
+      "norm_label": "createsubmissionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "adjustments_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "label": "adjustments.test.ts",
+      "norm_label": "adjustments.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
       "norm_label": "returnexchangeoperations.ts",
@@ -60172,7 +60277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -60181,7 +60286,7 @@
       "source_location": "L115"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -60190,7 +60295,7 @@
       "source_location": "L90"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -60199,58 +60304,13 @@
       "source_location": "L74"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
       "norm_label": "getlinerefundamount()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
       "source_location": "L70"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
     },
     {
       "community": 18,
@@ -60426,6 +60486,51 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
       "norm_label": "storefrontobservabilityreport.ts",
@@ -60433,7 +60538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -60442,7 +60547,7 @@
       "source_location": "L124"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -60451,7 +60556,7 @@
       "source_location": "L67"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -60460,7 +60565,7 @@
       "source_location": "L106"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -60469,7 +60574,7 @@
       "source_location": "L73"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -60478,7 +60583,7 @@
       "source_location": "L61"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -60487,7 +60592,7 @@
       "source_location": "L75"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -60496,7 +60601,7 @@
       "source_location": "L116"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -60505,7 +60610,7 @@
       "source_location": "L20"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -60514,7 +60619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -60523,7 +60628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -60532,7 +60637,7 @@
       "source_location": "L287"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -60541,7 +60646,7 @@
       "source_location": "L203"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -60550,7 +60655,7 @@
       "source_location": "L243"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -60559,7 +60664,7 @@
       "source_location": "L230"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -60568,7 +60673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -60577,7 +60682,7 @@
       "source_location": "L30"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -60586,25 +60691,25 @@
       "source_location": "L8"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
       "norm_label": "simplepageheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49"
+      "source_location": "L50"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
       "norm_label": "viewheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66"
+      "source_location": "L67"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -60613,7 +60718,7 @@
       "source_location": "L20"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -60622,7 +60727,7 @@
       "source_location": "L50"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -60631,7 +60736,7 @@
       "source_location": "L342"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -60640,7 +60745,7 @@
       "source_location": "L322"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -60649,7 +60754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -60658,7 +60763,7 @@
       "source_location": "L61"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -60667,7 +60772,7 @@
       "source_location": "L57"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -60676,7 +60781,7 @@
       "source_location": "L98"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -60685,7 +60790,7 @@
       "source_location": "L134"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -60694,7 +60799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -60703,7 +60808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -60712,7 +60817,7 @@
       "source_location": "L38"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -60721,7 +60826,7 @@
       "source_location": "L64"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -60730,7 +60835,7 @@
       "source_location": "L135"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -60739,7 +60844,7 @@
       "source_location": "L43"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "operationsqueueview_getapprovalrequestcopy",
       "label": "getApprovalRequestCopy()",
@@ -60748,7 +60853,7 @@
       "source_location": "L63"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "operationsqueueview_getdefaultworkflow",
       "label": "getDefaultWorkflow()",
@@ -60757,7 +60862,7 @@
       "source_location": "L54"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "operationsqueueview_if",
       "label": "if()",
@@ -60766,7 +60871,7 @@
       "source_location": "L579"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "operationsqueueview_setdecisioningapprovalrequestid",
       "label": "setDecisioningApprovalRequestId()",
@@ -60775,7 +60880,7 @@
       "source_location": "L638"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -60784,7 +60889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -60793,7 +60898,7 @@
       "source_location": "L58"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -60802,7 +60907,7 @@
       "source_location": "L63"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -60811,7 +60916,7 @@
       "source_location": "L50"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -60820,57 +60925,12 @@
       "source_location": "L53"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
       "norm_label": "activityview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1"
     },
     {
@@ -61047,6 +61107,51 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
       "norm_label": "handlerequestfeedback()",
@@ -61054,7 +61159,7 @@
       "source_location": "L92"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -61063,7 +61168,7 @@
       "source_location": "L307"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -61072,7 +61177,7 @@
       "source_location": "L70"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -61081,7 +61186,7 @@
       "source_location": "L50"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -61090,7 +61195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
@@ -61099,7 +61204,7 @@
       "source_location": "L30"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -61108,7 +61213,7 @@
       "source_location": "L43"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -61117,7 +61222,7 @@
       "source_location": "L106"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -61126,7 +61231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -61135,7 +61240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -61144,7 +61249,7 @@
       "source_location": "L40"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -61153,7 +61258,7 @@
       "source_location": "L57"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -61162,7 +61267,7 @@
       "source_location": "L66"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -61171,7 +61276,7 @@
       "source_location": "L36"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -61180,7 +61285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -61189,7 +61294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -61198,7 +61303,7 @@
       "source_location": "L27"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -61207,7 +61312,7 @@
       "source_location": "L18"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -61216,7 +61321,7 @@
       "source_location": "L40"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -61225,7 +61330,7 @@
       "source_location": "L14"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -61234,7 +61339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -61243,7 +61348,7 @@
       "source_location": "L234"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -61252,7 +61357,7 @@
       "source_location": "L239"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -61261,7 +61366,7 @@
       "source_location": "L272"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -61270,7 +61375,7 @@
       "source_location": "L263"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -61279,7 +61384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -61288,7 +61393,7 @@
       "source_location": "L80"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -61297,7 +61402,7 @@
       "source_location": "L84"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -61306,7 +61411,7 @@
       "source_location": "L73"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -61315,7 +61420,7 @@
       "source_location": "L61"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -61324,7 +61429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -61333,7 +61438,7 @@
       "source_location": "L37"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -61342,7 +61447,7 @@
       "source_location": "L46"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -61351,7 +61456,7 @@
       "source_location": "L33"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -61360,7 +61465,7 @@
       "source_location": "L72"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -61369,7 +61474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -61378,7 +61483,7 @@
       "source_location": "L157"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -61387,7 +61492,7 @@
       "source_location": "L230"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -61396,7 +61501,7 @@
       "source_location": "L322"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -61405,7 +61510,7 @@
       "source_location": "L377"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -61414,7 +61519,7 @@
       "source_location": "L99"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -61423,7 +61528,7 @@
       "source_location": "L53"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -61432,7 +61537,7 @@
       "source_location": "L75"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -61441,57 +61546,12 @@
       "source_location": "L63"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
       "norm_label": "date-time-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "custom_modal_example_basicmodalexample",
-      "label": "BasicModalExample()",
-      "norm_label": "basicmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "custom_modal_example_customclosebuttonexample",
-      "label": "CustomCloseButtonExample()",
-      "norm_label": "customclosebuttonexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "custom_modal_example_custompositionmodalexample",
-      "label": "CustomPositionModalExample()",
-      "norm_label": "custompositionmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "custom_modal_example_fullscreenmodalexample",
-      "label": "FullScreenModalExample()",
-      "norm_label": "fullscreenmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L103"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "label": "custom-modal-example.tsx",
-      "norm_label": "custom-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1"
     },
     {
@@ -61965,6 +62025,51 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "custom_modal_example_basicmodalexample",
+      "label": "BasicModalExample()",
+      "norm_label": "basicmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "custom_modal_example_customclosebuttonexample",
+      "label": "CustomCloseButtonExample()",
+      "norm_label": "customclosebuttonexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "custom_modal_example_custompositionmodalexample",
+      "label": "CustomPositionModalExample()",
+      "norm_label": "custompositionmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "custom_modal_example_fullscreenmodalexample",
+      "label": "FullScreenModalExample()",
+      "norm_label": "fullscreenmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L103"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
+      "label": "custom-modal-example.tsx",
+      "norm_label": "custom-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
       "norm_label": "getruntimeorigin()",
@@ -61972,7 +62077,7 @@
       "source_location": "L12"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -61981,7 +62086,7 @@
       "source_location": "L20"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -61990,7 +62095,7 @@
       "source_location": "L24"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -61999,7 +62104,7 @@
       "source_location": "L8"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -62008,7 +62113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -62017,7 +62122,7 @@
       "source_location": "L18"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -62026,7 +62131,7 @@
       "source_location": "L23"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -62035,7 +62140,7 @@
       "source_location": "L65"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -62044,7 +62149,7 @@
       "source_location": "L45"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -62053,7 +62158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -62062,7 +62167,7 @@
       "source_location": "L78"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -62071,7 +62176,7 @@
       "source_location": "L74"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -62080,7 +62185,7 @@
       "source_location": "L103"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -62089,7 +62194,7 @@
       "source_location": "L109"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -62098,7 +62203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -62107,7 +62212,7 @@
       "source_location": "L75"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -62116,7 +62221,7 @@
       "source_location": "L26"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -62125,7 +62230,7 @@
       "source_location": "L38"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -62134,7 +62239,7 @@
       "source_location": "L4"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -62143,7 +62248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -62152,7 +62257,7 @@
       "source_location": "L3"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -62161,7 +62266,7 @@
       "source_location": "L29"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -62170,7 +62275,7 @@
       "source_location": "L33"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -62179,7 +62284,7 @@
       "source_location": "L40"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -62188,7 +62293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -62197,7 +62302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -62206,7 +62311,7 @@
       "source_location": "L12"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -62215,7 +62320,7 @@
       "source_location": "L30"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -62224,7 +62329,7 @@
       "source_location": "L36"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -62233,7 +62338,7 @@
       "source_location": "L58"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -62242,7 +62347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -62251,7 +62356,7 @@
       "source_location": "L42"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -62260,7 +62365,7 @@
       "source_location": "L29"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -62269,7 +62374,7 @@
       "source_location": "L49"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -62278,7 +62383,7 @@
       "source_location": "L14"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -62287,7 +62392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -62296,7 +62401,7 @@
       "source_location": "L184"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -62305,7 +62410,7 @@
       "source_location": "L200"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -62314,7 +62419,7 @@
       "source_location": "L244"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -62323,7 +62428,7 @@
       "source_location": "L206"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -62332,7 +62437,7 @@
       "source_location": "L29"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -62341,7 +62446,7 @@
       "source_location": "L99"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "authed_topbar",
       "label": "TopBar()",
@@ -62350,7 +62455,7 @@
       "source_location": "L74"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "authed_usermenu",
       "label": "UserMenu()",
@@ -62359,57 +62464,12 @@
       "source_location": "L39"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
       "norm_label": "_authed.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "layout_completependingauthsync",
-      "label": "completePendingAuthSync()",
-      "norm_label": "completependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "layout_handlependingauthsync",
-      "label": "handlePendingAuthSync()",
-      "norm_label": "handlependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "layout_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "layout_usedocumentscrolllock",
-      "label": "useDocumentScrollLock()",
-      "norm_label": "usedocumentscrolllock()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L1"
     },
     {
@@ -62577,6 +62637,51 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "layout_completependingauthsync",
+      "label": "completePendingAuthSync()",
+      "norm_label": "completependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "layout_handlependingauthsync",
+      "label": "handlePendingAuthSync()",
+      "norm_label": "handlependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "layout_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "layout_usedocumentscrolllock",
+      "label": "useDocumentScrollLock()",
+      "norm_label": "usedocumentscrolllock()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
       "norm_label": "getproductviewcount()",
@@ -62584,7 +62689,7 @@
       "source_location": "L93"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -62593,7 +62698,7 @@
       "source_location": "L75"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -62602,7 +62707,7 @@
       "source_location": "L4"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -62611,7 +62716,7 @@
       "source_location": "L47"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -62620,7 +62725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -62629,7 +62734,7 @@
       "source_location": "L11"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -62638,7 +62743,7 @@
       "source_location": "L25"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -62647,7 +62752,7 @@
       "source_location": "L9"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -62656,7 +62761,7 @@
       "source_location": "L39"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -62665,7 +62770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -62674,7 +62779,7 @@
       "source_location": "L4"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -62683,7 +62788,7 @@
       "source_location": "L24"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -62692,7 +62797,7 @@
       "source_location": "L6"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -62701,7 +62806,7 @@
       "source_location": "L42"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -62710,7 +62815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -62719,7 +62824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -62728,7 +62833,7 @@
       "source_location": "L28"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -62737,7 +62842,7 @@
       "source_location": "L5"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -62746,7 +62851,7 @@
       "source_location": "L7"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -62755,7 +62860,7 @@
       "source_location": "L46"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -62764,7 +62869,7 @@
       "source_location": "L147"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -62773,7 +62878,7 @@
       "source_location": "L186"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -62782,7 +62887,7 @@
       "source_location": "L115"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -62791,7 +62896,7 @@
       "source_location": "L31"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -62800,7 +62905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -62809,7 +62914,7 @@
       "source_location": "L14"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -62818,7 +62923,7 @@
       "source_location": "L22"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -62827,7 +62932,7 @@
       "source_location": "L30"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -62836,7 +62941,7 @@
       "source_location": "L3"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -62845,7 +62950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -62854,7 +62959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -62863,7 +62968,7 @@
       "source_location": "L136"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -62872,7 +62977,7 @@
       "source_location": "L154"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -62881,7 +62986,7 @@
       "source_location": "L25"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -62890,7 +62995,7 @@
       "source_location": "L47"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -62899,7 +63004,7 @@
       "source_location": "L52"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -62908,7 +63013,7 @@
       "source_location": "L22"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -62917,7 +63022,7 @@
       "source_location": "L44"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -62926,7 +63031,7 @@
       "source_location": "L16"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -62935,7 +63040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -62944,7 +63049,7 @@
       "source_location": "L46"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -62953,7 +63058,7 @@
       "source_location": "L38"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -62962,7 +63067,7 @@
       "source_location": "L28"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -62971,57 +63076,12 @@
       "source_location": "L32"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
       "norm_label": "harness-repo-validation.ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_withtemprepo",
-      "label": "withTempRepo()",
-      "norm_label": "withtemprepo()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
-      "label": "writeConvexApiFixture()",
-      "norm_label": "writeconvexapifixture()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
       "source_location": "L1"
     },
     {
@@ -63189,6 +63249,51 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_withtemprepo",
+      "label": "withTempRepo()",
+      "norm_label": "withtemprepo()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
+      "label": "writeConvexApiFixture()",
+      "norm_label": "writeconvexapifixture()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
       "norm_label": "worktree-manager.test.ts",
@@ -63196,7 +63301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -63205,7 +63310,7 @@
       "source_location": "L17"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -63214,7 +63319,7 @@
       "source_location": "L72"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -63223,7 +63328,7 @@
       "source_location": "L45"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -63232,7 +63337,7 @@
       "source_location": "L59"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -63241,7 +63346,7 @@
       "source_location": "L12"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -63250,7 +63355,7 @@
       "source_location": "L26"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -63259,7 +63364,7 @@
       "source_location": "L20"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -63268,7 +63373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -63277,7 +63382,7 @@
       "source_location": "L109"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -63286,7 +63391,7 @@
       "source_location": "L84"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -63295,7 +63400,7 @@
       "source_location": "L95"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -63304,7 +63409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -63313,7 +63418,7 @@
       "source_location": "L149"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -63322,7 +63427,7 @@
       "source_location": "L39"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -63331,7 +63436,7 @@
       "source_location": "L164"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -63340,7 +63445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -63349,7 +63454,7 @@
       "source_location": "L50"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -63358,7 +63463,7 @@
       "source_location": "L23"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -63367,7 +63472,7 @@
       "source_location": "L37"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -63376,7 +63481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -63385,7 +63490,7 @@
       "source_location": "L21"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -63394,7 +63499,7 @@
       "source_location": "L35"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -63403,7 +63508,7 @@
       "source_location": "L45"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -63412,7 +63517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -63421,7 +63526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -63430,7 +63535,7 @@
       "source_location": "L21"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -63439,7 +63544,7 @@
       "source_location": "L35"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -63448,7 +63553,7 @@
       "source_location": "L45"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -63457,7 +63562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -63466,7 +63571,7 @@
       "source_location": "L393"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -63475,7 +63580,7 @@
       "source_location": "L160"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -63484,7 +63589,7 @@
       "source_location": "L410"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -63493,7 +63598,7 @@
       "source_location": "L5"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -63502,7 +63607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -63511,7 +63616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -63520,7 +63625,169 @@
       "source_location": "L1"
     },
     {
-      "community": 229,
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_getstockadjustmentscopekey",
+      "label": "getStockAdjustmentScopeKey()",
+      "norm_label": "getstockadjustmentscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_listinventorysnapshotwithctx",
+      "label": "listInventorySnapshotWithCtx()",
+      "norm_label": "listinventorysnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L397"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
+      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
+      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L791"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L368"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L844"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L594"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
+      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
+      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L513"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -63529,7 +63796,7 @@
       "source_location": "L26"
     },
     {
-      "community": 229,
+      "community": 230,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -63538,7 +63805,7 @@
       "source_location": "L79"
     },
     {
-      "community": 229,
+      "community": 230,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -63547,7 +63814,7 @@
       "source_location": "L33"
     },
     {
-      "community": 229,
+      "community": 230,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -63556,169 +63823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_calculatepromocodevalue",
-      "label": "calculatePromoCodeValue()",
-      "norm_label": "calculatepromocodevalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_checkadjustedavailability",
-      "label": "checkAdjustedAvailability()",
-      "norm_label": "checkadjustedavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_checkifitemshavechanged",
-      "label": "checkIfItemsHaveChanged()",
-      "norm_label": "checkifitemshavechanged()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_createonlineorder",
-      "label": "createOnlineOrder()",
-      "norm_label": "createonlineorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_createpatchobject",
-      "label": "createPatchObject()",
-      "norm_label": "createpatchobject()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_createsessionitems",
-      "label": "createSessionItems()",
-      "norm_label": "createsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_fetchproductskus",
-      "label": "fetchProductSkus()",
-      "norm_label": "fetchproductskus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_findbestvaluepromocode",
-      "label": "findBestValuePromoCode()",
-      "norm_label": "findbestvaluepromocode()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_handleexistingsession",
-      "label": "handleExistingSession()",
-      "norm_label": "handleexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_handleordercreation",
-      "label": "handleOrderCreation()",
-      "norm_label": "handleordercreation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_handleplaceorder",
-      "label": "handlePlaceOrder()",
-      "norm_label": "handleplaceorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_retrieveactivecheckoutsession",
-      "label": "retrieveActiveCheckoutSession()",
-      "norm_label": "retrieveactivecheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_updateavailability",
-      "label": "updateAvailability()",
-      "norm_label": "updateavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_updateexistingsession",
-      "label": "updateExistingSession()",
-      "norm_label": "updateexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_updateproductavailability",
-      "label": "updateProductAvailability()",
-      "norm_label": "updateproductavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "checkoutsession_validateexistingdiscount",
-      "label": "validateExistingDiscount()",
-      "norm_label": "validateexistingdiscount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -63727,7 +63832,7 @@
       "source_location": "L10"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -63736,7 +63841,7 @@
       "source_location": "L18"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -63745,7 +63850,7 @@
       "source_location": "L52"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -63754,7 +63859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -63763,7 +63868,7 @@
       "source_location": "L98"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -63772,7 +63877,7 @@
       "source_location": "L56"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -63781,7 +63886,7 @@
       "source_location": "L49"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -63790,7 +63895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -63799,7 +63904,7 @@
       "source_location": "L28"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -63808,7 +63913,7 @@
       "source_location": "L42"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -63817,7 +63922,7 @@
       "source_location": "L73"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -63826,7 +63931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -63835,7 +63940,7 @@
       "source_location": "L8"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -63844,7 +63949,7 @@
       "source_location": "L32"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -63853,7 +63958,7 @@
       "source_location": "L64"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -63862,7 +63967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -63871,7 +63976,7 @@
       "source_location": "L18"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -63880,7 +63985,7 @@
       "source_location": "L25"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -63889,7 +63994,7 @@
       "source_location": "L11"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -63898,7 +64003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -63907,7 +64012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -63916,7 +64021,7 @@
       "source_location": "L33"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -63925,7 +64030,7 @@
       "source_location": "L19"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -63934,7 +64039,7 @@
       "source_location": "L42"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -63943,7 +64048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -63952,7 +64057,7 @@
       "source_location": "L31"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -63961,7 +64066,7 @@
       "source_location": "L48"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -63970,7 +64075,7 @@
       "source_location": "L131"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -63979,7 +64084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -63988,7 +64093,7 @@
       "source_location": "L37"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -63997,7 +64102,7 @@
       "source_location": "L24"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -64006,7 +64111,7 @@
       "source_location": "L19"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -64015,7 +64120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -64024,7 +64129,7 @@
       "source_location": "L31"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -64033,7 +64138,7 @@
       "source_location": "L26"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -64042,7 +64147,169 @@
       "source_location": "L53"
     },
     {
-      "community": 239,
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_calculatepromocodevalue",
+      "label": "calculatePromoCodeValue()",
+      "norm_label": "calculatepromocodevalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1447"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_checkadjustedavailability",
+      "label": "checkAdjustedAvailability()",
+      "norm_label": "checkadjustedavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L990"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_checkifitemshavechanged",
+      "label": "checkIfItemsHaveChanged()",
+      "norm_label": "checkifitemshavechanged()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_createonlineorder",
+      "label": "createOnlineOrder()",
+      "norm_label": "createonlineorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_createpatchobject",
+      "label": "createPatchObject()",
+      "norm_label": "createpatchobject()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L651"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_createsessionitems",
+      "label": "createSessionItems()",
+      "norm_label": "createsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1102"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_fetchproductskus",
+      "label": "fetchProductSkus()",
+      "norm_label": "fetchproductskus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L979"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_findbestvaluepromocode",
+      "label": "findBestValuePromoCode()",
+      "norm_label": "findbestvaluepromocode()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1495"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_handleexistingsession",
+      "label": "handleExistingSession()",
+      "norm_label": "handleexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1161"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_handleordercreation",
+      "label": "handleOrderCreation()",
+      "norm_label": "handleordercreation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L734"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_handleplaceorder",
+      "label": "handlePlaceOrder()",
+      "norm_label": "handleplaceorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L698"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_retrieveactivecheckoutsession",
+      "label": "retrieveActiveCheckoutSession()",
+      "norm_label": "retrieveactivecheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L951"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_updateavailability",
+      "label": "updateAvailability()",
+      "norm_label": "updateavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1140"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_updateexistingsession",
+      "label": "updateExistingSession()",
+      "norm_label": "updateexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1020"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_updateproductavailability",
+      "label": "updateProductAvailability()",
+      "norm_label": "updateproductavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1123"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "checkoutsession_validateexistingdiscount",
+      "label": "validateExistingDiscount()",
+      "norm_label": "validateexistingdiscount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1321"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -64051,7 +64318,7 @@
       "source_location": "L36"
     },
     {
-      "community": 239,
+      "community": 240,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -64060,7 +64327,7 @@
       "source_location": "L96"
     },
     {
-      "community": 239,
+      "community": 240,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -64069,7 +64336,7 @@
       "source_location": "L71"
     },
     {
-      "community": 239,
+      "community": 240,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -64078,169 +64345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 24,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L212"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopekey",
-      "label": "getCountScopeKey()",
-      "norm_label": "getcountscopekey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L200"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L204"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L247"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_getskudetailentries",
-      "label": "getSkuDetailEntries()",
-      "norm_label": "getskudetailentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L251"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L958"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
-      "label": "normalizeStockAdjustmentSearch()",
-      "norm_label": "normalizestockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L268"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_parsecountscopekeys",
-      "label": "parseCountScopeKeys()",
-      "norm_label": "parsecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L272"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L239"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L309"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "label": "rowMatchesStockAdjustmentSearch()",
-      "norm_label": "rowmatchesstockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L285"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_serializecountscopekeys",
-      "label": "serializeCountScopeKeys()",
-      "norm_label": "serializecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L281"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L948"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L234"
-    },
-    {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -64249,7 +64354,7 @@
       "source_location": "L21"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -64258,7 +64363,7 @@
       "source_location": "L42"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -64267,7 +64372,7 @@
       "source_location": "L80"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -64276,7 +64381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -64285,7 +64390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -64294,7 +64399,7 @@
       "source_location": "L122"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -64303,7 +64408,7 @@
       "source_location": "L34"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -64312,7 +64417,7 @@
       "source_location": "L72"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -64321,7 +64426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -64330,7 +64435,7 @@
       "source_location": "L159"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -64339,49 +64444,13 @@
       "source_location": "L56"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L177"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "adjustments_test_createapprovaldecisionmutationctx",
-      "label": "createApprovalDecisionMutationCtx()",
-      "norm_label": "createapprovaldecisionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "adjustments_test_createsubmissionmutationctx",
-      "label": "createSubmissionMutationCtx()",
-      "norm_label": "createsubmissionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "adjustments_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
-      "label": "adjustments.test.ts",
-      "norm_label": "adjustments.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 244,
@@ -64602,164 +64671,164 @@
     {
       "community": 25,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L214"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L210"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L245"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopekey",
+      "label": "getCountScopeKey()",
+      "norm_label": "getcountscopekey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L202"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L206"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L249"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L253"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L984"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "label": "normalizeStockAdjustmentSearch()",
+      "norm_label": "normalizestockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L278"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_parsecountscopekeys",
+      "label": "parseCountScopeKeys()",
+      "norm_label": "parsecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L241"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L319"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "label": "rowMatchesStockAdjustmentSearch()",
+      "norm_label": "rowmatchesstockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L295"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_serializecountscopekeys",
+      "label": "serializeCountScopeKeys()",
+      "norm_label": "serializecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L291"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L974"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L236"
     },
     {
       "community": 250,
@@ -65124,154 +65193,163 @@
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L140"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L319"
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L242"
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_consumeinventoryholdsforsession",
-      "label": "consumeInventoryHoldsForSession()",
-      "norm_label": "consumeinventoryholdsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L446"
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_getactiveholdforsessionsku",
-      "label": "getActiveHoldForSessionSku()",
-      "norm_label": "getactiveholdforsessionsku()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L580"
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_listactivesessionholds",
-      "label": "listActiveSessionHolds()",
-      "norm_label": "listactivesessionholds()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L609"
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_markholdexpired",
-      "label": "markHoldExpired()",
-      "norm_label": "markholdexpired()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L637"
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_readactiveinventoryholddetailsforsession",
-      "label": "readActiveInventoryHoldDetailsForSession()",
-      "norm_label": "readactiveinventoryholddetailsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L517"
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_readactiveinventoryholdquantitiesforsession",
-      "label": "readActiveInventoryHoldQuantitiesForSession()",
-      "norm_label": "readactiveinventoryholdquantitiesforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L490"
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_releaseactiveinventoryholdsforsession",
-      "label": "releaseActiveInventoryHoldsForSession()",
-      "norm_label": "releaseactiveinventoryholdsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L410"
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L191"
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L348"
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsforsession",
-      "label": "releaseInventoryHoldsForSession()",
-      "norm_label": "releaseinventoryholdsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L386"
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_restorelegacyquantitypatchhold",
-      "label": "restoreLegacyQuantityPatchHold()",
-      "norm_label": "restorelegacyquantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L649"
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_sumactiveheldquantity",
-      "label": "sumActiveHeldQuantity()",
-      "norm_label": "sumactiveheldquantity()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L547"
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L77"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
     },
     {
@@ -65637,154 +65715,154 @@
     {
       "community": 27,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L140"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L319"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L242"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_consumeinventoryholdsforsession",
+      "label": "consumeInventoryHoldsForSession()",
+      "norm_label": "consumeinventoryholdsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L446"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_getactiveholdforsessionsku",
+      "label": "getActiveHoldForSessionSku()",
+      "norm_label": "getactiveholdforsessionsku()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L580"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_listactivesessionholds",
+      "label": "listActiveSessionHolds()",
+      "norm_label": "listactivesessionholds()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L609"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_markholdexpired",
+      "label": "markHoldExpired()",
+      "norm_label": "markholdexpired()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L637"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_readactiveinventoryholddetailsforsession",
+      "label": "readActiveInventoryHoldDetailsForSession()",
+      "norm_label": "readactiveinventoryholddetailsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L517"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_readactiveinventoryholdquantitiesforsession",
+      "label": "readActiveInventoryHoldQuantitiesForSession()",
+      "norm_label": "readactiveinventoryholdquantitiesforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L490"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_releaseactiveinventoryholdsforsession",
+      "label": "releaseActiveInventoryHoldsForSession()",
+      "norm_label": "releaseactiveinventoryholdsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L410"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L191"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L348"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_releaseinventoryholdsforsession",
+      "label": "releaseInventoryHoldsForSession()",
+      "norm_label": "releaseinventoryholdsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L386"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_restorelegacyquantitypatchhold",
+      "label": "restoreLegacyQuantityPatchHold()",
+      "norm_label": "restorelegacyquantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L649"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_sumactiveheldquantity",
+      "label": "sumActiveHeldQuantity()",
+      "norm_label": "sumactiveheldquantity()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L547"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L77"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1"
     },
     {
@@ -66150,154 +66228,154 @@
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -66663,154 +66741,154 @@
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1"
     },
     {
@@ -67455,145 +67533,154 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_buildcashcontrolsdashboardsnapshot",
-      "label": "buildCashControlsDashboardSnapshot()",
-      "norm_label": "buildcashcontrolsdashboardsnapshot()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L226"
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_buildregistersessiondeposittargetid",
-      "label": "buildRegisterSessionDepositTargetId()",
-      "norm_label": "buildregistersessiondeposittargetid()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L186"
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_buildregistersessionsummary",
-      "label": "buildRegisterSessionSummary()",
-      "norm_label": "buildregistersessionsummary()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L193"
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_collectstaffprofileids",
-      "label": "collectStaffProfileIds()",
-      "norm_label": "collectstaffprofileids()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L372"
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_iscashcontroldepositallocation",
-      "label": "isCashControlDepositAllocation()",
-      "norm_label": "iscashcontroldepositallocation()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L142"
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_listregistersessionsfordashboard",
-      "label": "listRegisterSessionsForDashboard()",
-      "norm_label": "listregistersessionsfordashboard()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L290"
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_listregistersessiontimeline",
-      "label": "listRegisterSessionTimeline()",
-      "norm_label": "listregistersessiontimeline()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L346"
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_listregistersessiontransactions",
-      "label": "listRegisterSessionTransactions()",
-      "norm_label": "listregistersessiontransactions()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L359"
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_listsessiondeposits",
-      "label": "listSessionDeposits()",
-      "norm_label": "listsessiondeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L332"
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L152"
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_liststoredeposits",
-      "label": "listStoreDeposits()",
-      "norm_label": "liststoredeposits()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L318"
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_listterminalnames",
-      "label": "listTerminalNames()",
-      "norm_label": "listterminalnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L301"
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L120"
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_sumdepositsbysession",
-      "label": "sumDepositsBySession()",
-      "norm_label": "sumdepositsbysession()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L169"
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "deposits_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L115"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
-      "label": "deposits.ts",
-      "norm_label": "deposits.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1"
     },
     {
@@ -67869,145 +67956,145 @@
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L204"
+      "id": "deposits_buildcashcontrolsdashboardsnapshot",
+      "label": "buildCashControlsDashboardSnapshot()",
+      "norm_label": "buildcashcontrolsdashboardsnapshot()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L226"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L128"
+      "id": "deposits_buildregistersessiondeposittargetid",
+      "label": "buildRegisterSessionDepositTargetId()",
+      "norm_label": "buildregistersessiondeposittargetid()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L186"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L158"
+      "id": "deposits_buildregistersessionsummary",
+      "label": "buildRegisterSessionSummary()",
+      "norm_label": "buildregistersessionsummary()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L193"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L262"
+      "id": "deposits_collectstaffprofileids",
+      "label": "collectStaffProfileIds()",
+      "norm_label": "collectstaffprofileids()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L372"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L252"
+      "id": "deposits_iscashcontroldepositallocation",
+      "label": "isCashControlDepositAllocation()",
+      "norm_label": "iscashcontroldepositallocation()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L142"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L144"
+      "id": "deposits_listregistersessionsfordashboard",
+      "label": "listRegisterSessionsForDashboard()",
+      "norm_label": "listregistersessionsfordashboard()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L290"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L148"
+      "id": "deposits_listregistersessiontimeline",
+      "label": "listRegisterSessionTimeline()",
+      "norm_label": "listregistersessiontimeline()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L346"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_getstockadjustmentscopekey",
-      "label": "getStockAdjustmentScopeKey()",
-      "norm_label": "getstockadjustmentscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L71"
+      "id": "deposits_listregistersessiontransactions",
+      "label": "listRegisterSessionTransactions()",
+      "norm_label": "listregistersessiontransactions()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L359"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
-      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
-      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L75"
+      "id": "deposits_listsessiondeposits",
+      "label": "listSessionDeposits()",
+      "norm_label": "listsessiondeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L332"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L735"
+      "id": "deposits_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L152"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L268"
+      "id": "deposits_liststoredeposits",
+      "label": "listStoreDeposits()",
+      "norm_label": "liststoredeposits()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L318"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L788"
+      "id": "deposits_listterminalnames",
+      "label": "listTerminalNames()",
+      "norm_label": "listterminalnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L301"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L538"
+      "id": "deposits_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L120"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
-      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
-      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L457"
+      "id": "deposits_sumdepositsbysession",
+      "label": "sumDepositsBySession()",
+      "norm_label": "sumdepositsbysession()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L169"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "adjustments_trimoptional",
+      "id": "deposits_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L66"
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
+      "source_location": "L115"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
+      "label": "deposits.ts",
+      "norm_label": "deposits.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
       "source_location": "L1"
     },
     {
@@ -74947,7 +75034,7 @@
       "label": "formatExpiry()",
       "norm_label": "formatexpiry()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L198"
+      "source_location": "L199"
     },
     {
       "community": 49,
@@ -74956,7 +75043,7 @@
       "label": "formatHoldDetails()",
       "norm_label": "formatholddetails()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L224"
+      "source_location": "L225"
     },
     {
       "community": 49,
@@ -74965,7 +75052,7 @@
       "label": "formatRegisterLabel()",
       "norm_label": "formatregisterlabel()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L155"
+      "source_location": "L156"
     },
     {
       "community": 49,
@@ -74974,7 +75061,7 @@
       "label": "formatStatusLabel()",
       "norm_label": "formatstatuslabel()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L126"
+      "source_location": "L127"
     },
     {
       "community": 49,
@@ -74983,7 +75070,7 @@
       "label": "getCartCount()",
       "norm_label": "getcartcount()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L188"
+      "source_location": "L189"
     },
     {
       "community": 49,
@@ -74992,7 +75079,7 @@
       "label": "getCustomerLabel()",
       "norm_label": "getcustomerlabel()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L184"
+      "source_location": "L185"
     },
     {
       "community": 49,
@@ -75001,7 +75088,7 @@
       "label": "getOperatorLabel()",
       "norm_label": "getoperatorlabel()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L146"
+      "source_location": "L147"
     },
     {
       "community": 49,
@@ -75010,7 +75097,7 @@
       "label": "getRegisterLabel()",
       "norm_label": "getregisterlabel()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L165"
+      "source_location": "L166"
     },
     {
       "community": 49,
@@ -75019,7 +75106,7 @@
       "label": "getSessionCode()",
       "norm_label": "getsessioncode()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L135"
+      "source_location": "L136"
     },
     {
       "community": 49,
@@ -75028,7 +75115,7 @@
       "label": "getSessionId()",
       "norm_label": "getsessionid()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L142"
+      "source_location": "L143"
     },
     {
       "community": 49,
@@ -75037,7 +75124,7 @@
       "label": "getSessions()",
       "norm_label": "getsessions()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L118"
+      "source_location": "L119"
     },
     {
       "community": 49,
@@ -75046,7 +75133,7 @@
       "label": "getStatusBadgeClass()",
       "norm_label": "getstatusbadgeclass()",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L258"
+      "source_location": "L259"
     },
     {
       "community": 490,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1586
-- Graph nodes: 4362
-- Graph edges: 4071
+- Graph nodes: 4365
+- Graph edges: 4076
 - Communities: 1514
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts
@@ -84,6 +84,9 @@ describe("POS and expense session indexing", () => {
       '.index("by_storeId_productSkuId_status_expiresAt", [',
     );
     expect(inventoryHoldSchema).toContain(
+      '.index("by_storeId_status_expiresAt", [',
+    );
+    expect(inventoryHoldSchema).toContain(
       '.index("by_sourceSessionId_status_productSkuId", [',
     );
   });

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -191,6 +191,11 @@ const schema = defineSchema({
       "status",
       "expiresAt",
     ])
+    .index("by_storeId_status_expiresAt", [
+      "storeId",
+      "status",
+      "expiresAt",
+    ])
     .index("by_sourceSessionId_status_productSkuId", [
       "sourceSessionId",
       "status",

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
-import type { MutationCtx } from "../_generated/server";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 
 const mockedAuthServer = vi.hoisted(() => ({
@@ -17,6 +17,7 @@ import {
   assertStockAdjustmentReasonCode,
   calculateCycleCountQuantityDelta,
   hasHighStockAdjustmentVariance,
+  listInventorySnapshotWithCtx,
   requiresStockAdjustmentApproval,
   resolveStockAdjustmentApprovalDecisionWithCtx,
   resolveStockAdjustmentQuantityDelta,
@@ -27,6 +28,146 @@ import {
 
 function getSource(relativePath: string) {
   return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+function createInventorySnapshotQueryCtx() {
+  const tables = {
+    category: new Map<string, Record<string, unknown>>([
+      ["category-1", { _id: "category-1", name: "Hair" }],
+    ]),
+    color: new Map<string, Record<string, unknown>>([
+      ["color-1", { _id: "color-1", name: "Black" }],
+    ]),
+    inventoryHold: new Map<string, Record<string, unknown>>([
+      [
+        "hold-active",
+        {
+          _id: "hold-active",
+          expiresAt: 2_000,
+          productSkuId: "sku-1",
+          quantity: 2,
+          sourceSessionId: "session-1",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      [
+        "hold-expired",
+        {
+          _id: "hold-expired",
+          expiresAt: 500,
+          productSkuId: "sku-1",
+          quantity: 1,
+          sourceSessionId: "session-2",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      [
+        "hold-released",
+        {
+          _id: "hold-released",
+          expiresAt: 2_000,
+          productSkuId: "sku-1",
+          quantity: 4,
+          sourceSessionId: "session-3",
+          status: "released",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    product: new Map<string, Record<string, unknown>>([
+      [
+        "product-1",
+        {
+          _id: "product-1",
+          categoryId: "category-1",
+          name: "Closure Wig",
+        },
+      ],
+    ]),
+    productSku: new Map<string, Record<string, unknown>>([
+      [
+        "sku-1",
+        {
+          _id: "sku-1",
+          color: "color-1",
+          images: [],
+          inventoryCount: 10,
+          productId: "product-1",
+          quantityAvailable: 8,
+          sku: "CW-18",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+  };
+
+  function indexedQuery(table: keyof typeof tables) {
+    const filters: Array<[string, unknown | { gt: number }]> = [];
+    const filteredRecords = () =>
+      Array.from(tables[table].values()).filter((record) =>
+        filters.every(([field, value]) =>
+          typeof value === "object" && value !== null && "gt" in value
+            ? Number(record[field]) > (value as { gt: number }).gt
+            : record[field] === value,
+        ),
+      );
+
+    const query = {
+      collect: async () => filteredRecords(),
+      take: async (limit: number) => filteredRecords().slice(0, limit),
+      withIndex(
+        _index: string,
+        applyIndex: (builder: {
+          eq: (field: string, value: unknown) => unknown;
+          gt: (field: string, value: number) => unknown;
+        }) => unknown,
+      ) {
+        const builder = {
+          eq(field: string, value: unknown) {
+            filters.push([field, value]);
+            return builder;
+          },
+          gt(field: string, value: number) {
+            filters.push([field, { gt: value }]);
+            return builder;
+          },
+        };
+
+        applyIndex(builder);
+
+        return {
+          collect: async () => filteredRecords(),
+          take: async (limit: number) => filteredRecords().slice(0, limit),
+        };
+      },
+    };
+
+    return query;
+  }
+
+  const ctx = {
+    db: {
+      async get(tableOrId: string, maybeId?: string) {
+        if (maybeId === undefined) {
+          for (const table of Object.values(tables)) {
+            const record = table.get(tableOrId);
+            if (record) return record;
+          }
+
+          return null;
+        }
+
+        return tables[tableOrId as keyof typeof tables].get(maybeId) ?? null;
+      },
+      query(table: keyof typeof tables) {
+        return indexedQuery(table);
+      },
+    },
+  } as unknown as QueryCtx;
+
+  return { ctx, tables };
 }
 
 function createApprovalDecisionMutationCtx() {
@@ -384,6 +525,25 @@ function createSubmissionMutationCtx(args: {
 }
 
 describe("stock ops adjustments", () => {
+  it("returns hold-adjusted sellable availability while preserving durable SKU availability", async () => {
+    const { ctx } = createInventorySnapshotQueryCtx();
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        _id: "sku-1",
+        durableQuantityAvailable: 8,
+        inventoryCount: 10,
+        quantityAvailable: 6,
+        reservedQuantity: 2,
+      }),
+    ]);
+  });
+
   it("calculates cycle-count deltas from the system quantity", () => {
     expect(
       calculateCycleCountQuantityDelta({

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -1,4 +1,9 @@
-import { mutation, query, type MutationCtx } from "../_generated/server";
+import {
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
 import {
@@ -62,6 +67,7 @@ type NormalizedStockAdjustmentLineItem = {
 const UNCATEGORIZED_SCOPE_KEY = "__uncategorized";
 const TEMPORARY_DELETE_SCOPE_CONFIRMATION =
   "delete-stock-adjustment-scope-skus";
+const ACTIVE_STORE_HOLD_SUM_LIMIT = 5000;
 
 function trimOptional(value?: string | null) {
   const nextValue = value?.trim();
@@ -359,76 +365,115 @@ export async function resolveStockAdjustmentApprovalDecisionWithCtx(
   return ctx.db.get("stockAdjustmentBatch", stockAdjustmentBatchId);
 }
 
-export const listInventorySnapshot = query({
+async function readActiveHeldQuantitiesForStockOpsSnapshot(
+  ctx: QueryCtx,
   args: {
-    storeId: v.id("store"),
-  },
-  handler: async (ctx, args) => {
-    // eslint-disable-next-line @convex-dev/no-collect-in-query -- This workspace needs the full store SKU snapshot so operators can reconcile counts across the entire catalog in one pass.
-    const productSkus = await ctx.db
-      .query("productSku")
-      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-      .collect();
+    now: number;
+    storeId: Id<"store">;
+  }
+) {
+  const holds = await ctx.db
+    .query("inventoryHold")
+    .withIndex("by_storeId_status_expiresAt", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "active").gt("expiresAt", args.now)
+    )
+    .take(ACTIVE_STORE_HOLD_SUM_LIMIT + 1);
 
-    const productIds = Array.from(
-      new Set(productSkus.map((productSku) => productSku.productId))
+  if (holds.length > ACTIVE_STORE_HOLD_SUM_LIMIT) {
+    throw new Error(
+      "Stock operations has too many active POS inventory holds to summarize. Expire stale POS sessions and retry."
     );
-    const colorIds = Array.from(
-      new Set(productSkus.map((productSku) => productSku.color).filter(Boolean))
-    ) as Id<"color">[];
+  }
 
-    const [products, colors] = await Promise.all([
-      Promise.all(productIds.map((productId) => ctx.db.get("product", productId))),
-      Promise.all(colorIds.map((colorId) => ctx.db.get("color", colorId))),
-    ]);
-
-    const productMap = new Map<
-      Id<"product">,
-      NonNullable<(typeof products)[number]>
-    >();
-    products.forEach((product) => {
-      if (product) {
-        productMap.set(product._id, product);
-      }
-    });
-    const categoryIds = Array.from(
-      new Set(
-        products
-          .map((product) => product?.categoryId)
-          .filter(Boolean)
-      )
-    ) as Id<"category">[];
-    const categories = await Promise.all(
-      categoryIds.map((categoryId) => ctx.db.get("category", categoryId))
+  return holds.reduce((quantities, hold) => {
+    quantities.set(
+      hold.productSkuId,
+      (quantities.get(hold.productSkuId) ?? 0) + Math.max(0, hold.quantity)
     );
-    const categoryMap = new Map<
-      Id<"category">,
-      NonNullable<(typeof categories)[number]>
-    >();
-    categories.forEach((category) => {
-      if (category) {
-        categoryMap.set(category._id, category);
-      }
-    });
-    const colorMap = new Map<Id<"color">, NonNullable<(typeof colors)[number]>>();
-    colors.forEach((color) => {
-      if (color) {
-        colorMap.set(color._id, color);
-      }
-    });
+    return quantities;
+  }, new Map<Id<"productSku">, number>());
+}
 
-    return productSkus
-      .map((productSku) => {
+export async function listInventorySnapshotWithCtx(
+  ctx: QueryCtx,
+  args: {
+    now?: number;
+    storeId: Id<"store">;
+  }
+) {
+  const now = args.now ?? Date.now();
+  // eslint-disable-next-line @convex-dev/no-collect-in-query -- This workspace needs the full store SKU snapshot so operators can reconcile counts across the entire catalog in one pass.
+  const productSkus = await ctx.db
+    .query("productSku")
+    .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+    .collect();
+  const heldQuantities = await readActiveHeldQuantitiesForStockOpsSnapshot(ctx, {
+    now,
+    storeId: args.storeId,
+  });
+
+  const productIds = Array.from(
+    new Set(productSkus.map((productSku) => productSku.productId))
+  );
+  const colorIds = Array.from(
+    new Set(productSkus.map((productSku) => productSku.color).filter(Boolean))
+  ) as Id<"color">[];
+
+  const [products, colors] = await Promise.all([
+    Promise.all(productIds.map((productId) => ctx.db.get("product", productId))),
+    Promise.all(colorIds.map((colorId) => ctx.db.get("color", colorId))),
+  ]);
+
+  const productMap = new Map<
+    Id<"product">,
+    NonNullable<(typeof products)[number]>
+  >();
+  products.forEach((product) => {
+    if (product) {
+      productMap.set(product._id, product);
+    }
+  });
+  const categoryIds = Array.from(
+    new Set(products.map((product) => product?.categoryId).filter(Boolean))
+  ) as Id<"category">[];
+  const categories = await Promise.all(
+    categoryIds.map((categoryId) => ctx.db.get("category", categoryId))
+  );
+  const categoryMap = new Map<
+    Id<"category">,
+    NonNullable<(typeof categories)[number]>
+  >();
+  categories.forEach((category) => {
+    if (category) {
+      categoryMap.set(category._id, category);
+    }
+  });
+  const colorMap = new Map<Id<"color">, NonNullable<(typeof colors)[number]>>();
+  colors.forEach((color) => {
+    if (color) {
+      colorMap.set(color._id, color);
+    }
+  });
+
+  const rows = await Promise.all(
+    productSkus.map(async (productSku) => {
         const product = productMap.get(productSku.productId);
         const category = product?.categoryId
           ? categoryMap.get(product.categoryId)
           : null;
         const color = productSku.color ? colorMap.get(productSku.color) : null;
+        const reservedQuantity = heldQuantities.get(productSku._id) ?? 0;
+        const durableQuantityAvailable = productSku.quantityAvailable;
+        const quantityAvailable = Math.max(
+          0,
+          durableQuantityAvailable - reservedQuantity
+        );
 
         return {
           _id: productSku._id,
           barcode: productSku.barcode ?? null,
           colorName: color?.name ?? null,
+          durableQuantityAvailable,
           imageUrl: productSku.images[0] ?? null,
           inventoryCount: productSku.inventoryCount,
           length: productSku.length ?? null,
@@ -439,18 +484,29 @@ export const listInventorySnapshot = query({
             productSku.productName ??
             productSku.sku ??
             String(productSku._id),
-          quantityAvailable: productSku.quantityAvailable,
+          quantityAvailable,
+          reservedQuantity,
           sku: productSku.sku ?? null,
         };
       })
-      .sort((left, right) => {
-        const nameCompare = left.productName.localeCompare(right.productName);
-        if (nameCompare !== 0) {
-          return nameCompare;
-        }
+  );
 
-        return (left.sku ?? "").localeCompare(right.sku ?? "");
-      });
+  return rows.sort((left, right) => {
+    const nameCompare = left.productName.localeCompare(right.productName);
+    if (nameCompare !== 0) {
+      return nameCompare;
+    }
+
+    return (left.sku ?? "").localeCompare(right.sku ?? "");
+  });
+}
+
+export const listInventorySnapshot = query({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    return listInventorySnapshotWithCtx(ctx, args);
   },
 });
 

--- a/packages/athena-webapp/src/components/common/PageHeader.tsx
+++ b/packages/athena-webapp/src/components/common/PageHeader.tsx
@@ -37,6 +37,7 @@ export const NavigateBackButton = () => {
 
   return (
     <Button
+      aria-label="Go back"
       onClick={navigateBack}
       variant="ghost"
       className="h-8 px-2 lg:px-3 "
@@ -94,6 +95,7 @@ export const ComposedPageHeader = ({
       <FadeIn className="flex min-w-0 flex-1 items-center gap-4">
         {o && (
           <Button
+            aria-label="Go back"
             onClick={onNavigateBack ? onNavigateBack : navigateBack}
             variant="ghost"
             className="h-8 px-2 lg:px-3 "

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -759,6 +759,30 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(screen.getByText("Unavailable")).toBeInTheDocument();
   });
 
+  it("shows POS reserved units as reducing sellable availability", () => {
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-held" as Id<"productSku">,
+          durableQuantityAvailable: 8,
+          inventoryCount: 10,
+          productCategory: "Hair",
+          productName: "Held Closure",
+          quantityAvailable: 6,
+          reservedQuantity: 2,
+          sku: "HC-18",
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(
+        /6 of 10 units are available to sell\. 2 reserved in POS sessions\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2 reserved")).toBeInTheDocument();
+  });
+
   it("formats inventory status numbers with compact k notation", () => {
     renderStockAdjustmentWorkspace({
       inventoryItems: [

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -45,6 +45,7 @@ export type InventorySnapshotItem = {
   _id: Id<"productSku">;
   barcode?: string | null;
   colorName?: string | null;
+  durableQuantityAvailable?: number;
   imageUrl?: string | null;
   inventoryCount: number;
   length?: number | null;
@@ -52,6 +53,7 @@ export type InventorySnapshotItem = {
   productId?: Id<"product"> | null;
   productName: string;
   quantityAvailable: number;
+  reservedQuantity?: number;
   sku?: string | null;
 };
 
@@ -249,6 +251,8 @@ function getInventoryItemDisplayName(item: InventorySnapshotItem) {
 }
 
 function getSkuDetailEntries(item: InventorySnapshotItem) {
+  const reservedQuantity = item.reservedQuantity ?? 0;
+
   return [
     item.sku ? { label: "SKU", value: item.sku } : null,
     item.barcode ? { label: "Barcode", value: item.barcode } : null,
@@ -259,6 +263,12 @@ function getSkuDetailEntries(item: InventorySnapshotItem) {
       ? { label: "Length", value: `${item.length}"` }
       : null,
     item.colorName ? { label: "Color", value: item.colorName } : null,
+    reservedQuantity > 0
+      ? {
+          label: "Reserved",
+          value: `${formatInventoryNumber(reservedQuantity)} in POS sessions`,
+        }
+      : null,
   ].filter(
     (entry): entry is { label: string; value: string } =>
       entry !== null && entry.value.trim().length > 0,
@@ -682,10 +692,12 @@ export function StockAdjustmentWorkspaceContent({
           0,
           item.inventoryCount - item.quantityAvailable,
         );
+        const reservedUnits = Math.max(0, item.reservedQuantity ?? 0);
 
         return {
           availableUnits: current.availableUnits + item.quantityAvailable,
           onHandUnits: current.onHandUnits + item.inventoryCount,
+          reservedUnits: current.reservedUnits + reservedUnits,
           unavailableSkuCount:
             current.unavailableSkuCount + (unavailableUnits > 0 ? 1 : 0),
           unavailableUnits: current.unavailableUnits + unavailableUnits,
@@ -694,6 +706,7 @@ export function StockAdjustmentWorkspaceContent({
       {
         availableUnits: 0,
         onHandUnits: 0,
+        reservedUnits: 0,
         unavailableSkuCount: 0,
         unavailableUnits: 0,
       },
@@ -713,7 +726,13 @@ export function StockAdjustmentWorkspaceContent({
             )} of ${formatInventoryNumber(totals.onHandUnits)} ${pluralize(
               totals.onHandUnits,
               "unit",
-            )} are available to sell.`,
+            )} are available to sell.${
+              totals.reservedUnits > 0
+                ? ` ${formatInventoryNumber(
+                    totals.reservedUnits,
+                  )} reserved in POS sessions.`
+                : ""
+            }`,
       title:
         itemCount === 0
           ? "No inventory loaded."
@@ -912,8 +931,15 @@ export function StockAdjustmentWorkspaceContent({
               <span className="font-medium text-foreground">
                 {formatInventoryNumber(item.inventoryCount)}
               </span>
-              <span className="text-muted-foreground">
-                {formatInventoryNumber(item.quantityAvailable)}
+              <span className="space-y-0.5 text-muted-foreground">
+                <span className="block">
+                  {formatInventoryNumber(item.quantityAvailable)}
+                </span>
+                {(item.reservedQuantity ?? 0) > 0 ? (
+                  <span className="block text-[11px] font-medium uppercase tracking-[0.12em] text-warning">
+                    {formatInventoryNumber(item.reservedQuantity ?? 0)} reserved
+                  </span>
+                ) : null}
               </span>
             </div>
           );

--- a/packages/athena-webapp/src/components/pos/sessions/POSSessionsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/sessions/POSSessionsView.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@tanstack/react-router", () => ({
     </a>
   ),
   useParams: () => useParamsMock(),
+  useSearch: () => ({ o: "%2Fwigclub%2Fstore%2Fwigclub%2Fpos" }),
 }));
 
 vi.mock("convex/react", () => ({
@@ -64,6 +65,10 @@ vi.mock("@/components/View", () => ({
 
 vi.mock("@/components/common/FadeIn", () => ({
   FadeIn: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("~/src/hooks/use-navigate-back", () => ({
+  useNavigateBack: () => vi.fn(),
 }));
 
 vi.mock("@/components/base/table/data-table", () => ({
@@ -185,6 +190,7 @@ describe("POSSessionsView", () => {
 
     render(<POSSessionsView />);
 
+    expect(screen.getByRole("button", { name: "Go back" })).toBeInTheDocument();
     expect(screen.getByText("No active POS sessions")).toBeInTheDocument();
     expect(screen.getByText("0 sessions")).toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, ClipboardList } from "lucide-react";
 import { GenericDataTable } from "@/components/base/table/data-table";
 import View from "@/components/View";
 import { FadeIn } from "@/components/common/FadeIn";
+import { NavigateBackButton } from "@/components/common/PageHeader";
 import { EmptyState } from "@/components/states/empty/empty-state";
 import { NoPermissionView } from "@/components/states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "@/components/states/signed-out/ProtectedAdminSignInView";
@@ -288,7 +289,10 @@ function POSSessionsLoadingState() {
 function POSSessionsHeader() {
   return (
     <div className="container mx-auto flex h-10 items-center justify-between gap-3">
-      <p className="text-xl font-medium">POS sessions</p>
+      <div className="flex min-w-0 items-center gap-2">
+        <NavigateBackButton />
+        <p className="truncate text-xl font-medium">POS sessions</p>
+      </div>
       <Badge
         className="border-border bg-surface-raised text-muted-foreground"
         variant="outline"


### PR DESCRIPTION
## Summary

Stock operations now reports sellable SKU availability after active POS session holds, while preserving the durable SKU availability used for inventory reconciliation. This keeps the stock adjustment workspace honest about what can be sold right now without treating temporary POS reservations as physical stock movement.

## What Changed

- Computes store-scoped active POS hold totals once for the inventory snapshot using a new `by_storeId_status_expiresAt` inventory hold index.
- Returns both hold-adjusted `quantityAvailable` and raw `durableQuantityAvailable` from the stock ops inventory snapshot.
- Surfaces reserved POS units in the stock adjustment workspace summary, row availability display, and SKU detail rail.
- Keeps the POS sessions back button change in the shared page header path with an accessible `Go back` label.

## Validation

- Full pre-push validation passed, including graphify check, architecture check, harness review, webapp test suite, Convex audit, changed Convex lint, typecheck, build, stock-ops focused tests, and runtime behavior scenarios.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)