### PR TITLE
fix: index recent storefront activity lookup

### DIFF
--- a/packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts
+++ b/packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts
@@ -52,6 +52,7 @@ describe("V26-169 time/query refactors", () => {
     const reviewsSource = readSource("convex/storeFront/reviews.ts");
     const guestSource = readSource("convex/storeFront/guest.ts");
     const analyticsSource = readSource("convex/storeFront/analytics.ts");
+    const userSource = readSource("convex/storeFront/user.ts");
 
     expect(offersSource).toContain('.withIndex("by_storeId_status"');
     expect(offersSource).toContain('.withIndex("by_storeFrontUserId_promoCodeId"');
@@ -67,6 +68,13 @@ describe("V26-169 time/query refactors", () => {
     expect(guestSource).toContain('.withIndex("by_marker"');
     expect(analyticsSource).toContain('.withIndex("by_storeFrontUserId_storeId"');
     expect(analyticsSource).toContain('.withIndex("by_action_productId"');
+    const mostRecentActivitySource = userSource.slice(
+      userSource.indexOf("export const getMostRecentActivity")
+    );
+    expect(mostRecentActivitySource).toContain('.withIndex("by_storeFrontUserId"');
+    expect(mostRecentActivitySource).not.toContain(
+      'q.eq(q.field("storeFrontUserId"), args.id)'
+    );
   });
 
   it("covers the remaining V26-172 analytics and reporting query hotspots", () => {

--- a/packages/athena-webapp/convex/storeFront/user.ts
+++ b/packages/athena-webapp/convex/storeFront/user.ts
@@ -625,11 +625,11 @@ export const getMostRecentActivity = query({
     // Get only the most recent analytics record
     const analytics = await ctx.db
       .query("analytics")
+      .withIndex("by_storeFrontUserId", (q) =>
+        q.eq("storeFrontUserId", args.id)
+      )
       .filter((q) =>
-        q.and(
-          q.eq(q.field("storeFrontUserId"), args.id),
-          q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN)
-        )
+        q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN)
       )
       .order("desc") // Most recent first
       .first();


### PR DESCRIPTION
## Summary
- route `getMostRecentActivity` through the existing `analytics.by_storeFrontUserId` index before filtering synthetic monitor records
- add a regression assertion so the recent-activity lookup does not fall back to field-filtering the analytics table

## Validation
- `bun run --filter '@athena/webapp' test -- convex/storeFront/timeQueryRefactors.test.ts convex/storeFront/commerceQueryIndexes.test.ts`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' audit:convex`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `cd packages/athena-webapp && CONVEX_DEPLOYMENT=prod:colorless-cardinal-870 npx convex deploy --dry-run --typecheck disable --codegen disable`
- `git push -u origin HEAD` pre-push suite