### PR TITLE
Archive products instead of deleting them

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1588 files · ~0 words
+- 1591 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4389 nodes · 4118 edges · 1516 communities detected
+- 4395 nodes · 4123 edges · 1519 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1526,6 +1526,9 @@
 - [[_COMMUNITY_Community 1513|Community 1513]]
 - [[_COMMUNITY_Community 1514|Community 1514]]
 - [[_COMMUNITY_Community 1515|Community 1515]]
+- [[_COMMUNITY_Community 1516|Community 1516]]
+- [[_COMMUNITY_Community 1517|Community 1517]]
+- [[_COMMUNITY_Community 1518|Community 1518]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1778,24 +1781,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 56 - "Community 56"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 57 - "Community 57"
 Cohesion: 0.25
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 59 - "Community 59"
+### Community 58 - "Community 58"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 60 - "Community 60"
+### Community 59 - "Community 59"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 60 - "Community 60"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 61 - "Community 61"
 Cohesion: 0.18
@@ -2110,12 +2113,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 139 - "Community 139"
-Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 140 - "Community 140"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
+
+### Community 140 - "Community 140"
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 141 - "Community 141"
 Cohesion: 0.33
@@ -2130,16 +2133,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 144 - "Community 144"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 146 - "Community 146"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 0.33
@@ -2154,12 +2157,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 150 - "Community 150"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 151 - "Community 151"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 151 - "Community 151"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 152 - "Community 152"
 Cohesion: 0.33
@@ -2170,36 +2173,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 154 - "Community 154"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 155 - "Community 155"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 156 - "Community 156"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 157 - "Community 157"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 161 - "Community 161"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 162 - "Community 162"
 Cohesion: 0.53
@@ -2474,88 +2477,88 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.67
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 232 - "Community 232"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 236 - "Community 236"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 237 - "Community 237"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 238 - "Community 238"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 238 - "Community 238"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
-
 ### Community 239 - "Community 239"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 240 - "Community 240"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 242 - "Community 242"
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+
+### Community 243 - "Community 243"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 244 - "Community 244"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 243 - "Community 243"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 244 - "Community 244"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 245 - "Community 245"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 246 - "Community 246"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 247 - "Community 247"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 246 - "Community 246"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 247 - "Community 247"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 248 - "Community 248"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 251 - "Community 251"
 Cohesion: 0.5
@@ -2566,16 +2569,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 255 - "Community 255"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.5
@@ -2586,16 +2589,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.5
@@ -2618,20 +2621,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 266 - "Community 266"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 267 - "Community 267"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 269 - "Community 269"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.5
@@ -2639,11 +2642,11 @@ Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 272 - "Community 272"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.5
@@ -2651,43 +2654,43 @@ Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 276 - "Community 276"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 277 - "Community 277"
 Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 280 - "Community 280"
-Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 281 - "Community 281"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 282 - "Community 282"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 283 - "Community 283"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.5
@@ -2706,63 +2709,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 288 - "Community 288"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 289 - "Community 289"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 290 - "Community 290"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 291 - "Community 291"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 289 - "Community 289"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 290 - "Community 290"
+### Community 292 - "Community 292"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 291 - "Community 291"
+### Community 293 - "Community 293"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 292 - "Community 292"
+### Community 294 - "Community 294"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 293 - "Community 293"
+### Community 295 - "Community 295"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 294 - "Community 294"
+### Community 296 - "Community 296"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 295 - "Community 295"
+### Community 297 - "Community 297"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 296 - "Community 296"
+### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 297 - "Community 297"
+### Community 299 - "Community 299"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 298 - "Community 298"
+### Community 300 - "Community 300"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 299 - "Community 299"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 300 - "Community 300"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 301 - "Community 301"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 303 - "Community 303"
@@ -2815,35 +2818,35 @@ Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 316 - "Community 316"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 319 - "Community 319"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 322 - "Community 322"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.67
@@ -2854,36 +2857,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 326 - "Community 326"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 327 - "Community 327"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 328 - "Community 328"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 330 - "Community 330"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 331 - "Community 331"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 331 - "Community 331"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 333 - "Community 333"
 Cohesion: 0.67
@@ -2898,24 +2901,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 338 - "Community 338"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.67
@@ -2923,23 +2926,23 @@ Nodes (0):
 
 ### Community 342 - "Community 342"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 343 - "Community 343"
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
+
+### Community 344 - "Community 344"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 345 - "Community 345"
-Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 346 - "Community 346"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 347 - "Community 347"
 Cohesion: 0.67
@@ -2994,84 +2997,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 360 - "Community 360"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 361 - "Community 361"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 378 - "Community 378"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 379 - "Community 379"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.67
@@ -3099,11 +3102,11 @@ Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.67
@@ -7617,6 +7620,18 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1516 - "Community 1516"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1517 - "Community 1517"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1518 - "Community 1518"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -7640,2123 +7655,2129 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 456`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 457`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 458`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 459`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 460`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 461`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 462`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 463`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 464`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 465`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 466`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 467`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 468`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 469`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 470`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 471`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 472`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 473`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 474`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 475`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 476`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 477`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 478`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 479`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `createCtx()`, `inventoryHoldGateway.test.ts`
+- **Thin community `Community 480`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 481`** (2 nodes): `createCtx()`, `inventoryHoldGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 482`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 483`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 484`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 485`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 486`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 487`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 488`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 489`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 490`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 491`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 492`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 493`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 494`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 495`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 496`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 497`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 498`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 499`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 500`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 501`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 502`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 503`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 504`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 505`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 506`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 507`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 508`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 509`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 510`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 511`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 512`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 513`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 514`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 515`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 516`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 517`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 518`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 519`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 520`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 521`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 522`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 523`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 524`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 525`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 526`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 527`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 528`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 529`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 530`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 531`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 532`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 533`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 534`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 535`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 536`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 537`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 538`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 539`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 540`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 541`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 542`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 543`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 544`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 545`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 546`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 547`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 548`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 549`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 550`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 551`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 552`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `PageLevelHeader.tsx`, `PageLevelHeader()`
+- **Thin community `Community 553`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 554`** (2 nodes): `PageLevelHeader.tsx`, `PageLevelHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 555`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 556`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 557`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 558`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 559`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 560`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 561`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 562`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 563`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 564`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 565`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 566`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 567`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 568`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 569`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 570`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 571`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 572`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 573`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 574`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 575`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 576`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 577`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 578`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 579`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 580`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 581`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 582`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 583`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 584`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 585`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 586`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 587`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 588`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 589`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 590`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 591`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 592`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 593`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 594`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 595`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 596`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 597`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 598`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 599`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 600`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 601`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 602`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 603`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 604`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 605`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 606`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 607`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 608`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 609`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 610`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 611`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 612`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 613`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 614`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 615`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 616`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 617`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 618`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 619`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 620`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 621`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 622`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 623`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 624`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 625`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 626`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 627`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 628`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 629`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 630`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 631`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 632`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 633`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 634`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 635`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 636`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 637`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 638`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 639`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 640`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 641`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 642`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 643`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 644`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 645`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 646`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 647`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 648`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 649`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 650`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 651`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 652`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 653`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 654`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 655`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 656`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 657`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 658`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 659`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 660`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 661`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 662`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 663`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 664`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 665`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 666`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 667`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 668`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 669`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 670`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 671`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 672`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 673`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 674`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 675`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 676`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 677`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 678`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 679`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 680`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 681`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 682`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 683`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 684`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 685`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 686`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 687`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 688`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 689`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 690`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 691`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 692`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 693`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 694`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 695`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 696`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 697`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 698`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 699`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 700`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 701`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 702`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 703`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 704`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 705`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 706`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 707`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 708`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 709`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 710`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 711`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 712`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 713`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 714`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 715`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 716`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 717`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 718`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 719`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 720`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 721`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 722`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 723`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 724`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 725`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 726`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 727`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 728`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 729`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 730`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 731`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 732`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 733`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 734`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 735`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 736`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 737`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 738`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 739`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 740`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 741`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 742`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 743`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 744`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 745`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 746`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 747`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 748`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 749`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 750`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 751`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 752`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 753`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 754`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 755`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 756`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 757`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 758`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 759`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 760`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 761`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 762`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 763`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 764`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 765`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 766`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 767`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 768`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 769`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 770`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 771`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 772`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 773`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 774`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 775`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 776`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 777`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 778`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 779`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 780`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 781`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 782`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 783`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 784`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 785`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 786`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 787`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 788`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 789`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 790`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 791`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 792`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 793`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 794`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 795`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 796`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 797`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 798`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 799`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 800`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 801`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 802`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 803`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 804`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 805`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 806`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 807`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 808`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 809`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 810`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 811`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 812`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 813`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 814`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 815`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 816`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 817`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 818`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 819`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 820`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 821`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 822`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 823`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 824`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 825`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 826`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 827`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 828`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 829`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `api.d.ts`
+- **Thin community `Community 830`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `api.js`
+- **Thin community `Community 831`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 832`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `server.d.ts`
+- **Thin community `Community 833`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `server.js`
+- **Thin community `Community 834`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `app.ts`
+- **Thin community `Community 835`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `auth.config.js`
+- **Thin community `Community 836`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `auth.ts`
+- **Thin community `Community 837`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 838`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 839`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `countries.ts`
+- **Thin community `Community 840`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `email.ts`
+- **Thin community `Community 841`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `ghana.ts`
+- **Thin community `Community 842`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `payment.ts`
+- **Thin community `Community 843`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `crons.ts`
+- **Thin community `Community 844`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 845`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 846`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 847`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 848`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `env.ts`
+- **Thin community `Community 849`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `analytics.ts`
+- **Thin community `Community 850`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `auth.ts`
+- **Thin community `Community 851`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 852`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `colors.ts`
+- **Thin community `Community 853`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `index.ts`
+- **Thin community `Community 854`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `organizations.ts`
+- **Thin community `Community 855`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `products.ts`
+- **Thin community `Community 856`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 857`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `stores.ts`
+- **Thin community `Community 858`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `bag.ts`
+- **Thin community `Community 859`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `guest.ts`
+- **Thin community `Community 860`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `index.ts`
+- **Thin community `Community 861`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `me.ts`
+- **Thin community `Community 862`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `offers.ts`
+- **Thin community `Community 863`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 864`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `paystack.ts`
+- **Thin community `Community 865`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 866`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `reviews.ts`
+- **Thin community `Community 867`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `rewards.ts`
+- **Thin community `Community 868`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 869`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `security.test.ts`
+- **Thin community `Community 870`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `storefront.ts`
+- **Thin community `Community 871`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `upsells.ts`
+- **Thin community `Community 872`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `user.ts`
+- **Thin community `Community 873`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 874`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `index.ts`
+- **Thin community `Community 875`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `health.test.ts`
+- **Thin community `Community 876`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `http.ts`
+- **Thin community `Community 877`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 878`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 879`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 880`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `categories.ts`
+- **Thin community `Community 881`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `colors.ts`
+- **Thin community `Community 882`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 883`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 884`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 885`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 886`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 887`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `organizations.ts`
+- **Thin community `Community 888`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `pos.ts`
+- **Thin community `Community 889`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 890`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 891`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `productSku.ts`
+- **Thin community `Community 892`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 893`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 894`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 895`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 896`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 897`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 898`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 899`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 900`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 901`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 902`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `client.test.ts`
+- **Thin community `Community 903`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `config.test.ts`
+- **Thin community `Community 904`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 905`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `types.ts`
+- **Thin community `Community 906`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 907`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 908`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 909`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 910`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 911`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 912`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 913`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `dto.ts`
+- **Thin community `Community 914`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 915`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 916`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 917`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `types.ts`
+- **Thin community `Community 918`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 919`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `catalog.ts`
+- **Thin community `Community 920`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `customers.ts`
+- **Thin community `Community 921`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `register.ts`
+- **Thin community `Community 922`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `terminals.ts`
+- **Thin community `Community 923`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `schema.ts`
+- **Thin community `Community 924`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 925`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 926`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 927`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 928`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `category.ts`
+- **Thin community `Community 929`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `color.ts`
+- **Thin community `Community 930`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 931`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 932`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `index.ts`
+- **Thin community `Community 933`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 934`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 935`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `organization.ts`
+- **Thin community `Community 936`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 937`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `product.ts`
+- **Thin community `Community 938`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 939`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 940`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `store.ts`
+- **Thin community `Community 941`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 942`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `index.ts`
+- **Thin community `Community 943`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 944`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 945`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 946`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 947`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 948`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `index.ts`
+- **Thin community `Community 949`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 950`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 951`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 952`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 953`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 954`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 955`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 956`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 957`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 958`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `customer.ts`
+- **Thin community `Community 959`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 960`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 961`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 962`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 963`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `index.ts`
+- **Thin community `Community 964`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `posSession.ts`
+- **Thin community `Community 965`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 966`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 967`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 968`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 969`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `index.ts`
+- **Thin community `Community 970`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 971`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 972`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 973`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 974`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 975`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 976`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `index.ts`
+- **Thin community `Community 977`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 978`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 979`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 980`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 981`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `vendor.ts`
+- **Thin community `Community 982`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `analytics.ts`
+- **Thin community `Community 983`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `bag.ts`
+- **Thin community `Community 984`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 985`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 986`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 987`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `guest.ts`
+- **Thin community `Community 988`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `index.ts`
+- **Thin community `Community 989`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `offer.ts`
+- **Thin community `Community 990`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 991`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 992`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `review.ts`
+- **Thin community `Community 993`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `rewards.ts`
+- **Thin community `Community 994`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 995`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 996`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 997`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 998`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 999`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1000`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1001`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `bag.ts`
+- **Thin community `Community 1002`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1003`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `customer.ts`
+- **Thin community `Community 1004`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `guest.ts`
+- **Thin community `Community 1005`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1006`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1007`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `payment.ts`
+- **Thin community `Community 1008`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1009`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1010`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1011`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `users.ts`
+- **Thin community `Community 1012`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `payment.ts`
+- **Thin community `Community 1013`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1017`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `index.ts`
+- **Thin community `Community 1018`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1019`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1020`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `auth.ts`
+- **Thin community `Community 1021`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1022`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1023`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1024`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1025`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1026`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1027`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1028`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1029`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1030`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1031`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `constants.ts`
+- **Thin community `Community 1032`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1033`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `types.ts`
+- **Thin community `Community 1036`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1037`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1038`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1039`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1040`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1043`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1044`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1045`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1046`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1049`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1050`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1051`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1052`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1053`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1054`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1055`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1056`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `constants.ts`
+- **Thin community `Community 1057`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1058`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1059`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1060`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `data.ts`
+- **Thin community `Community 1061`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1062`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1063`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1064`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1065`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1066`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1067`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1068`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1069`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1070`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `constants.ts`
+- **Thin community `Community 1071`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1072`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1073`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1074`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `data.ts`
+- **Thin community `Community 1075`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1077`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1078`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1079`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1080`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1081`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1082`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1084`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1085`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `constants.ts`
+- **Thin community `Community 1086`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1087`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1090`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1091`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1092`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1093`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1094`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1095`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1096`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1097`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1098`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1099`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1100`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1101`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1102`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1103`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1104`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1105`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1106`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1107`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1109`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1110`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1111`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1112`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `constants.ts`
+- **Thin community `Community 1113`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1114`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1115`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1116`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data.ts`
+- **Thin community `Community 1117`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1118`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `constants.ts`
+- **Thin community `Community 1119`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1120`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1121`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1122`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1123`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `data.ts`
+- **Thin community `Community 1124`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `constants.ts`
+- **Thin community `Community 1126`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1127`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1128`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1129`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1130`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `data.ts`
+- **Thin community `Community 1131`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1132`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1133`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1134`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1135`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1136`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1137`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1138`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1139`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1140`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1141`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1142`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1143`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1144`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1145`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1146`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1147`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1148`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1149`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1150`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1151`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1152`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1153`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1154`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1155`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `types.ts`
+- **Thin community `Community 1156`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1157`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1158`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1159`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1160`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1161`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1162`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1163`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1164`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1165`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1166`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1167`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1168`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1169`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1170`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1171`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1172`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data.ts`
+- **Thin community `Community 1174`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1177`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1178`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1179`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1180`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1181`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1182`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1183`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1184`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1185`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1186`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `constants.ts`
+- **Thin community `Community 1187`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1188`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1189`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1190`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data.ts`
+- **Thin community `Community 1191`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `types.ts`
+- **Thin community `Community 1192`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1194`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1195`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1196`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `index.tsx`
+- **Thin community `Community 1197`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1198`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1199`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1200`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1201`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1202`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `index.tsx`
+- **Thin community `Community 1203`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1204`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1205`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1206`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `button.tsx`
+- **Thin community `Community 1207`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1208`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `card.tsx`
+- **Thin community `Community 1209`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1210`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1211`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `command.tsx`
+- **Thin community `Community 1212`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1213`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1214`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1215`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `form.tsx`
+- **Thin community `Community 1216`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1217`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1218`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `input.tsx`
+- **Thin community `Community 1219`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1220`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1221`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1222`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1223`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1224`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `select.tsx`
+- **Thin community `Community 1225`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1226`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1227`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1228`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `table.tsx`
+- **Thin community `Community 1229`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1230`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1231`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1232`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1233`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1234`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1235`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1236`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1237`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `constants.ts`
+- **Thin community `Community 1238`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1239`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1240`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1241`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data.ts`
+- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1245`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1246`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1251`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1252`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1253`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1254`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `index.ts`
+- **Thin community `Community 1255`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1256`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1257`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1259`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1260`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1262`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `aws.ts`
+- **Thin community `Community 1263`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `constants.ts`
+- **Thin community `Community 1264`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `countries.ts`
+- **Thin community `Community 1265`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1267`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1268`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1270`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1271`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `dto.ts`
+- **Thin community `Community 1272`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `ports.ts`
+- **Thin community `Community 1273`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `constants.ts`
+- **Thin community `Community 1274`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1275`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `index.ts`
+- **Thin community `Community 1277`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `types.ts`
+- **Thin community `Community 1279`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1282`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1285`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `category.ts`
+- **Thin community `Community 1287`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `product.ts`
+- **Thin community `Community 1288`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `store.ts`
+- **Thin community `Community 1289`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1290`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `user.ts`
+- **Thin community `Community 1291`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1295`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1296`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `index.tsx`
+- **Thin community `Community 1297`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `index.tsx`
+- **Thin community `Community 1298`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1299`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1300`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1301`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1302`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1303`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1304`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `index.tsx`
+- **Thin community `Community 1305`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1306`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1307`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1308`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `home.tsx`
+- **Thin community `Community 1309`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1310`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1311`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1312`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `index.tsx`
+- **Thin community `Community 1313`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `index.tsx`
+- **Thin community `Community 1314`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1315`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1316`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1317`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `index.tsx`
+- **Thin community `Community 1318`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1319`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1320`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1321`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1322`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1323`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1324`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `index.tsx`
+- **Thin community `Community 1325`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1326`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1327`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1328`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1329`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1330`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1331`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1332`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `index.tsx`
+- **Thin community `Community 1333`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `index.tsx`
+- **Thin community `Community 1334`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `new.tsx`
+- **Thin community `Community 1335`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `index.tsx`
+- **Thin community `Community 1336`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `new.tsx`
+- **Thin community `Community 1337`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1338`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1339`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `index.tsx`
+- **Thin community `Community 1340`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `new.tsx`
+- **Thin community `Community 1341`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `index.tsx`
+- **Thin community `Community 1342`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1343`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1344`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1345`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1346`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1347`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1349`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `index.tsx`
+- **Thin community `Community 1350`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1352`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1353`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1354`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1355`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1356`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1357`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1358`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1360`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1362`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1363`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1364`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1365`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1367`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1368`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1369`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1370`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1372`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1373`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `setup.ts`
+- **Thin community `Community 1374`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1375`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1376`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `types.ts`
+- **Thin community `Community 1377`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1378`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1379`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1380`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1381`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1382`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `types.ts`
+- **Thin community `Community 1383`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1384`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1385`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1386`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1387`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1388`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1389`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1390`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1391`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1392`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `schema.ts`
+- **Thin community `Community 1393`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1394`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1395`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1396`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1397`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1398`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1399`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1400`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1401`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1402`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `types.ts`
+- **Thin community `Community 1403`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1404`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1405`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1406`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1407`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1408`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1409`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1410`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `constants.ts`
+- **Thin community `Community 1411`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1412`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `About.tsx`
+- **Thin community `Community 1413`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1414`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1415`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1416`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1417`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1418`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1419`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1420`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1421`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1422`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `types.ts`
+- **Thin community `Community 1423`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1424`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1425`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1426`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1427`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1428`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1429`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1430`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1431`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1432`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1433`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1434`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `button.tsx`
+- **Thin community `Community 1435`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `card.tsx`
+- **Thin community `Community 1436`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1437`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `command.tsx`
+- **Thin community `Community 1438`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1439`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1440`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1441`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `form.tsx`
+- **Thin community `Community 1442`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1443`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1444`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1445`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1446`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `input.tsx`
+- **Thin community `Community 1447`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `label.tsx`
+- **Thin community `Community 1448`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1449`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1450`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1451`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `index.ts`
+- **Thin community `Community 1452`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `types.ts`
+- **Thin community `Community 1453`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1454`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1455`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1456`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1457`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `select.tsx`
+- **Thin community `Community 1458`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1459`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1460`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `table.tsx`
+- **Thin community `Community 1461`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1462`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1463`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1464`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1465`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1466`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `config.ts`
+- **Thin community `Community 1467`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1468`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1469`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1471`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `constants.ts`
+- **Thin community `Community 1472`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `countries.ts`
+- **Thin community `Community 1473`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1475`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1476`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `index.ts`
+- **Thin community `Community 1478`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `store.ts`
+- **Thin community `Community 1479`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `bag.ts`
+- **Thin community `Community 1480`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1481`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `category.ts`
+- **Thin community `Community 1482`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `organization.ts`
+- **Thin community `Community 1483`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `product.ts`
+- **Thin community `Community 1484`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `store.ts`
+- **Thin community `Community 1485`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1486`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `user.ts`
+- **Thin community `Community 1487`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `states.ts`
+- **Thin community `Community 1488`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1492`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1494`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1495`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `index.tsx`
+- **Thin community `Community 1496`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1497`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `index.tsx`
+- **Thin community `Community 1498`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1499`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1500`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1501`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1502`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1503`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `index.tsx`
+- **Thin community `Community 1504`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1505`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1506`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1507`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1508`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `index.js`
+- **Thin community `Community 1509`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1516`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1517`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1518`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11,7 +11,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentsourceid",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L223",
+      "source_location": "L227",
       "target": "adjustments_applystockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -23,7 +23,7 @@
       "relation": "calls",
       "source": "adjustments_readactiveheldquantitiesforstockopssnapshot",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L410",
+      "source_location": "L414",
       "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
@@ -35,7 +35,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L314",
+      "source_location": "L318",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -47,7 +47,7 @@
       "relation": "calls",
       "source": "adjustments_buildresolvedstockadjustmentstatus",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L327",
+      "source_location": "L331",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -59,7 +59,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentdecisioneventtype",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L344",
+      "source_location": "L348",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -71,7 +71,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L357",
+      "source_location": "L361",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -83,7 +83,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L354",
+      "source_location": "L358",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -95,7 +95,7 @@
       "relation": "calls",
       "source": "adjustments_mapsubmitstockadjustmentbatcherror",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L851",
+      "source_location": "L860",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -107,7 +107,7 @@
       "relation": "calls",
       "source": "adjustments_submitstockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L849",
+      "source_location": "L858",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -119,7 +119,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L750",
+      "source_location": "L759",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -131,7 +131,7 @@
       "relation": "calls",
       "source": "adjustments_assertdistinctstockadjustmentlineitems",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L610",
+      "source_location": "L619",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -143,7 +143,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L706",
+      "source_location": "L715",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -155,7 +155,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L598",
+      "source_location": "L607",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -167,7 +167,7 @@
       "relation": "calls",
       "source": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L543",
+      "source_location": "L552",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -1139,7 +1139,7 @@
       "relation": "calls",
       "source": "checkoutsession_checkifitemshavechanged",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1184",
+      "source_location": "L1186",
       "target": "checkoutsession_handleexistingsession",
       "weight": 1
     },
@@ -1151,7 +1151,7 @@
       "relation": "calls",
       "source": "checkoutsession_handleexistingsession",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1270",
+      "source_location": "L1272",
       "target": "checkoutsession_findbestvaluepromocode",
       "weight": 1
     },
@@ -1163,7 +1163,7 @@
       "relation": "calls",
       "source": "checkoutsession_listsessionitems",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1309",
+      "source_location": "L1311",
       "target": "checkoutsession_handleexistingsession",
       "weight": 1
     },
@@ -1175,7 +1175,7 @@
       "relation": "calls",
       "source": "checkoutsession_updateexistingsession",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1190",
+      "source_location": "L1192",
       "target": "checkoutsession_handleexistingsession",
       "weight": 1
     },
@@ -1187,7 +1187,7 @@
       "relation": "calls",
       "source": "checkoutsession_handleexistingsession",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1215",
+      "source_location": "L1217",
       "target": "checkoutsession_validateexistingdiscount",
       "weight": 1
     },
@@ -1199,7 +1199,7 @@
       "relation": "calls",
       "source": "checkoutsession_handleordercreation",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L752",
+      "source_location": "L754",
       "target": "checkoutsession_createonlineorder",
       "weight": 1
     },
@@ -1211,7 +1211,7 @@
       "relation": "calls",
       "source": "checkoutsession_handleplaceorder",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L716",
+      "source_location": "L718",
       "target": "checkoutsession_createonlineorder",
       "weight": 1
     },
@@ -8003,7 +8003,7 @@
       "relation": "calls",
       "source": "listregistercatalog_mapskutoregistercatalogrow",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L121",
+      "source_location": "L125",
       "target": "listregistercatalog_listregistercatalog",
       "weight": 1
     },
@@ -8015,7 +8015,7 @@
       "relation": "calls",
       "source": "listregistercatalog_readcategoryname",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L124",
+      "source_location": "L128",
       "target": "listregistercatalog_listregistercatalog",
       "weight": 1
     },
@@ -8027,7 +8027,7 @@
       "relation": "calls",
       "source": "listregistercatalog_readcolorname",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L125",
+      "source_location": "L129",
       "target": "listregistercatalog_listregistercatalog",
       "weight": 1
     },
@@ -9892,6 +9892,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
+      "_tgt": "bestseller_test_gethandler",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
+      "source_location": "L6",
+      "target": "bestseller_test_gethandler",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "_tgt": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "confidence": "EXTRACTED",
@@ -10937,13 +10949,25 @@
     },
     {
       "_src": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
+      "_tgt": "products_sku_test_createproductsqueryctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L110",
+      "target": "products_sku_test_createproductsqueryctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "_tgt": "products_sku_test_createskumutationctx",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L14",
+      "source_location": "L22",
       "target": "products_sku_test_createskumutationctx",
       "weight": 1
     },
@@ -10955,7 +10979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L10",
+      "source_location": "L18",
       "target": "products_sku_test_gethandler",
       "weight": 1
     },
@@ -10967,7 +10991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70",
+      "source_location": "L71",
       "target": "products_calculatetotalavailablecount",
       "weight": 1
     },
@@ -10979,7 +11003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65",
+      "source_location": "L66",
       "target": "products_calculatetotalinventorycount",
       "weight": 1
     },
@@ -10991,7 +11015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42",
+      "source_location": "L43",
       "target": "products_generatebarcode",
       "weight": 1
     },
@@ -11003,7 +11027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18",
+      "source_location": "L19",
       "target": "products_generatesku",
       "weight": 1
     },
@@ -15167,7 +15191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L133",
+      "source_location": "L137",
       "target": "listregistercatalog_listregistercatalogavailability",
       "weight": 1
     },
@@ -15215,7 +15239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L122",
+      "source_location": "L126",
       "target": "searchcatalog_lookupbybarcode",
       "weight": 1
     },
@@ -15239,7 +15263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L72",
+      "source_location": "L76",
       "target": "searchcatalog_searchproducts",
       "weight": 1
     },
@@ -16871,7 +16895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L210",
+      "source_location": "L214",
       "target": "adjustments_applystockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -16883,7 +16907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L134",
+      "source_location": "L138",
       "target": "adjustments_assertdistinctstockadjustmentlineitems",
       "weight": 1
     },
@@ -16895,7 +16919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L164",
+      "source_location": "L168",
       "target": "adjustments_assertnormalizedlineitem",
       "weight": 1
     },
@@ -16907,7 +16931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L268",
+      "source_location": "L272",
       "target": "adjustments_buildresolvedstockadjustmentstatus",
       "weight": 1
     },
@@ -16919,7 +16943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L258",
+      "source_location": "L262",
       "target": "adjustments_buildstockadjustmentdecisioneventtype",
       "weight": 1
     },
@@ -16931,7 +16955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L150",
+      "source_location": "L154",
       "target": "adjustments_buildstockadjustmentsourceid",
       "weight": 1
     },
@@ -16943,7 +16967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L154",
+      "source_location": "L158",
       "target": "adjustments_buildstockadjustmenttitle",
       "weight": 1
     },
@@ -16967,7 +16991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L397",
+      "source_location": "L401",
       "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
@@ -16991,7 +17015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L791",
+      "source_location": "L800",
       "target": "adjustments_mapsubmitstockadjustmentbatcherror",
       "weight": 1
     },
@@ -17003,7 +17027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L368",
+      "source_location": "L372",
       "target": "adjustments_readactiveheldquantitiesforstockopssnapshot",
       "weight": 1
     },
@@ -17015,7 +17039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L274",
+      "source_location": "L278",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -17027,7 +17051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L844",
+      "source_location": "L853",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -17039,7 +17063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L594",
+      "source_location": "L603",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -17051,7 +17075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L513",
+      "source_location": "L522",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -17807,7 +17831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447",
+      "source_location": "L1449",
       "target": "checkoutsession_calculatepromocodevalue",
       "weight": 1
     },
@@ -17819,7 +17843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990",
+      "source_location": "L992",
       "target": "checkoutsession_checkadjustedavailability",
       "weight": 1
     },
@@ -17843,7 +17867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765",
+      "source_location": "L767",
       "target": "checkoutsession_createonlineorder",
       "weight": 1
     },
@@ -17855,7 +17879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651",
+      "source_location": "L653",
       "target": "checkoutsession_createpatchobject",
       "weight": 1
     },
@@ -17867,7 +17891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102",
+      "source_location": "L1104",
       "target": "checkoutsession_createsessionitems",
       "weight": 1
     },
@@ -17879,7 +17903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979",
+      "source_location": "L981",
       "target": "checkoutsession_fetchproductskus",
       "weight": 1
     },
@@ -17891,7 +17915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495",
+      "source_location": "L1497",
       "target": "checkoutsession_findbestvaluepromocode",
       "weight": 1
     },
@@ -17903,7 +17927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161",
+      "source_location": "L1163",
       "target": "checkoutsession_handleexistingsession",
       "weight": 1
     },
@@ -17915,7 +17939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734",
+      "source_location": "L736",
       "target": "checkoutsession_handleordercreation",
       "weight": 1
     },
@@ -17927,7 +17951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698",
+      "source_location": "L700",
       "target": "checkoutsession_handleplaceorder",
       "weight": 1
     },
@@ -17951,7 +17975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951",
+      "source_location": "L953",
       "target": "checkoutsession_retrieveactivecheckoutsession",
       "weight": 1
     },
@@ -17963,7 +17987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140",
+      "source_location": "L1142",
       "target": "checkoutsession_updateavailability",
       "weight": 1
     },
@@ -17975,7 +17999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020",
+      "source_location": "L1022",
       "target": "checkoutsession_updateexistingsession",
       "weight": 1
     },
@@ -17987,7 +18011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123",
+      "source_location": "L1125",
       "target": "checkoutsession_updateproductavailability",
       "weight": 1
     },
@@ -17999,7 +18023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321",
+      "source_location": "L1323",
       "target": "checkoutsession_validateexistingdiscount",
       "weight": 1
     },
@@ -25097,14 +25121,14 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_product_actions_tsx",
-      "_tgt": "product_actions_usedeleteproduct",
+      "_tgt": "product_actions_usearchiveproduct",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_actions_tsx",
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6",
-      "target": "product_actions_usedeleteproduct",
+      "target": "product_actions_usearchiveproduct",
       "weight": 1
     },
     {
@@ -28373,13 +28397,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_hooks_usegetproducts_ts",
+      "_tgt": "usegetproducts_usegetarchivedproducts",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_hooks_usegetproducts_ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L36",
+      "target": "usegetproducts_usegetarchivedproducts",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "_tgt": "usegetproducts_usegetproducts",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L5",
+      "source_location": "L7",
       "target": "usegetproducts_usegetproducts",
       "weight": 1
     },
@@ -28391,7 +28427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L31",
+      "source_location": "L40",
       "target": "usegetproducts_usegetunresolvedproducts",
       "weight": 1
     },
@@ -39160,6 +39196,18 @@
       "weight": 1
     },
     {
+      "_src": "products_sku_test_createproductsqueryctx",
+      "_tgt": "products_sku_test_createskumutationctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "products_sku_test_createskumutationctx",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L111",
+      "target": "products_sku_test_createproductsqueryctx",
+      "weight": 1
+    },
+    {
       "_src": "productstock_shoulddisable",
       "_tgt": "productstock_isskureserved",
       "confidence": "EXTRACTED",
@@ -46235,7 +46283,7 @@
       "relation": "calls",
       "source": "searchcatalog_mapskutocatalogresult",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L174",
+      "source_location": "L178",
       "target": "searchcatalog_lookupbybarcode",
       "weight": 1
     },
@@ -49192,6 +49240,18 @@
       "weight": 1
     },
     {
+      "_src": "usegetproducts_usegetarchivedproducts",
+      "_tgt": "usegetproducts_usegetproducts",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "usegetproducts_usegetproducts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L37",
+      "target": "usegetproducts_usegetarchivedproducts",
+      "weight": 1
+    },
+    {
       "_src": "useregisterviewmodel_useregisterviewmodel",
       "_tgt": "useregisterviewmodel_hascustomerdetails",
       "confidence": "EXTRACTED",
@@ -50532,6 +50592,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
+      "label": "storeFrontVerificationCode.ts",
+      "norm_label": "storefrontverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
@@ -50539,7 +50608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -50548,7 +50617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -50557,7 +50626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -50566,7 +50635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -50575,7 +50644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -50584,7 +50653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -50593,7 +50662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -50602,21 +50671,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
-      "label": "paystackActions.ts",
-      "norm_label": "paystackactions.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
       "source_location": "L1"
     },
     {
@@ -50685,6 +50745,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
+      "label": "paystackActions.ts",
+      "norm_label": "paystackactions.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
@@ -50692,7 +50761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -50701,7 +50770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -50710,7 +50779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -50719,7 +50788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -50728,7 +50797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -50737,7 +50806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -50746,7 +50815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -50755,21 +50824,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -50838,6 +50898,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
       "norm_label": "approvalpolicy.ts",
@@ -50845,7 +50914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -50854,7 +50923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -50863,7 +50932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -50872,7 +50941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -50881,7 +50950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
       "label": "staffDisplayName.test.ts",
@@ -50890,7 +50959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -50899,7 +50968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -50908,21 +50977,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
       "norm_label": "storesaccordion.tsx",
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "label": "ThemeToggle.tsx",
-      "norm_label": "themetoggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1"
     },
     {
@@ -50991,6 +51051,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
+      "label": "ThemeToggle.tsx",
+      "norm_label": "themetoggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
       "norm_label": "defaultattributestogglegroup.tsx",
@@ -50998,7 +51067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -51007,7 +51076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -51016,7 +51085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51025,7 +51094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51034,7 +51103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51043,7 +51112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -51052,7 +51121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -51061,21 +51130,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
       "norm_label": "revenuechart.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -51144,6 +51204,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -51151,7 +51220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51160,7 +51229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51169,7 +51238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51178,7 +51247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -51187,7 +51256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51196,7 +51265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51205,7 +51274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51214,21 +51283,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -51297,6 +51357,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -51304,7 +51373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51313,7 +51382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -51322,7 +51391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -51331,7 +51400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51340,7 +51409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51349,7 +51418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -51358,7 +51427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -51367,21 +51436,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -51450,6 +51510,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -51457,7 +51526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -51466,7 +51535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -51475,7 +51544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51484,7 +51553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51493,7 +51562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -51502,7 +51571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51511,7 +51580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51520,21 +51589,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -51603,6 +51663,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
       "norm_label": "assetscolumns.tsx",
@@ -51610,7 +51679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -51619,7 +51688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51628,7 +51697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51637,7 +51706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51646,7 +51715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -51655,7 +51724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -51664,7 +51733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -51673,21 +51742,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
       "norm_label": "loginform.test.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1"
     },
     {
@@ -51756,6 +51816,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -51763,7 +51832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51772,7 +51841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51781,7 +51850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51790,7 +51859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51799,7 +51868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -51808,7 +51877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -51817,7 +51886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51826,21 +51895,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -51909,6 +51969,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
       "norm_label": "bulkoperationspage.tsx",
@@ -51916,7 +51985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -51925,7 +51994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -51934,7 +52003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -51943,7 +52012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -51952,7 +52021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -51961,7 +52030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
@@ -51970,7 +52039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -51979,21 +52048,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -52260,6 +52320,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -52267,7 +52336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
       "label": "PageLevelHeader.test.tsx",
@@ -52276,7 +52345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -52285,7 +52354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -52294,7 +52363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
@@ -52303,7 +52372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -52312,7 +52381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -52321,7 +52390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -52330,21 +52399,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
       "norm_label": "orderstatus.test.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
-      "label": "OrderStatus.tsx",
-      "norm_label": "orderstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1"
     },
     {
@@ -52413,6 +52473,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
+      "label": "OrderStatus.tsx",
+      "norm_label": "orderstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
@@ -52420,7 +52489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -52429,7 +52498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -52438,7 +52507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -52447,7 +52516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52456,7 +52525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52465,7 +52534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -52474,7 +52543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -52483,21 +52552,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
       "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
       "source_location": "L1"
     },
     {
@@ -52566,6 +52626,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -52573,7 +52642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52582,7 +52651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52591,7 +52660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -52600,7 +52669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -52609,7 +52678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -52618,7 +52687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -52627,7 +52696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52636,21 +52705,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -52719,6 +52779,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -52726,7 +52795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -52735,7 +52804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -52744,7 +52813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -52753,7 +52822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -52762,7 +52831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -52771,7 +52840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -52780,7 +52849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -52789,21 +52858,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
       "norm_label": "pointofsaleview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "label": "ProductLookup.tsx",
-      "norm_label": "productlookup.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1"
     },
     {
@@ -52872,6 +52932,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
+      "label": "ProductLookup.tsx",
+      "norm_label": "productlookup.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
       "norm_label": "registeractions.tsx",
@@ -52879,7 +52948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -52888,7 +52957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -52897,7 +52966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -52906,7 +52975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -52915,7 +52984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -52924,7 +52993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -52933,7 +53002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -52942,21 +53011,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
       "norm_label": "posregisterview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
-      "label": "RegisterActionBar.test.tsx",
-      "norm_label": "registeractionbar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.test.tsx",
       "source_location": "L1"
     },
     {
@@ -53025,6 +53085,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
+      "label": "RegisterActionBar.test.tsx",
+      "norm_label": "registeractionbar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
       "norm_label": "registeractionbar.tsx",
@@ -53032,7 +53101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -53041,7 +53110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -53050,7 +53119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
       "label": "POSSessionsView.test.tsx",
@@ -53059,7 +53128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
@@ -53068,7 +53137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -53077,7 +53146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -53086,7 +53155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -53095,21 +53164,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
       "norm_label": "receivingview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1"
     },
     {
@@ -53178,6 +53238,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
       "norm_label": "attributesview.tsx",
@@ -53185,7 +53254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -53194,7 +53263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -53203,7 +53272,16 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
+      "label": "ArchivedProducts.tsx",
+      "norm_label": "archivedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ArchivedProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -53212,7 +53290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -53221,7 +53299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -53230,7 +53308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -53239,30 +53317,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
       "norm_label": "unresolvedproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "label": "ComplimentaryProducts.tsx",
-      "norm_label": "complimentaryproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "label": "complimentaryProductsColumn.tsx",
-      "norm_label": "complimentaryproductscolumn.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1"
     },
     {
@@ -53331,6 +53391,24 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
+      "label": "ComplimentaryProducts.tsx",
+      "norm_label": "complimentaryproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
+      "label": "complimentaryProductsColumn.tsx",
+      "norm_label": "complimentaryproductscolumn.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -53338,7 +53416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53347,7 +53425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -53356,7 +53434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -53365,7 +53443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -53374,7 +53452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -53383,7 +53461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -53392,30 +53470,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
       "norm_label": "promocodes.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
-      "label": "PromoCodeAnalytics.tsx",
-      "norm_label": "promocodeanalytics.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
-      "label": "captured-emails-columns.tsx",
-      "norm_label": "captured-emails-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -53484,6 +53544,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
+      "label": "PromoCodeAnalytics.tsx",
+      "norm_label": "promocodeanalytics.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
+      "label": "captured-emails-columns.tsx",
+      "norm_label": "captured-emails-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
       "norm_label": "promocodemoney.test.ts",
@@ -53491,7 +53569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -53500,7 +53578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53509,7 +53587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53518,7 +53596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -53527,7 +53605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53536,7 +53614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -53545,30 +53623,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -53637,6 +53697,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -53644,7 +53722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -53653,7 +53731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -53662,7 +53740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -53671,7 +53749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -53680,7 +53758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -53689,7 +53767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -53698,30 +53776,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/staff/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
-      "label": "StaffAuthenticationDialog.test.tsx",
-      "norm_label": "staffauthenticationdialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
-      "label": "FulfillmentView.test.tsx",
-      "norm_label": "fulfillmentview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -53988,6 +54048,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
+      "label": "StaffAuthenticationDialog.test.tsx",
+      "norm_label": "staffauthenticationdialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
+      "label": "FulfillmentView.test.tsx",
+      "norm_label": "fulfillmentview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
       "norm_label": "maintenanceview.test.tsx",
@@ -53995,7 +54073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -54004,7 +54082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -54013,7 +54091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -54022,7 +54100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -54031,7 +54109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -54040,7 +54118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -54049,30 +54127,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "label": "calendar.test.tsx",
-      "norm_label": "calendar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
@@ -54141,6 +54201,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
+      "label": "calendar.test.tsx",
+      "norm_label": "calendar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
@@ -54148,7 +54226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -54157,7 +54235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -54166,7 +54244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -54175,7 +54253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -54184,7 +54262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -54193,7 +54271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -54202,30 +54280,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
@@ -54294,6 +54354,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
@@ -54301,7 +54379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -54310,7 +54388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -54319,7 +54397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -54328,7 +54406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -54337,7 +54415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -54346,7 +54424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -54355,30 +54433,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
@@ -54447,6 +54507,24 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
@@ -54454,7 +54532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -54463,7 +54541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -54472,7 +54550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -54481,7 +54559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -54490,7 +54568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -54499,7 +54577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -54508,30 +54586,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -54600,6 +54660,24 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1242,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -54607,7 +54685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -54616,7 +54694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -54625,7 +54703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -54634,7 +54712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -54643,7 +54721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -54652,7 +54730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -54661,30 +54739,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -54753,6 +54813,24 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1252,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
       "norm_label": "linkedaccounts.tsx",
@@ -54760,7 +54838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -54769,7 +54847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -54778,7 +54856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -54787,7 +54865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -54796,7 +54874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -54805,7 +54883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -54814,30 +54892,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
       "norm_label": "themecontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
-      "label": "design-system-build-config.test.ts",
-      "norm_label": "design-system-build-config.test.ts",
-      "source_file": "packages/athena-webapp/src/design-system-build-config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -54906,6 +54966,24 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
+      "label": "design-system-build-config.test.ts",
+      "norm_label": "design-system-build-config.test.ts",
+      "source_file": "packages/athena-webapp/src/design-system-build-config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1262,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
       "norm_label": "useauth.test.tsx",
@@ -54913,7 +54991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -54922,7 +55000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -54931,7 +55009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -54940,7 +55018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -54949,7 +55027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -54958,7 +55036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -54967,30 +55045,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
       "norm_label": "presentcommandtoast.test.ts",
       "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
-      "label": "presentUnexpectedErrorToast.test.ts",
-      "norm_label": "presentunexpectederrortoast.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
-      "label": "runCommand.test.ts",
-      "norm_label": "runcommand.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
       "source_location": "L1"
     },
     {
@@ -55059,6 +55119,24 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
+      "label": "presentUnexpectedErrorToast.test.ts",
+      "norm_label": "presentunexpectederrortoast.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
+      "label": "runCommand.test.ts",
+      "norm_label": "runcommand.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1272,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -55066,7 +55144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -55075,7 +55153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -55084,7 +55162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -55093,7 +55171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -55102,7 +55180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -55111,7 +55189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -55120,30 +55198,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1278,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
-      "label": "session.test.ts",
-      "norm_label": "session.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
       "source_location": "L1"
     },
     {
@@ -55203,6 +55263,24 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
+      "label": "session.test.ts",
+      "norm_label": "session.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1282,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
       "norm_label": "registergateway.test.ts",
@@ -55210,7 +55288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -55219,7 +55297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -55228,7 +55306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "label": "useExpenseRegisterViewModel.test.ts",
@@ -55237,7 +55315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
@@ -55246,7 +55324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -55255,7 +55333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -55264,30 +55342,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1"
     },
     {
@@ -55347,6 +55407,24 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1292,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -55354,7 +55432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -55363,7 +55441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -55372,7 +55450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -55381,7 +55459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -55390,7 +55468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -55399,7 +55477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -55408,30 +55486,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1"
     },
     {
@@ -55639,7 +55699,7 @@
       "label": "listRegisterCatalogAvailability()",
       "norm_label": "listregistercatalogavailability()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L133"
+      "source_location": "L137"
     },
     {
       "community": 130,
@@ -55680,6 +55740,24 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
@@ -55687,7 +55765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -55696,7 +55774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -55705,7 +55783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -55714,7 +55792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -55723,7 +55801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -55732,7 +55810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -55741,30 +55819,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
       "norm_label": "configuration.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1"
     },
     {
@@ -55824,6 +55884,24 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1312,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
@@ -55831,7 +55909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -55840,7 +55918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -55849,7 +55927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -55858,7 +55936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -55867,7 +55945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -55876,7 +55954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -55885,30 +55963,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
       "norm_label": "completed.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
@@ -55968,6 +56028,24 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1322,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
@@ -55975,7 +56053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -55984,7 +56062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -55993,7 +56071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -56002,7 +56080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -56011,7 +56089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -56020,7 +56098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -56029,30 +56107,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
       "norm_label": "sessions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1"
     },
     {
@@ -56112,6 +56172,24 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1332,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
@@ -56119,7 +56197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -56128,7 +56206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -56137,7 +56215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -56146,7 +56224,16 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1336,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
+      "label": "archived.tsx",
+      "norm_label": "archived.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -56155,7 +56242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -56164,39 +56251,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1337,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1"
     },
     {
@@ -56256,6 +56316,33 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1342,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1343,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -56263,7 +56350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -56272,7 +56359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -56281,7 +56368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -56290,7 +56377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -56299,7 +56386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -56308,39 +56395,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
       "norm_label": "catalog-management.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1347,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
-      "label": "$traceId.test.tsx",
-      "norm_label": "$traceid.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1"
     },
     {
@@ -56400,6 +56460,33 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
+      "label": "$traceId.test.tsx",
+      "norm_label": "$traceid.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1352,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1353,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -56407,7 +56494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -56416,7 +56503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -56425,7 +56512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -56434,7 +56521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -56443,7 +56530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -56452,39 +56539,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
       "norm_label": "storessettingsaccordion.tsx",
       "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1357,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
       "source_location": "L1"
     },
     {
@@ -56544,6 +56604,33 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1362,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1363,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
       "norm_label": "introduction.stories.tsx",
@@ -56551,7 +56638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -56560,7 +56647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -56569,7 +56656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -56578,7 +56665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -56587,7 +56674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -56596,39 +56683,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
       "norm_label": "view-patterns.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1367,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -56688,6 +56748,33 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1372,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1373,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
       "norm_label": "settingsworkspace.stories.tsx",
@@ -56695,7 +56782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -56704,7 +56791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
@@ -56713,7 +56800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -56722,7 +56809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -56731,7 +56818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -56740,39 +56827,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
       "norm_label": "tailwind.config.js",
       "source_file": "packages/athena-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1377,
-      "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1"
     },
     {
@@ -56832,6 +56892,33 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_athena_webapp_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1382,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1383,
+      "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
       "norm_label": "global.d.ts",
@@ -56839,7 +56926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -56848,7 +56935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -56857,7 +56944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -56866,7 +56953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -56875,7 +56962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -56884,7 +56971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -56893,7 +56980,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 139,
+      "file_type": "code",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1390,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -56902,7 +57043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -56911,7 +57052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1389,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -56920,61 +57061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 1390,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -56983,7 +57070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -56992,7 +57079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -57001,7 +57088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -57010,7 +57097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -57019,7 +57106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -57028,39 +57115,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
       "norm_label": "deliveryfees.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1397,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "label": "deriveCheckoutState.test.ts",
-      "norm_label": "derivecheckoutstate.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1398,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "label": "checkoutFormSchema.ts",
-      "norm_label": "checkoutformschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1"
     },
     {
@@ -57246,59 +57306,86 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
+    },
+    {
       "community": 1400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
+      "label": "deriveCheckoutState.test.ts",
+      "norm_label": "derivecheckoutstate.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1402,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
+      "label": "checkoutFormSchema.ts",
+      "norm_label": "checkoutformschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -57307,7 +57394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -57316,7 +57403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -57325,7 +57412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -57334,7 +57421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -57343,7 +57430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -57352,39 +57439,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
       "norm_label": "bestsellerssection.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1407,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "label": "HomeHero.tsx",
-      "norm_label": "homehero.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1408,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
-      "label": "homePageContent.test.ts",
-      "norm_label": "homepagecontent.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
       "source_location": "L1"
     },
     {
@@ -57444,6 +57504,33 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
+      "label": "HomeHero.tsx",
+      "norm_label": "homehero.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1412,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
+      "label": "homePageContent.test.ts",
+      "norm_label": "homepagecontent.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1413,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
       "norm_label": "mobilemenu.tsx",
@@ -57451,7 +57538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -57460,7 +57547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -57469,7 +57556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -57478,7 +57565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -57487,7 +57574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -57496,39 +57583,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
       "norm_label": "productinfo.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1417,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "label": "ProductReviews.tsx",
-      "norm_label": "productreviews.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1418,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "label": "ErrorMessage.tsx",
-      "norm_label": "errormessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -57588,6 +57648,33 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
+      "label": "ProductReviews.tsx",
+      "norm_label": "productreviews.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1422,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
+      "label": "ErrorMessage.tsx",
+      "norm_label": "errormessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1423,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
       "norm_label": "existingreviewmessage.tsx",
@@ -57595,7 +57682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -57604,7 +57691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -57613,7 +57700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -57622,7 +57709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -57631,7 +57718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -57640,39 +57727,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
       "norm_label": "carticon.tsx",
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1427,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1428,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
-      "label": "Maintenance.test.tsx",
-      "norm_label": "maintenance.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
       "source_location": "L1"
     },
     {
@@ -57732,6 +57792,33 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1432,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
+      "label": "Maintenance.test.tsx",
+      "norm_label": "maintenance.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1433,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
@@ -57739,7 +57826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -57748,7 +57835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -57757,7 +57844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -57766,7 +57853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -57775,7 +57862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -57784,7 +57871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -57793,178 +57880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1438,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 144,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1440,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1441,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1442,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1443,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1444,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "label": "image-with-fallback.tsx",
-      "norm_label": "image-with-fallback.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1445,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1446,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "label": "input-with-end-button.tsx",
-      "norm_label": "input-with-end-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1447,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1448,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "label": "LeaveAReviewModalForm.tsx",
-      "norm_label": "leaveareviewmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -57973,7 +57889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -57982,7 +57898,7 @@
       "source_location": "L147"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -57991,7 +57907,7 @@
       "source_location": "L105"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -58000,7 +57916,7 @@
       "source_location": "L224"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -58009,7 +57925,7 @@
       "source_location": "L228"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -58018,97 +57934,97 @@
       "source_location": "L45"
     },
     {
-      "community": 1450,
+      "community": 1440,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1441,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "label": "welcomeBackModalAnimations.ts",
-      "norm_label": "welcomebackmodalanimations.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1442,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1443,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
+      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1444,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "label": "navigation-menu.tsx",
-      "norm_label": "navigation-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1445,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1446,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1447,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
+      "label": "image-with-fallback.tsx",
+      "norm_label": "image-with-fallback.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1458,
+      "community": 1448,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1459,
+      "community": 1449,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
+      "label": "input-with-end-button.tsx",
+      "norm_label": "input-with-end-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -58117,7 +58033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -58126,7 +58042,7 @@
       "source_location": "L56"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -58135,7 +58051,7 @@
       "source_location": "L87"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -58144,7 +58060,7 @@
       "source_location": "L101"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -58153,7 +58069,7 @@
       "source_location": "L158"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -58162,97 +58078,97 @@
       "source_location": "L139"
     },
     {
-      "community": 1460,
+      "community": 1450,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1451,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1452,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
+      "label": "LeaveAReviewModalForm.tsx",
+      "norm_label": "leaveareviewmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1453,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1454,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
+      "label": "welcomeBackModalAnimations.ts",
+      "norm_label": "welcomebackmodalanimations.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1455,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1456,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1457,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
+      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
+      "label": "navigation-menu.tsx",
+      "norm_label": "navigation-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1458,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1469,
+      "community": 1459,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -58261,7 +58177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -58270,7 +58186,7 @@
       "source_location": "L42"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -58279,7 +58195,7 @@
       "source_location": "L32"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -58288,7 +58204,7 @@
       "source_location": "L62"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -58297,7 +58213,7 @@
       "source_location": "L101"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -58306,97 +58222,97 @@
       "source_location": "L10"
     },
     {
-      "community": 1470,
+      "community": 1460,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
-      "label": "useQueryEnabled.test.ts",
-      "norm_label": "usequeryenabled.test.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
+      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1461,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1462,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
+      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1463,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
+      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1464,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "label": "feeUtils.test.ts",
-      "norm_label": "feeutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
+      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1475,
+      "community": 1465,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
+      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1476,
+      "community": 1466,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
+      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1477,
+      "community": 1467,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "label": "maintenanceUtils.test.ts",
-      "norm_label": "maintenanceutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1478,
+      "community": 1468,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1479,
+      "community": 1469,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -58405,7 +58321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -58414,7 +58330,7 @@
       "source_location": "L17"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -58423,7 +58339,7 @@
       "source_location": "L24"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -58432,7 +58348,7 @@
       "source_location": "L10"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -58441,7 +58357,7 @@
       "source_location": "L33"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -58450,97 +58366,97 @@
       "source_location": "L31"
     },
     {
-      "community": 1480,
+      "community": 1470,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1481,
+      "community": 1471,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1482,
+      "community": 1472,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
+      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1483,
+      "community": 1473,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
+      "label": "useQueryEnabled.test.ts",
+      "norm_label": "usequeryenabled.test.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1474,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1"
     },
     {
-      "community": 1485,
+      "community": 1475,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
+      "id": "packages_storefront_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1486,
+      "community": 1476,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "id": "packages_storefront_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
-      "community": 1487,
+      "community": 1477,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
+      "label": "feeUtils.test.ts",
+      "norm_label": "feeutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1488,
+      "community": 1478,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_states_ts",
-      "label": "states.ts",
-      "norm_label": "states.ts",
-      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "id": "packages_storefront_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
       "source_location": "L1"
     },
     {
-      "community": 1489,
+      "community": 1479,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -58549,7 +58465,7 @@
       "source_location": "L173"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -58558,7 +58474,7 @@
       "source_location": "L71"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -58567,7 +58483,7 @@
       "source_location": "L251"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -58576,7 +58492,7 @@
       "source_location": "L36"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -58585,7 +58501,7 @@
       "source_location": "L277"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -58594,7 +58510,178 @@
       "source_location": "L1"
     },
     {
+      "community": 1480,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
+      "label": "maintenanceUtils.test.ts",
+      "norm_label": "maintenanceutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1481,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1482,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1483,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1484,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1485,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1486,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1487,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1488,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1489,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L102"
+    },
+    {
       "community": 1490,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1491,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_states_ts",
+      "label": "states.ts",
+      "norm_label": "states.ts",
+      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1492,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -58603,7 +58690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1491,
+      "community": 1494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -58612,7 +58699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1492,
+      "community": 1495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -58621,7 +58708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1493,
+      "community": 1496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -58630,7 +58717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1494,
+      "community": 1497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -58639,7 +58726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1495,
+      "community": 1498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -58648,39 +58735,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1496,
+      "community": 1499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1497,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "label": "$subcategorySlug.tsx",
-      "norm_label": "$subcategoryslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1498,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1"
     },
     {
@@ -58866,150 +58926,6 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 1500,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1501,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1502,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
-      "label": "complete.tsx",
-      "norm_label": "complete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1503,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
-      "label": "incomplete.tsx",
-      "norm_label": "incomplete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1504,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1505,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "label": "pending.tsx",
-      "norm_label": "pending.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1506,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/storefront-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1507,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1508,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
       "norm_label": "payments.ts",
@@ -59017,7 +58933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -59026,7 +58942,7 @@
       "source_location": "L3"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -59035,7 +58951,7 @@
       "source_location": "L20"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -59044,7 +58960,7 @@
       "source_location": "L14"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -59053,7 +58969,7 @@
       "source_location": "L7"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -59062,7 +58978,178 @@
       "source_location": "L27"
     },
     {
+      "community": 1500,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
+      "label": "$subcategorySlug.tsx",
+      "norm_label": "$subcategoryslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1501,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1502,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1503,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1504,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1505,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
+      "label": "complete.tsx",
+      "norm_label": "complete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1506,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
+      "label": "incomplete.tsx",
+      "norm_label": "incomplete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1507,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1508,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
+      "label": "pending.tsx",
+      "norm_label": "pending.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1509,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/storefront-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L49"
+    },
+    {
       "community": 1510,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1511,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/storefront-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1512,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1513,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -59071,7 +59158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1511,
+      "community": 1514,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -59080,7 +59167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1512,
+      "community": 1515,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -59089,7 +59176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1513,
+      "community": 1516,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -59098,7 +59185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1514,
+      "community": 1517,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -59107,7 +59194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1515,
+      "community": 1518,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -59118,60 +59205,6 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
       "norm_label": "toastservice.ts",
@@ -59179,7 +59212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -59188,7 +59221,7 @@
       "source_location": "L171"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -59197,7 +59230,7 @@
       "source_location": "L302"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -59206,7 +59239,7 @@
       "source_location": "L319"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -59215,7 +59248,7 @@
       "source_location": "L312"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -59224,7 +59257,7 @@
       "source_location": "L293"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -59233,7 +59266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -59242,7 +59275,7 @@
       "source_location": "L12"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -59251,7 +59284,7 @@
       "source_location": "L21"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -59260,7 +59293,7 @@
       "source_location": "L101"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -59269,7 +59302,7 @@
       "source_location": "L35"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -59278,7 +59311,7 @@
       "source_location": "L66"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -59287,7 +59320,7 @@
       "source_location": "L155"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -59296,7 +59329,7 @@
       "source_location": "L197"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -59305,7 +59338,7 @@
       "source_location": "L104"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -59314,7 +59347,7 @@
       "source_location": "L25"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -59323,7 +59356,7 @@
       "source_location": "L72"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -59332,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -59341,7 +59374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -59350,7 +59383,7 @@
       "source_location": "L231"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -59359,7 +59392,7 @@
       "source_location": "L167"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -59368,7 +59401,7 @@
       "source_location": "L116"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -59377,7 +59410,7 @@
       "source_location": "L83"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -59386,7 +59419,7 @@
       "source_location": "L29"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -59395,7 +59428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -59404,7 +59437,7 @@
       "source_location": "L76"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -59413,7 +59446,7 @@
       "source_location": "L55"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -59422,7 +59455,7 @@
       "source_location": "L88"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -59431,7 +59464,7 @@
       "source_location": "L34"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -59440,7 +59473,7 @@
       "source_location": "L13"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -59449,7 +59482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -59458,7 +59491,7 @@
       "source_location": "L4"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -59467,7 +59500,7 @@
       "source_location": "L49"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -59476,7 +59509,7 @@
       "source_location": "L34"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -59485,7 +59518,7 @@
       "source_location": "L74"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -59494,7 +59527,7 @@
       "source_location": "L6"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -59503,7 +59536,7 @@
       "source_location": "L173"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -59512,7 +59545,7 @@
       "source_location": "L102"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -59521,7 +59554,7 @@
       "source_location": "L201"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -59530,7 +59563,7 @@
       "source_location": "L150"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -59539,12 +59572,66 @@
       "source_location": "L155"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
       "norm_label": "billingdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -59730,60 +59817,6 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
       "norm_label": "checkoutexpired()",
@@ -59791,7 +59824,7 @@
       "source_location": "L9"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -59800,7 +59833,7 @@
       "source_location": "L73"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -59809,7 +59842,7 @@
       "source_location": "L54"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -59818,7 +59851,7 @@
       "source_location": "L98"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -59827,12 +59860,66 @@
       "source_location": "L33"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -60436,7 +60523,7 @@
       "label": "calculateTotalAvailableCount()",
       "norm_label": "calculatetotalavailablecount()",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
+      "source_location": "L71"
     },
     {
       "community": 170,
@@ -60445,7 +60532,7 @@
       "label": "calculateTotalInventoryCount()",
       "norm_label": "calculatetotalinventorycount()",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
+      "source_location": "L66"
     },
     {
       "community": 170,
@@ -60454,7 +60541,7 @@
       "label": "generateBarcode()",
       "norm_label": "generatebarcode()",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
+      "source_location": "L43"
     },
     {
       "community": 170,
@@ -60463,7 +60550,7 @@
       "label": "generateSKU()",
       "norm_label": "generatesku()",
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
+      "source_location": "L19"
     },
     {
       "community": 171,
@@ -64365,6 +64452,78 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
+      "label": "products.sku.test.ts",
+      "norm_label": "products.sku.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "products_sku_test_createproductsqueryctx",
+      "label": "createProductsQueryCtx()",
+      "norm_label": "createproductsqueryctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "products_sku_test_createskumutationctx",
+      "label": "createSkuMutationCtx()",
+      "norm_label": "createskumutationctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "products_sku_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -64372,7 +64531,7 @@
       "source_location": "L26"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -64381,7 +64540,7 @@
       "source_location": "L79"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -64390,7 +64549,7 @@
       "source_location": "L33"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -64399,7 +64558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -64408,7 +64567,7 @@
       "source_location": "L10"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -64417,7 +64576,7 @@
       "source_location": "L18"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -64426,7 +64585,7 @@
       "source_location": "L52"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -64435,7 +64594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -64444,7 +64603,7 @@
       "source_location": "L98"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -64453,7 +64612,7 @@
       "source_location": "L56"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -64462,7 +64621,7 @@
       "source_location": "L49"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -64471,7 +64630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -64480,7 +64639,7 @@
       "source_location": "L28"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -64489,7 +64648,7 @@
       "source_location": "L42"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -64498,7 +64657,7 @@
       "source_location": "L73"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -64507,7 +64666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -64516,7 +64675,7 @@
       "source_location": "L8"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -64525,7 +64684,7 @@
       "source_location": "L32"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -64534,7 +64693,7 @@
       "source_location": "L64"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -64543,7 +64702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -64552,7 +64711,7 @@
       "source_location": "L18"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -64561,7 +64720,7 @@
       "source_location": "L25"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -64570,7 +64729,7 @@
       "source_location": "L11"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -64579,7 +64738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -64588,7 +64747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -64597,7 +64756,7 @@
       "source_location": "L33"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -64606,7 +64765,7 @@
       "source_location": "L19"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -64615,7 +64774,7 @@
       "source_location": "L42"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -64624,7 +64783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -64633,7 +64792,7 @@
       "source_location": "L31"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -64642,7 +64801,7 @@
       "source_location": "L48"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -64651,85 +64810,13 @@
       "source_location": "L131"
     },
     {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "serviceintake_resolveserviceintakecustomerprofile",
-      "label": "resolveServiceIntakeCustomerProfile()",
-      "norm_label": "resolveserviceintakecustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "serviceintake_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "serviceintake_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
-      "label": "register.ts",
-      "norm_label": "register.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "register_mapopendrawerusererror",
-      "label": "mapOpenDrawerUserError()",
-      "norm_label": "mapopendrawerusererror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "register_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "register_opendrawer",
-      "label": "openDrawer()",
-      "norm_label": "opendrawer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L53"
-    },
-    {
       "community": 24,
       "file_type": "code",
       "id": "adjustments_applystockadjustmentbatchwithctx",
       "label": "applyStockAdjustmentBatchWithCtx()",
       "norm_label": "applystockadjustmentbatchwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L210"
+      "source_location": "L214"
     },
     {
       "community": 24,
@@ -64738,7 +64825,7 @@
       "label": "assertDistinctStockAdjustmentLineItems()",
       "norm_label": "assertdistinctstockadjustmentlineitems()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L134"
+      "source_location": "L138"
     },
     {
       "community": 24,
@@ -64747,7 +64834,7 @@
       "label": "assertNormalizedLineItem()",
       "norm_label": "assertnormalizedlineitem()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L164"
+      "source_location": "L168"
     },
     {
       "community": 24,
@@ -64756,7 +64843,7 @@
       "label": "buildResolvedStockAdjustmentStatus()",
       "norm_label": "buildresolvedstockadjustmentstatus()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L268"
+      "source_location": "L272"
     },
     {
       "community": 24,
@@ -64765,7 +64852,7 @@
       "label": "buildStockAdjustmentDecisionEventType()",
       "norm_label": "buildstockadjustmentdecisioneventtype()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L258"
+      "source_location": "L262"
     },
     {
       "community": 24,
@@ -64774,7 +64861,7 @@
       "label": "buildStockAdjustmentSourceId()",
       "norm_label": "buildstockadjustmentsourceid()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L150"
+      "source_location": "L154"
     },
     {
       "community": 24,
@@ -64783,7 +64870,7 @@
       "label": "buildStockAdjustmentTitle()",
       "norm_label": "buildstockadjustmenttitle()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L154"
+      "source_location": "L158"
     },
     {
       "community": 24,
@@ -64801,7 +64888,7 @@
       "label": "listInventorySnapshotWithCtx()",
       "norm_label": "listinventorysnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L397"
+      "source_location": "L401"
     },
     {
       "community": 24,
@@ -64819,7 +64906,7 @@
       "label": "mapSubmitStockAdjustmentBatchError()",
       "norm_label": "mapsubmitstockadjustmentbatcherror()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L791"
+      "source_location": "L800"
     },
     {
       "community": 24,
@@ -64828,7 +64915,7 @@
       "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
       "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L368"
+      "source_location": "L372"
     },
     {
       "community": 24,
@@ -64837,7 +64924,7 @@
       "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
       "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L274"
+      "source_location": "L278"
     },
     {
       "community": 24,
@@ -64846,7 +64933,7 @@
       "label": "submitStockAdjustmentBatchCommandWithCtx()",
       "norm_label": "submitstockadjustmentbatchcommandwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L844"
+      "source_location": "L853"
     },
     {
       "community": 24,
@@ -64855,7 +64942,7 @@
       "label": "submitStockAdjustmentBatchWithCtx()",
       "norm_label": "submitstockadjustmentbatchwithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L594"
+      "source_location": "L603"
     },
     {
       "community": 24,
@@ -64864,7 +64951,7 @@
       "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
       "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L513"
+      "source_location": "L522"
     },
     {
       "community": 24,
@@ -64887,6 +64974,78 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "serviceintake_resolveserviceintakecustomerprofile",
+      "label": "resolveServiceIntakeCustomerProfile()",
+      "norm_label": "resolveserviceintakecustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "serviceintake_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "serviceintake_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
+      "label": "register.ts",
+      "norm_label": "register.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "register_mapopendrawerusererror",
+      "label": "mapOpenDrawerUserError()",
+      "norm_label": "mapopendrawerusererror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "register_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "register_opendrawer",
+      "label": "openDrawer()",
+      "norm_label": "opendrawer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
       "norm_label": "createdbgetmock()",
@@ -64894,7 +65053,7 @@
       "source_location": "L36"
     },
     {
-      "community": 240,
+      "community": 242,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -64903,7 +65062,7 @@
       "source_location": "L96"
     },
     {
-      "community": 240,
+      "community": 242,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -64912,7 +65071,7 @@
       "source_location": "L71"
     },
     {
-      "community": 240,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -64921,7 +65080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -64930,7 +65089,7 @@
       "source_location": "L21"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -64939,7 +65098,7 @@
       "source_location": "L42"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -64948,7 +65107,7 @@
       "source_location": "L80"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -64957,7 +65116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -64966,16 +65125,16 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
       "norm_label": "lookupbybarcode()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L122"
+      "source_location": "L126"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -64984,16 +65143,16 @@
       "source_location": "L34"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
       "norm_label": "searchproducts()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L72"
+      "source_location": "L76"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -65002,7 +65161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -65011,7 +65170,7 @@
       "source_location": "L159"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -65020,7 +65179,7 @@
       "source_location": "L56"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -65029,7 +65188,7 @@
       "source_location": "L177"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -65038,7 +65197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -65047,7 +65206,7 @@
       "source_location": "L23"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -65056,7 +65215,7 @@
       "source_location": "L9"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -65065,7 +65224,7 @@
       "source_location": "L13"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -65074,7 +65233,7 @@
       "source_location": "L19"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -65083,7 +65242,7 @@
       "source_location": "L26"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -65092,7 +65251,7 @@
       "source_location": "L12"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -65101,7 +65260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 248,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -65110,7 +65269,7 @@
       "source_location": "L21"
     },
     {
-      "community": 246,
+      "community": 248,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -65119,7 +65278,7 @@
       "source_location": "L63"
     },
     {
-      "community": 246,
+      "community": 248,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -65128,7 +65287,7 @@
       "source_location": "L71"
     },
     {
-      "community": 246,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -65137,7 +65296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -65146,7 +65305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -65155,7 +65314,7 @@
       "source_location": "L13"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -65164,7 +65323,7 @@
       "source_location": "L31"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -65173,85 +65332,13 @@
       "source_location": "L9"
     },
     {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
-      "label": "staffDisplayName.ts",
-      "norm_label": "staffdisplayname.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplayname",
-      "label": "formatStaffDisplayName()",
-      "norm_label": "formatstaffdisplayname()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
-      "label": "formatStaffDisplayNameOrFallback()",
-      "norm_label": "formatstaffdisplaynameorfallback()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "staffdisplayname_normalizenamepart",
-      "label": "normalizeNamePart()",
-      "norm_label": "normalizenamepart()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "attributesmanager_attributesmanager",
-      "label": "AttributesManager()",
-      "norm_label": "attributesmanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L227"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "attributesmanager_colormanager",
-      "label": "ColorManager()",
-      "norm_label": "colormanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "attributesmanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "label": "AttributesManager.tsx",
-      "norm_label": "attributesmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 25,
       "file_type": "code",
       "id": "checkoutsession_calculatepromocodevalue",
       "label": "calculatePromoCodeValue()",
       "norm_label": "calculatepromocodevalue()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447"
+      "source_location": "L1449"
     },
     {
       "community": 25,
@@ -65260,7 +65347,7 @@
       "label": "checkAdjustedAvailability()",
       "norm_label": "checkadjustedavailability()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990"
+      "source_location": "L992"
     },
     {
       "community": 25,
@@ -65278,7 +65365,7 @@
       "label": "createOnlineOrder()",
       "norm_label": "createonlineorder()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765"
+      "source_location": "L767"
     },
     {
       "community": 25,
@@ -65287,7 +65374,7 @@
       "label": "createPatchObject()",
       "norm_label": "createpatchobject()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651"
+      "source_location": "L653"
     },
     {
       "community": 25,
@@ -65296,7 +65383,7 @@
       "label": "createSessionItems()",
       "norm_label": "createsessionitems()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102"
+      "source_location": "L1104"
     },
     {
       "community": 25,
@@ -65305,7 +65392,7 @@
       "label": "fetchProductSkus()",
       "norm_label": "fetchproductskus()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979"
+      "source_location": "L981"
     },
     {
       "community": 25,
@@ -65314,7 +65401,7 @@
       "label": "findBestValuePromoCode()",
       "norm_label": "findbestvaluepromocode()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495"
+      "source_location": "L1497"
     },
     {
       "community": 25,
@@ -65323,7 +65410,7 @@
       "label": "handleExistingSession()",
       "norm_label": "handleexistingsession()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161"
+      "source_location": "L1163"
     },
     {
       "community": 25,
@@ -65332,7 +65419,7 @@
       "label": "handleOrderCreation()",
       "norm_label": "handleordercreation()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734"
+      "source_location": "L736"
     },
     {
       "community": 25,
@@ -65341,7 +65428,7 @@
       "label": "handlePlaceOrder()",
       "norm_label": "handleplaceorder()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698"
+      "source_location": "L700"
     },
     {
       "community": 25,
@@ -65359,7 +65446,7 @@
       "label": "retrieveActiveCheckoutSession()",
       "norm_label": "retrieveactivecheckoutsession()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951"
+      "source_location": "L953"
     },
     {
       "community": 25,
@@ -65368,7 +65455,7 @@
       "label": "updateAvailability()",
       "norm_label": "updateavailability()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140"
+      "source_location": "L1142"
     },
     {
       "community": 25,
@@ -65377,7 +65464,7 @@
       "label": "updateExistingSession()",
       "norm_label": "updateexistingsession()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020"
+      "source_location": "L1022"
     },
     {
       "community": 25,
@@ -65386,7 +65473,7 @@
       "label": "updateProductAvailability()",
       "norm_label": "updateproductavailability()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123"
+      "source_location": "L1125"
     },
     {
       "community": 25,
@@ -65395,7 +65482,7 @@
       "label": "validateExistingDiscount()",
       "norm_label": "validateexistingdiscount()",
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321"
+      "source_location": "L1323"
     },
     {
       "community": 25,
@@ -65409,6 +65496,78 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
+      "label": "staffDisplayName.ts",
+      "norm_label": "staffdisplayname.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplayname",
+      "label": "formatStaffDisplayName()",
+      "norm_label": "formatstaffdisplayname()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
+      "label": "formatStaffDisplayNameOrFallback()",
+      "norm_label": "formatstaffdisplaynameorfallback()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "staffdisplayname_normalizenamepart",
+      "label": "normalizeNamePart()",
+      "norm_label": "normalizenamepart()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "attributesmanager_attributesmanager",
+      "label": "AttributesManager()",
+      "norm_label": "attributesmanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L227"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "attributesmanager_colormanager",
+      "label": "ColorManager()",
+      "norm_label": "colormanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "attributesmanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
+      "label": "AttributesManager.tsx",
+      "norm_label": "attributesmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
       "norm_label": "getproductattribute()",
@@ -65416,7 +65575,7 @@
       "source_location": "L55"
     },
     {
-      "community": 250,
+      "community": 252,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -65425,7 +65584,7 @@
       "source_location": "L32"
     },
     {
-      "community": 250,
+      "community": 252,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -65434,7 +65593,7 @@
       "source_location": "L211"
     },
     {
-      "community": 250,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -65443,7 +65602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -65452,7 +65611,7 @@
       "source_location": "L52"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -65461,7 +65620,7 @@
       "source_location": "L27"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -65470,7 +65629,7 @@
       "source_location": "L288"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -65479,7 +65638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -65488,7 +65647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -65497,7 +65656,7 @@
       "source_location": "L15"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -65506,7 +65665,7 @@
       "source_location": "L32"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -65515,7 +65674,7 @@
       "source_location": "L19"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -65524,7 +65683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -65533,7 +65692,7 @@
       "source_location": "L52"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -65542,7 +65701,7 @@
       "source_location": "L3"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -65551,7 +65710,7 @@
       "source_location": "L90"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -65560,7 +65719,7 @@
       "source_location": "L86"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -65569,7 +65728,7 @@
       "source_location": "L76"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -65578,7 +65737,7 @@
       "source_location": "L52"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -65587,7 +65746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -65596,7 +65755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -65605,7 +65764,7 @@
       "source_location": "L67"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -65614,7 +65773,7 @@
       "source_location": "L90"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -65623,7 +65782,7 @@
       "source_location": "L73"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -65632,7 +65791,7 @@
       "source_location": "L78"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -65641,7 +65800,7 @@
       "source_location": "L67"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -65650,7 +65809,7 @@
       "source_location": "L85"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -65659,7 +65818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -65668,7 +65827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -65677,7 +65836,7 @@
       "source_location": "L67"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -65686,85 +65845,13 @@
       "source_location": "L61"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
       "norm_label": "useapprovedcommand()",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
       "source_location": "L73"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
-      "label": "ReturnExchangeView.tsx",
-      "norm_label": "returnexchangeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "returnexchangeview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "returnexchangeview_resetreplacementfields",
-      "label": "resetReplacementFields()",
-      "norm_label": "resetreplacementfields()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "returnexchangeview_toggleitem",
-      "label": "toggleItem()",
-      "norm_label": "toggleitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -65931,6 +66018,78 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "label": "ReturnExchangeView.tsx",
+      "norm_label": "returnexchangeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "returnexchangeview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "returnexchangeview_resetreplacementfields",
+      "label": "resetReplacementFields()",
+      "norm_label": "resetreplacementfields()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "returnexchangeview_toggleitem",
+      "label": "toggleItem()",
+      "norm_label": "toggleitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
       "norm_label": "transactionview.test.tsx",
@@ -65938,7 +66097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 262,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -65947,7 +66106,7 @@
       "source_location": "L162"
     },
     {
-      "community": 260,
+      "community": 262,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -65956,7 +66115,7 @@
       "source_location": "L384"
     },
     {
-      "community": 260,
+      "community": 262,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -65965,7 +66124,7 @@
       "source_location": "L345"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -65974,7 +66133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -65983,7 +66142,7 @@
       "source_location": "L22"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -65992,7 +66151,7 @@
       "source_location": "L27"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -66001,7 +66160,7 @@
       "source_location": "L40"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -66010,7 +66169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -66019,7 +66178,7 @@
       "source_location": "L78"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -66028,7 +66187,7 @@
       "source_location": "L118"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -66037,7 +66196,7 @@
       "source_location": "L89"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -66046,7 +66205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -66055,7 +66214,7 @@
       "source_location": "L63"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -66064,7 +66223,7 @@
       "source_location": "L54"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -66073,7 +66232,7 @@
       "source_location": "L11"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -66082,7 +66241,7 @@
       "source_location": "L16"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -66091,7 +66250,7 @@
       "source_location": "L35"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -66100,7 +66259,7 @@
       "source_location": "L6"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -66109,7 +66268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -66118,7 +66277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -66127,7 +66286,7 @@
       "source_location": "L5"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -66136,7 +66295,7 @@
       "source_location": "L30"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -66145,7 +66304,7 @@
       "source_location": "L21"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -66154,7 +66313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -66163,7 +66322,7 @@
       "source_location": "L178"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -66172,7 +66331,7 @@
       "source_location": "L205"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -66181,7 +66340,7 @@
       "source_location": "L806"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -66190,7 +66349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -66199,7 +66358,7 @@
       "source_location": "L41"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -66208,85 +66367,13 @@
       "source_location": "L45"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
       "norm_label": "workflowtraceheader()",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
       "source_location": "L65"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "engagementmetrics_formatlastactivity",
-      "label": "formatLastActivity()",
-      "norm_label": "formatlastactivity()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "engagementmetrics_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "engagementmetrics_getdevicelabel",
-      "label": "getDeviceLabel()",
-      "norm_label": "getdevicelabel()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "label": "EngagementMetrics.tsx",
-      "norm_label": "engagementmetrics.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "label": "RiskIndicators.tsx",
-      "norm_label": "riskindicators.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "riskindicators_getriskicon",
-      "label": "getRiskIcon()",
-      "norm_label": "getriskicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "riskindicators_getriskstyles",
-      "label": "getRiskStyles()",
-      "norm_label": "getriskstyles()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "riskindicators_riskindicators",
-      "label": "RiskIndicators()",
-      "norm_label": "riskindicators()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L54"
     },
     {
       "community": 27,
@@ -66453,6 +66540,114 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "engagementmetrics_formatlastactivity",
+      "label": "formatLastActivity()",
+      "norm_label": "formatlastactivity()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "engagementmetrics_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "engagementmetrics_getdevicelabel",
+      "label": "getDeviceLabel()",
+      "norm_label": "getdevicelabel()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
+      "label": "EngagementMetrics.tsx",
+      "norm_label": "engagementmetrics.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
+      "label": "RiskIndicators.tsx",
+      "norm_label": "riskindicators.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "riskindicators_getriskicon",
+      "label": "getRiskIcon()",
+      "norm_label": "getriskicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "riskindicators_getriskstyles",
+      "label": "getRiskStyles()",
+      "norm_label": "getriskstyles()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "riskindicators_riskindicators",
+      "label": "RiskIndicators()",
+      "norm_label": "riskindicators()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
+      "label": "useGetProducts.ts",
+      "norm_label": "usegetproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "usegetproducts_usegetarchivedproducts",
+      "label": "useGetArchivedProducts()",
+      "norm_label": "usegetarchivedproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "usegetproducts_usegetproducts",
+      "label": "useGetProducts()",
+      "norm_label": "usegetproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "usegetproducts_usegetunresolvedproducts",
+      "label": "useGetUnresolvedProducts()",
+      "norm_label": "usegetunresolvedproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
       "norm_label": "formatobservabilitylabel()",
@@ -66460,7 +66655,7 @@
       "source_location": "L66"
     },
     {
-      "community": 270,
+      "community": 273,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -66469,7 +66664,7 @@
       "source_location": "L121"
     },
     {
-      "community": 270,
+      "community": 273,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -66478,7 +66673,7 @@
       "source_location": "L74"
     },
     {
-      "community": 270,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -66487,7 +66682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -66496,7 +66691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -66505,7 +66700,7 @@
       "source_location": "L34"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -66514,7 +66709,7 @@
       "source_location": "L28"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -66523,7 +66718,7 @@
       "source_location": "L48"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -66532,7 +66727,7 @@
       "source_location": "L51"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -66541,7 +66736,7 @@
       "source_location": "L92"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -66550,7 +66745,7 @@
       "source_location": "L16"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -66559,7 +66754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -66568,7 +66763,7 @@
       "source_location": "L22"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -66577,7 +66772,7 @@
       "source_location": "L10"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -66586,7 +66781,7 @@
       "source_location": "L57"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -66595,7 +66790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -66604,7 +66799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -66613,7 +66808,7 @@
       "source_location": "L83"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -66622,7 +66817,7 @@
       "source_location": "L100"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -66631,7 +66826,7 @@
       "source_location": "L79"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -66640,7 +66835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -66649,7 +66844,7 @@
       "source_location": "L38"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -66658,7 +66853,7 @@
       "source_location": "L65"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -66667,7 +66862,7 @@
       "source_location": "L91"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -66676,7 +66871,7 @@
       "source_location": "L4"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -66685,7 +66880,7 @@
       "source_location": "L20"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -66694,121 +66889,13 @@
       "source_location": "L42"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
       "norm_label": "fingerprint.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
-      "label": "useExpenseRegisterViewModel.ts",
-      "norm_label": "useexpenseregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
-      "label": "getExpenseSessionLoadKey()",
-      "norm_label": "getexpensesessionloadkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
-      "label": "useExpenseRegisterViewModel()",
-      "norm_label": "useexpenseregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
     },
     {
       "community": 28,
@@ -66966,6 +67053,114 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
+      "label": "useExpenseRegisterViewModel.ts",
+      "norm_label": "useexpenseregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
+      "label": "getExpenseSessionLoadKey()",
+      "norm_label": "getexpensesessionloadkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
+      "label": "useExpenseRegisterViewModel()",
+      "norm_label": "useexpenseregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -66973,7 +67168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 283,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -66982,7 +67177,7 @@
       "source_location": "L11"
     },
     {
-      "community": 280,
+      "community": 283,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -66991,7 +67186,7 @@
       "source_location": "L9"
     },
     {
-      "community": 280,
+      "community": 283,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -67000,7 +67195,7 @@
       "source_location": "L25"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -67009,7 +67204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -67018,7 +67213,7 @@
       "source_location": "L50"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -67027,7 +67222,7 @@
       "source_location": "L92"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -67036,7 +67231,7 @@
       "source_location": "L74"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -67045,7 +67240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -67054,7 +67249,7 @@
       "source_location": "L62"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -67063,7 +67258,7 @@
       "source_location": "L109"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -67072,7 +67267,7 @@
       "source_location": "L177"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -67081,7 +67276,7 @@
       "source_location": "L18"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -67090,7 +67285,7 @@
       "source_location": "L52"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -67099,7 +67294,7 @@
       "source_location": "L68"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -67108,7 +67303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -67117,7 +67312,7 @@
       "source_location": "L68"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -67126,7 +67321,7 @@
       "source_location": "L26"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -67135,7 +67330,7 @@
       "source_location": "L7"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -67144,7 +67339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -67153,7 +67348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -67162,7 +67357,7 @@
       "source_location": "L81"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -67171,7 +67366,7 @@
       "source_location": "L85"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -67180,7 +67375,7 @@
       "source_location": "L27"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -67189,7 +67384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -67198,7 +67393,7 @@
       "source_location": "L43"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -67207,121 +67402,13 @@
       "source_location": "L13"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
       "norm_label": "shippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "label": "UpsellModal.tsx",
-      "norm_label": "upsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "upsellmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L111"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "upsellmodal_handlescroll",
-      "label": "handleScroll()",
-      "norm_label": "handlescroll()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "upsellmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "label": "StoreContext.tsx",
-      "norm_label": "storecontext.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "storecontext_storeprovider",
-      "label": "StoreProvider()",
-      "norm_label": "storeprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "storecontext_useoptionalstorecontext",
-      "label": "useOptionalStoreContext()",
-      "norm_label": "useoptionalstorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "storecontext_usestorecontext",
-      "label": "useStoreContext()",
-      "norm_label": "usestorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 29,
@@ -67479,6 +67566,78 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
+      "label": "UpsellModal.tsx",
+      "norm_label": "upsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "upsellmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L111"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "upsellmodal_handlescroll",
+      "label": "handleScroll()",
+      "norm_label": "handlescroll()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "upsellmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
+      "label": "StoreContext.tsx",
+      "norm_label": "storecontext.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "storecontext_storeprovider",
+      "label": "StoreProvider()",
+      "norm_label": "storeprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "storecontext_useoptionalstorecontext",
+      "label": "useOptionalStoreContext()",
+      "norm_label": "useoptionalstorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "storecontext_usestorecontext",
+      "label": "useStoreContext()",
+      "norm_label": "usestorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
       "norm_label": "_shoplayout.tsx",
@@ -67486,7 +67645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -67495,7 +67654,7 @@
       "source_location": "L115"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -67504,7 +67663,7 @@
       "source_location": "L105"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -67513,7 +67672,7 @@
       "source_location": "L110"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -67522,7 +67681,7 @@
       "source_location": "L121"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -67531,7 +67690,7 @@
       "source_location": "L26"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -67540,7 +67699,7 @@
       "source_location": "L71"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -67549,7 +67708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -67558,7 +67717,7 @@
       "source_location": "L46"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -67567,7 +67726,7 @@
       "source_location": "L24"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -67576,7 +67735,7 @@
       "source_location": "L20"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -67585,7 +67744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -67594,7 +67753,7 @@
       "source_location": "L17"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -67603,7 +67762,7 @@
       "source_location": "L11"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -67612,7 +67771,7 @@
       "source_location": "L24"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -67621,7 +67780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -67630,7 +67789,7 @@
       "source_location": "L20"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -67639,7 +67798,7 @@
       "source_location": "L65"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -67648,7 +67807,7 @@
       "source_location": "L14"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -67657,7 +67816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -67666,7 +67825,7 @@
       "source_location": "L126"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -67675,7 +67834,7 @@
       "source_location": "L130"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -67684,7 +67843,7 @@
       "source_location": "L879"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -67693,7 +67852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -67702,7 +67861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -67711,7 +67870,7 @@
       "source_location": "L8"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -67720,7 +67879,7 @@
       "source_location": "L79"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -67729,7 +67888,7 @@
       "source_location": "L61"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -67738,7 +67897,7 @@
       "source_location": "L49"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -67747,7 +67906,7 @@
       "source_location": "L17"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -67756,84 +67915,12 @@
       "source_location": "L11"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
       "norm_label": "harness-scorecard.test.ts",
       "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "harness_test_collectharnesstesttargets",
-      "label": "collectHarnessTestTargets()",
-      "norm_label": "collectharnesstesttargets()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "harness_test_parseharnesstestcliargs",
-      "label": "parseHarnessTestCliArgs()",
-      "norm_label": "parseharnesstestcliargs()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "harness_test_runharnesstest",
-      "label": "runHarnessTest()",
-      "norm_label": "runharnesstest()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "scripts_harness_test_ts",
-      "label": "harness-test.ts",
-      "norm_label": "harness-test.ts",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "pre_push_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "pre_push_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "pre_push_review_test_warn",
-      "label": "warn()",
-      "norm_label": "warn()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_test_ts",
-      "label": "pre-push-review.test.ts",
-      "norm_label": "pre-push-review.test.ts",
-      "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -68280,6 +68367,78 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "harness_test_collectharnesstesttargets",
+      "label": "collectHarnessTestTargets()",
+      "norm_label": "collectharnesstesttargets()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "harness_test_parseharnesstestcliargs",
+      "label": "parseHarnessTestCliArgs()",
+      "norm_label": "parseharnesstestcliargs()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "harness_test_runharnesstest",
+      "label": "runHarnessTest()",
+      "norm_label": "runharnesstest()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "scripts_harness_test_ts",
+      "label": "harness-test.ts",
+      "norm_label": "harness-test.ts",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "pre_push_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "pre_push_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "pre_push_review_test_warn",
+      "label": "warn()",
+      "norm_label": "warn()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_test_ts",
+      "label": "pre-push-review.test.ts",
+      "norm_label": "pre-push-review.test.ts",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
       "norm_label": "makedir()",
@@ -68287,7 +68446,7 @@
       "source_location": "L17"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -68296,7 +68455,7 @@
       "source_location": "L23"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -68305,7 +68464,7 @@
       "source_location": "L40"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -68314,7 +68473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -68323,7 +68482,7 @@
       "source_location": "L15"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -68332,7 +68491,7 @@
       "source_location": "L11"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -68341,7 +68500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -68350,7 +68509,7 @@
       "source_location": "L98"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -68359,7 +68518,7 @@
       "source_location": "L33"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -68368,7 +68527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -68377,7 +68536,7 @@
       "source_location": "L85"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -68386,7 +68545,7 @@
       "source_location": "L31"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -68395,7 +68554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -68404,7 +68563,7 @@
       "source_location": "L12"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -68413,7 +68572,7 @@
       "source_location": "L21"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -68422,7 +68581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -68431,7 +68590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -68440,7 +68599,7 @@
       "source_location": "L5"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -68449,7 +68608,7 @@
       "source_location": "L12"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
@@ -68458,7 +68617,7 @@
       "source_location": "L467"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
@@ -68467,7 +68626,7 @@
       "source_location": "L38"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -68476,34 +68635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
-      "label": "products.sku.test.ts",
-      "norm_label": "products.sku.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "products_sku_test_createskumutationctx",
-      "label": "createSkuMutationCtx()",
-      "norm_label": "createskumutationctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "products_sku_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -68512,7 +68644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -68521,40 +68653,13 @@
       "source_location": "L6"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
       "norm_label": "readsourceslice()",
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "analyticsutils_calculateactivitytrend",
-      "label": "calculateActivityTrend()",
-      "norm_label": "calculateactivitytrend()",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "analyticsutils_calculatedevicedistribution",
-      "label": "calculateDeviceDistribution()",
-      "norm_label": "calculatedevicedistribution()",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "label": "analyticsUtils.ts",
-      "norm_label": "analyticsutils.ts",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L1"
     },
     {
       "community": 31,
@@ -68712,6 +68817,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "analyticsutils_calculateactivitytrend",
+      "label": "calculateActivityTrend()",
+      "norm_label": "calculateactivitytrend()",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "analyticsutils_calculatedevicedistribution",
+      "label": "calculateDeviceDistribution()",
+      "norm_label": "calculatedevicedistribution()",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
+      "label": "analyticsUtils.ts",
+      "norm_label": "analyticsutils.ts",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
       "norm_label": "staffcredentials.test.ts",
@@ -68719,7 +68851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -68728,7 +68860,7 @@
       "source_location": "L26"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -68737,7 +68869,7 @@
       "source_location": "L118"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -68746,7 +68878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -68755,7 +68887,7 @@
       "source_location": "L16"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -68764,7 +68896,7 @@
       "source_location": "L92"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -68773,7 +68905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -68782,7 +68914,7 @@
       "source_location": "L21"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -68791,7 +68923,7 @@
       "source_location": "L31"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -68800,7 +68932,7 @@
       "source_location": "L7"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -68809,7 +68941,7 @@
       "source_location": "L109"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -68818,7 +68950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -68827,7 +68959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -68836,7 +68968,7 @@
       "source_location": "L18"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -68845,7 +68977,7 @@
       "source_location": "L9"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -68854,7 +68986,7 @@
       "source_location": "L8"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -68863,7 +68995,7 @@
       "source_location": "L9"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -68872,7 +69004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -68881,7 +69013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -68890,7 +69022,7 @@
       "source_location": "L7"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -68899,7 +69031,7 @@
       "source_location": "L29"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -68908,7 +69040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -68917,7 +69049,7 @@
       "source_location": "L13"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -68926,7 +69058,7 @@
       "source_location": "L45"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -68935,7 +69067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -68944,40 +69076,13 @@
       "source_location": "L36"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
       "norm_label": "mapregistersessiontocashdrawersummary()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
-      "label": "transactions.test.ts",
-      "norm_label": "transactions.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "transactions_test_exportreturns",
-      "label": "exportReturns()",
-      "norm_label": "exportreturns()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "transactions_test_parsevalidator",
-      "label": "parseValidator()",
-      "norm_label": "parsevalidator()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L18"
     },
     {
       "community": 32,
@@ -69126,6 +69231,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
+      "label": "transactions.test.ts",
+      "norm_label": "transactions.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "transactions_test_exportreturns",
+      "label": "exportReturns()",
+      "norm_label": "exportreturns()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "transactions_test_parsevalidator",
+      "label": "parseValidator()",
+      "norm_label": "parsevalidator()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
       "norm_label": "buildserviceappointment()",
@@ -69133,7 +69265,7 @@
       "source_location": "L17"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -69142,7 +69274,7 @@
       "source_location": "L61"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -69151,7 +69283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -69160,7 +69292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -69169,7 +69301,7 @@
       "source_location": "L23"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -69178,7 +69310,7 @@
       "source_location": "L16"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -69187,7 +69319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -69196,7 +69328,7 @@
       "source_location": "L20"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -69205,7 +69337,7 @@
       "source_location": "L16"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -69214,7 +69346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -69223,7 +69355,7 @@
       "source_location": "L12"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -69232,7 +69364,7 @@
       "source_location": "L7"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -69241,7 +69373,7 @@
       "source_location": "L25"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -69250,7 +69382,7 @@
       "source_location": "L21"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -69259,7 +69391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -69268,7 +69400,7 @@
       "source_location": "L7"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -69277,7 +69409,7 @@
       "source_location": "L14"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -69286,7 +69418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -69295,7 +69427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -69304,7 +69436,7 @@
       "source_location": "L45"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -69313,7 +69445,7 @@
       "source_location": "L37"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -69322,7 +69454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -69331,7 +69463,7 @@
       "source_location": "L10"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -69340,7 +69472,7 @@
       "source_location": "L44"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -69349,7 +69481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -69358,40 +69490,13 @@
       "source_location": "L84"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
       "norm_label": "createtestctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
       "source_location": "L100"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "currencyformatter_currencydisplaysymbol",
-      "label": "currencyDisplaySymbol()",
-      "norm_label": "currencydisplaysymbol()",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "currencyformatter_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_currencyformatter_ts",
-      "label": "currencyFormatter.ts",
-      "norm_label": "currencyformatter.ts",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L1"
     },
     {
       "community": 33,
@@ -69540,6 +69645,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "currencyformatter_currencydisplaysymbol",
+      "label": "currencyDisplaySymbol()",
+      "norm_label": "currencydisplaysymbol()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "currencyformatter_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_currencyformatter_ts",
+      "label": "currencyFormatter.ts",
+      "norm_label": "currencyformatter.ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
@@ -69547,7 +69679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -69556,7 +69688,7 @@
       "source_location": "L35"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -69565,7 +69697,7 @@
       "source_location": "L25"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -69574,7 +69706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -69583,7 +69715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -69592,7 +69724,7 @@
       "source_location": "L4"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -69601,7 +69733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -69610,7 +69742,7 @@
       "source_location": "L19"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -69619,7 +69751,7 @@
       "source_location": "L5"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -69628,7 +69760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -69637,7 +69769,7 @@
       "source_location": "L19"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -69646,7 +69778,7 @@
       "source_location": "L11"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -69655,7 +69787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -69664,7 +69796,7 @@
       "source_location": "L22"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -69673,7 +69805,7 @@
       "source_location": "L8"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -69682,7 +69814,7 @@
       "source_location": "L21"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -69691,7 +69823,7 @@
       "source_location": "L13"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -69700,7 +69832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -69709,7 +69841,7 @@
       "source_location": "L100"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -69718,7 +69850,7 @@
       "source_location": "L10"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -69727,7 +69859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -69736,7 +69868,7 @@
       "source_location": "L100"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -69745,7 +69877,7 @@
       "source_location": "L10"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -69754,7 +69886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -69763,7 +69895,7 @@
       "source_location": "L15"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -69772,39 +69904,12 @@
       "source_location": "L39"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
       "norm_label": "log-items-provider.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "fadein_fadein",
-      "label": "FadeIn()",
-      "norm_label": "fadein()",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1"
     },
     {
@@ -69954,6 +70059,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "fadein_fadein",
+      "label": "FadeIn()",
+      "norm_label": "fadein()",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
       "norm_label": "handleremovebestseller()",
@@ -69961,7 +70093,7 @@
       "source_location": "L53"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -69970,7 +70102,7 @@
       "source_location": "L65"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -69979,7 +70111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -69988,7 +70120,7 @@
       "source_location": "L47"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -69997,7 +70129,7 @@
       "source_location": "L53"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -70006,7 +70138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -70015,7 +70147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -70024,7 +70156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -70033,7 +70165,7 @@
       "source_location": "L9"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -70042,7 +70174,7 @@
       "source_location": "L70"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -70051,7 +70183,7 @@
       "source_location": "L227"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -70060,7 +70192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -70069,7 +70201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -70078,7 +70210,7 @@
       "source_location": "L71"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -70087,7 +70219,7 @@
       "source_location": "L9"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
@@ -70096,7 +70228,7 @@
       "source_location": "L33"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -70105,7 +70237,7 @@
       "source_location": "L24"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -70114,7 +70246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -70123,7 +70255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -70132,7 +70264,7 @@
       "source_location": "L117"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -70141,7 +70273,7 @@
       "source_location": "L84"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -70150,7 +70282,7 @@
       "source_location": "L28"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -70159,7 +70291,7 @@
       "source_location": "L34"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -70168,7 +70300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -70177,7 +70309,7 @@
       "source_location": "L36"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -70186,40 +70318,13 @@
       "source_location": "L32"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
       "norm_label": "heldsessionslist.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "label": "POSSettingsView.tsx",
-      "norm_label": "possettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "possettingsview_fingerprintregistrationcard",
-      "label": "FingerprintRegistrationCard()",
-      "norm_label": "fingerprintregistrationcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "possettingsview_possettingsview",
-      "label": "POSSettingsView()",
-      "norm_label": "possettingsview()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L180"
     },
     {
       "community": 35,
@@ -70368,6 +70473,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
+      "label": "POSSettingsView.tsx",
+      "norm_label": "possettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "possettingsview_fingerprintregistrationcard",
+      "label": "FingerprintRegistrationCard()",
+      "norm_label": "fingerprintregistrationcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "possettingsview_possettingsview",
+      "label": "POSSettingsView()",
+      "norm_label": "possettingsview()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
       "norm_label": "productstatus.test.tsx",
@@ -70375,7 +70507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -70384,7 +70516,7 @@
       "source_location": "L8"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -70393,7 +70525,7 @@
       "source_location": "L18"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -70402,7 +70534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -70411,7 +70543,7 @@
       "source_location": "L65"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -70420,7 +70552,7 @@
       "source_location": "L20"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -70429,7 +70561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -70438,7 +70570,7 @@
       "source_location": "L16"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -70447,7 +70579,7 @@
       "source_location": "L60"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -70456,7 +70588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -70465,7 +70597,7 @@
       "source_location": "L45"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -70474,7 +70606,7 @@
       "source_location": "L19"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -70483,7 +70615,7 @@
       "source_location": "L128"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -70492,7 +70624,7 @@
       "source_location": "L40"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -70501,7 +70633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -70510,7 +70642,7 @@
       "source_location": "L24"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -70519,7 +70651,7 @@
       "source_location": "L20"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -70528,7 +70660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -70537,7 +70669,7 @@
       "source_location": "L25"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -70546,7 +70678,7 @@
       "source_location": "L17"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -70555,7 +70687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -70564,7 +70696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -70573,7 +70705,7 @@
       "source_location": "L59"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -70582,7 +70714,7 @@
       "source_location": "L50"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -70591,7 +70723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -70600,40 +70732,13 @@
       "source_location": "L225"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
       "norm_label": "serviceintakeviewcontent()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
       "source_location": "L80"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
-      "label": "StaffManagement.test.tsx",
-      "norm_label": "staffmanagement.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "staffmanagement_test_chooserole",
-      "label": "chooseRole()",
-      "norm_label": "chooserole()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "staffmanagement_test_mockconvex",
-      "label": "mockConvex()",
-      "norm_label": "mockconvex()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L107"
     },
     {
       "community": 36,
@@ -70773,6 +70878,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
+      "label": "StaffManagement.test.tsx",
+      "norm_label": "staffmanagement.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "staffmanagement_test_chooserole",
+      "label": "chooseRole()",
+      "norm_label": "chooserole()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "staffmanagement_test_mockconvex",
+      "label": "mockConvex()",
+      "norm_label": "mockconvex()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
       "norm_label": "staffauthenticationdialog.tsx",
@@ -70780,7 +70912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -70789,7 +70921,7 @@
       "source_location": "L168"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -70798,7 +70930,7 @@
       "source_location": "L110"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -70807,7 +70939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -70816,7 +70948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -70825,7 +70957,7 @@
       "source_location": "L3"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -70834,7 +70966,7 @@
       "source_location": "L9"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -70843,7 +70975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -70852,7 +70984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -70861,7 +70993,7 @@
       "source_location": "L3"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -70870,7 +71002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -70879,7 +71011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -70888,7 +71020,7 @@
       "source_location": "L3"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -70897,7 +71029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -70906,7 +71038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -70915,7 +71047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -70924,7 +71056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -70933,7 +71065,7 @@
       "source_location": "L3"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -70942,7 +71074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -70951,7 +71083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -70960,7 +71092,7 @@
       "source_location": "L3"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -70969,7 +71101,7 @@
       "source_location": "L4"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -70978,7 +71110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -70987,7 +71119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -70996,7 +71128,7 @@
       "source_location": "L120"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -71005,40 +71137,13 @@
       "source_location": "L36"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
       "norm_label": "feesview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
-      "label": "WorkflowTraceRouteLink.tsx",
-      "norm_label": "workflowtraceroutelink.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
-      "label": "getWorkflowTraceRouteTarget()",
-      "norm_label": "getworkflowtraceroutetarget()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "workflowtraceroutelink_workflowtraceroutelink",
-      "label": "WorkflowTraceRouteLink()",
-      "norm_label": "workflowtraceroutelink()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L41"
     },
     {
       "community": 37,
@@ -71178,6 +71283,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
+      "label": "WorkflowTraceRouteLink.tsx",
+      "norm_label": "workflowtraceroutelink.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
+      "label": "getWorkflowTraceRouteTarget()",
+      "norm_label": "getworkflowtraceroutetarget()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "workflowtraceroutelink_workflowtraceroutelink",
+      "label": "WorkflowTraceRouteLink()",
+      "norm_label": "workflowtraceroutelink()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
       "norm_label": "appcontextmenu()",
@@ -71185,7 +71317,7 @@
       "source_location": "L20"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -71194,7 +71326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -71203,7 +71335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -71212,7 +71344,7 @@
       "source_location": "L30"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -71221,7 +71353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -71230,7 +71362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -71239,7 +71371,7 @@
       "source_location": "L9"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -71248,7 +71380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -71257,7 +71389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -71266,7 +71398,7 @@
       "source_location": "L38"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -71275,7 +71407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -71284,7 +71416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -71293,7 +71425,7 @@
       "source_location": "L20"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -71302,7 +71434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -71311,7 +71443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -71320,7 +71452,7 @@
       "source_location": "L12"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -71329,7 +71461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -71338,7 +71470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -71347,7 +71479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -71356,7 +71488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -71365,7 +71497,7 @@
       "source_location": "L3"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -71374,7 +71506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -71383,7 +71515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -71392,7 +71524,7 @@
       "source_location": "L6"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -71401,7 +71533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -71410,40 +71542,13 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
       "norm_label": "spinner()",
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "activitysummarycards_activitysummarycards",
-      "label": "ActivitySummaryCards()",
-      "norm_label": "activitysummarycards()",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "activitysummarycards_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "label": "ActivitySummaryCards.tsx",
-      "norm_label": "activitysummarycards.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -71583,6 +71688,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "activitysummarycards_activitysummarycards",
+      "label": "ActivitySummaryCards()",
+      "norm_label": "activitysummarycards()",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "activitysummarycards_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
+      "label": "ActivitySummaryCards.tsx",
+      "norm_label": "activitysummarycards.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
       "norm_label": "timelineeventcard.tsx",
@@ -71590,7 +71722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -71599,7 +71731,7 @@
       "source_location": "L159"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -71608,7 +71740,7 @@
       "source_location": "L195"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -71617,7 +71749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -71626,7 +71758,7 @@
       "source_location": "L22"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -71635,7 +71767,7 @@
       "source_location": "L45"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -71644,7 +71776,7 @@
       "source_location": "L24"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -71653,7 +71785,7 @@
       "source_location": "L38"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -71662,7 +71794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -71671,7 +71803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -71680,7 +71812,7 @@
       "source_location": "L23"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -71689,7 +71821,7 @@
       "source_location": "L51"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -71698,7 +71830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -71707,7 +71839,7 @@
       "source_location": "L54"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -71716,7 +71848,7 @@
       "source_location": "L282"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -71725,7 +71857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -71734,7 +71866,7 @@
       "source_location": "L12"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -71743,7 +71875,7 @@
       "source_location": "L37"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -71752,7 +71884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -71761,7 +71893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -71770,7 +71902,7 @@
       "source_location": "L4"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -71779,7 +71911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -71788,7 +71920,7 @@
       "source_location": "L9"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -71797,7 +71929,7 @@
       "source_location": "L50"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -71806,7 +71938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -71815,39 +71947,12 @@
       "source_location": "L6"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
       "norm_label": "usegetorganizations()",
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "label": "useGetProducts.ts",
-      "norm_label": "usegetproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "usegetproducts_usegetproducts",
-      "label": "useGetProducts()",
-      "norm_label": "usegetproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "usegetproducts_usegetunresolvedproducts",
-      "label": "useGetUnresolvedProducts()",
-      "norm_label": "usegetunresolvedproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31"
     },
     {
@@ -74733,6 +74838,24 @@
     {
       "community": 457,
       "file_type": "code",
+      "id": "bestseller_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 457,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
+      "label": "bestSeller.test.ts",
+      "norm_label": "bestseller.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 458,
+      "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
       "norm_label": "usererrorfromexpenseitemcommandfailure()",
@@ -74740,7 +74863,7 @@
       "source_location": "L14"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -74749,7 +74872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -74758,31 +74881,13 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
-      "label": "posSessionItems.ts",
-      "norm_label": "possessionitems.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "possessionitems_usererrorfromsessionitemfailure",
-      "label": "userErrorFromSessionItemFailure()",
-      "norm_label": "usererrorfromsessionitemfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
-      "source_location": "L22"
     },
     {
       "community": 46,
@@ -74904,6 +75009,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
+      "label": "posSessionItems.ts",
+      "norm_label": "possessionitems.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "possessionitems_usererrorfromsessionitemfailure",
+      "label": "userErrorFromSessionItemFailure()",
+      "norm_label": "usererrorfromsessionitemfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
       "norm_label": "productutil.ts",
@@ -74911,7 +75034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -74920,7 +75043,7 @@
       "source_location": "L8"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -74929,7 +75052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -74938,7 +75061,7 @@
       "source_location": "L29"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -74947,7 +75070,7 @@
       "source_location": "L73"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -74956,7 +75079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -74965,7 +75088,7 @@
       "source_location": "L4"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -74974,7 +75097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -74983,7 +75106,7 @@
       "source_location": "L3"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -74992,7 +75115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -75001,7 +75124,7 @@
       "source_location": "L3"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -75010,7 +75133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -75019,7 +75142,7 @@
       "source_location": "L6"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -75028,7 +75151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "approvalactions_consumecommandapprovalproofwithctx",
       "label": "consumeCommandApprovalProofWithCtx()",
@@ -75037,7 +75160,7 @@
       "source_location": "L34"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "label": "approvalActions.ts",
@@ -75046,7 +75169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -75055,30 +75178,12 @@
       "source_location": "L11"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
       "norm_label": "approvalauditevents.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "approvalproofs_test_createapprovalproofmutationctx",
-      "label": "createApprovalProofMutationCtx()",
-      "norm_label": "createapprovalproofmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
-      "label": "approvalProofs.test.ts",
-      "norm_label": "approvalproofs.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
       "source_location": "L1"
     },
     {
@@ -75201,6 +75306,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "approvalproofs_test_createapprovalproofmutationctx",
+      "label": "createApprovalProofMutationCtx()",
+      "norm_label": "createapprovalproofmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
+      "label": "approvalProofs.test.ts",
+      "norm_label": "approvalproofs.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
       "norm_label": "buildapprovalrequest()",
@@ -75208,7 +75331,7 @@
       "source_location": "L3"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -75217,7 +75340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -75226,7 +75349,7 @@
       "source_location": "L19"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -75235,7 +75358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -75244,7 +75367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -75253,7 +75376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -75262,7 +75385,7 @@
       "source_location": "L9"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -75271,7 +75394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -75280,7 +75403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -75289,7 +75412,7 @@
       "source_location": "L17"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -75298,7 +75421,7 @@
       "source_location": "L82"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -75307,7 +75430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -75316,7 +75439,7 @@
       "source_location": "L38"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -75325,7 +75448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -75334,7 +75457,7 @@
       "source_location": "L35"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -75343,7 +75466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -75352,30 +75475,12 @@
       "source_location": "L33"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
       "norm_label": "gettransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "listregistercatalog_test_createregistercatalogctx",
-      "label": "createRegisterCatalogCtx()",
-      "norm_label": "createregistercatalogctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
-      "label": "listRegisterCatalog.test.ts",
-      "norm_label": "listregistercatalog.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
       "source_location": "L1"
     },
     {
@@ -75498,6 +75603,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "listregistercatalog_test_createregistercatalogctx",
+      "label": "createRegisterCatalogCtx()",
+      "norm_label": "createregistercatalogctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
+      "label": "listRegisterCatalog.test.ts",
+      "norm_label": "listregistercatalog.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "inventoryholdgateway_test_createctx",
       "label": "createCtx()",
       "norm_label": "createctx()",
@@ -75505,7 +75628,7 @@
       "source_location": "L5"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
       "label": "inventoryHoldGateway.test.ts",
@@ -75514,7 +75637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -75523,7 +75646,7 @@
       "source_location": "L7"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -75532,7 +75655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -75541,7 +75664,7 @@
       "source_location": "L60"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -75550,7 +75673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -75559,7 +75682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "sessioncommandrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -75568,7 +75691,7 @@
       "source_location": "L9"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -75577,7 +75700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -75586,7 +75709,7 @@
       "source_location": "L88"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -75595,7 +75718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -75604,7 +75727,7 @@
       "source_location": "L57"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -75613,7 +75736,7 @@
       "source_location": "L9"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -75622,7 +75745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -75631,7 +75754,7 @@
       "source_location": "L4"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -75640,7 +75763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -75649,30 +75772,12 @@
       "source_location": "L15"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
       "norm_label": "access.test.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "access_requirestorefulladminaccess",
-      "label": "requireStoreFullAdminAccess()",
-      "norm_label": "requirestorefulladminaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_ts",
-      "label": "access.ts",
-      "norm_label": "access.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
       "source_location": "L1"
     },
     {
@@ -75795,6 +75900,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "access_requirestorefulladminaccess",
+      "label": "requireStoreFullAdminAccess()",
+      "norm_label": "requirestorefulladminaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_ts",
+      "label": "access.ts",
+      "norm_label": "access.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "cyclecountdrafts_test_createcyclecountdraftctx",
       "label": "createCycleCountDraftCtx()",
       "norm_label": "createcyclecountdraftctx()",
@@ -75802,7 +75925,7 @@
       "source_location": "L22"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_test_ts",
       "label": "cycleCountDrafts.test.ts",
@@ -75811,7 +75934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -75820,7 +75943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -75829,7 +75952,7 @@
       "source_location": "L8"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -75838,7 +75961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -75847,7 +75970,7 @@
       "source_location": "L5"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -75856,7 +75979,7 @@
       "source_location": "L15"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -75865,7 +75988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -75874,7 +75997,7 @@
       "source_location": "L8"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -75883,7 +76006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -75892,7 +76015,7 @@
       "source_location": "L17"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -75901,7 +76024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -75910,7 +76033,7 @@
       "source_location": "L6"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -75919,7 +76042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -75928,7 +76051,7 @@
       "source_location": "L5"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -75937,7 +76060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -75946,31 +76069,13 @@
       "source_location": "L25"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "reviews_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L19"
     },
     {
       "community": 5,
@@ -76344,6 +76449,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "reviews_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -76351,7 +76474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -76360,7 +76483,7 @@
       "source_location": "L7"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -76369,7 +76492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -76378,7 +76501,7 @@
       "source_location": "L14"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -76387,7 +76510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -76396,7 +76519,7 @@
       "source_location": "L8"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -76405,7 +76528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -76414,7 +76537,7 @@
       "source_location": "L3"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -76423,7 +76546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -76432,7 +76555,7 @@
       "source_location": "L5"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -76441,7 +76564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -76450,7 +76573,7 @@
       "source_location": "L16"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -76459,7 +76582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -76468,7 +76591,7 @@
       "source_location": "L30"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -76477,7 +76600,7 @@
       "source_location": "L42"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
@@ -76486,7 +76609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -76495,31 +76618,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
       "norm_label": "buildpossessiontraceseed()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
       "source_location": "L42"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
-      "label": "presentation.ts",
-      "norm_label": "presentation.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "presentation_buildworkflowtraceviewmodel",
-      "label": "buildWorkflowTraceViewModel()",
-      "norm_label": "buildworkflowtraceviewmodel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L31"
     },
     {
       "community": 51,
@@ -76641,6 +76746,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "label": "presentation.ts",
+      "norm_label": "presentation.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "presentation_buildworkflowtraceviewmodel",
+      "label": "buildWorkflowTraceViewModel()",
+      "norm_label": "buildworkflowtraceviewmodel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
       "norm_label": "schemaindexes.test.ts",
@@ -76648,7 +76771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -76657,7 +76780,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -76666,7 +76789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -76675,7 +76798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -76684,7 +76807,7 @@
       "source_location": "L7"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -76693,7 +76816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -76702,7 +76825,7 @@
       "source_location": "L12"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -76711,7 +76834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -76720,7 +76843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -76729,7 +76852,7 @@
       "source_location": "L11"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -76738,7 +76861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -76747,7 +76870,7 @@
       "source_location": "L11"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -76756,7 +76879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -76765,7 +76888,7 @@
       "source_location": "L3"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -76774,7 +76897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -76783,7 +76906,7 @@
       "source_location": "L12"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -76792,31 +76915,13 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
     },
     {
       "community": 52,
@@ -76938,6 +77043,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
       "norm_label": "storesdropdown.tsx",
@@ -76945,7 +77068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -76954,7 +77077,7 @@
       "source_location": "L42"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -76963,7 +77086,7 @@
       "source_location": "L31"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -76972,7 +77095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -76981,7 +77104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -76990,7 +77113,7 @@
       "source_location": "L10"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -76999,7 +77122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -77008,7 +77131,7 @@
       "source_location": "L14"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -77017,7 +77140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -77026,7 +77149,7 @@
       "source_location": "L5"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -77035,7 +77158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -77044,7 +77167,7 @@
       "source_location": "L10"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -77053,7 +77176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -77062,7 +77185,7 @@
       "source_location": "L15"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -77071,7 +77194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -77080,7 +77203,7 @@
       "source_location": "L13"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -77089,31 +77212,13 @@
       "source_location": "L118"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
     },
     {
       "community": 53,
@@ -77235,6 +77340,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
       "norm_label": "capitalizefirstletter()",
@@ -77242,7 +77365,7 @@
       "source_location": "L151"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -77251,7 +77374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -77260,7 +77383,7 @@
       "source_location": "L6"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -77269,7 +77392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -77278,7 +77401,7 @@
       "source_location": "L18"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -77287,7 +77410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -77296,7 +77419,7 @@
       "source_location": "L7"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -77305,7 +77428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -77314,7 +77437,7 @@
       "source_location": "L42"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -77323,7 +77446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -77332,7 +77455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -77341,7 +77464,7 @@
       "source_location": "L66"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -77350,7 +77473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -77359,7 +77482,7 @@
       "source_location": "L18"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -77368,7 +77491,7 @@
       "source_location": "L6"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -77377,7 +77500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -77386,30 +77509,12 @@
       "source_location": "L10"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1"
     },
     {
@@ -77523,6 +77628,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
       "norm_label": "useloadlogitems.ts",
@@ -77530,7 +77653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -77539,7 +77662,7 @@
       "source_location": "L12"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenucollapsible",
       "label": "SidebarMenuCollapsible()",
@@ -77548,7 +77671,7 @@
       "source_location": "L58"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -77557,7 +77680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -77566,7 +77689,7 @@
       "source_location": "L3"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -77575,7 +77698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "inputotp_test_resolvesignin",
       "label": "resolveSignIn()",
@@ -77584,7 +77707,7 @@
       "source_location": "L102"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -77593,7 +77716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -77602,7 +77725,7 @@
       "source_location": "L5"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -77611,7 +77734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
@@ -77620,7 +77743,7 @@
       "source_location": "L25"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -77629,7 +77752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -77638,7 +77761,7 @@
       "source_location": "L49"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -77647,7 +77770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -77656,7 +77779,7 @@
       "source_location": "L23"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -77665,7 +77788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -77674,30 +77797,12 @@
       "source_location": "L50"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
       "norm_label": "bulkoperationspreview.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "formatreviewreason_formatreviewreason",
-      "label": "formatReviewReason()",
-      "norm_label": "formatreviewreason()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
-      "label": "formatReviewReason.ts",
-      "norm_label": "formatreviewreason.ts",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
       "source_location": "L1"
     },
     {
@@ -77811,6 +77916,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "formatreviewreason_formatreviewreason",
+      "label": "formatReviewReason()",
+      "norm_label": "formatreviewreason()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
+      "label": "formatReviewReason.ts",
+      "norm_label": "formatreviewreason.ts",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
       "norm_label": "registersessioncolumns.tsx",
@@ -77818,7 +77941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -77827,7 +77950,7 @@
       "source_location": "L33"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -77836,7 +77959,7 @@
       "source_location": "L13"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -77845,7 +77968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -77854,7 +77977,7 @@
       "source_location": "L11"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -77863,7 +77986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
       "label": "PageLevelHeader.tsx",
@@ -77872,7 +77995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "pagelevelheader_pagelevelheader",
       "label": "PageLevelHeader()",
@@ -77881,7 +78004,7 @@
       "source_location": "L12"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -77890,7 +78013,7 @@
       "source_location": "L24"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -77899,7 +78022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "expenseview_expenseview",
       "label": "ExpenseView()",
@@ -77908,7 +78031,7 @@
       "source_location": "L4"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
       "label": "ExpenseView.tsx",
@@ -77917,7 +78040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -77926,7 +78049,7 @@
       "source_location": "L29"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -77935,7 +78058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -77944,7 +78067,7 @@
       "source_location": "L37"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -77953,7 +78076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -77962,7 +78085,7 @@
       "source_location": "L25"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -77971,304 +78094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 559,
-      "file_type": "code",
-      "id": "landingpagereelversion_handleupdateconfig",
-      "label": "handleUpdateConfig()",
-      "norm_label": "handleupdateconfig()",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
-      "label": "LandingPageReelVersion.tsx",
-      "norm_label": "landingpagereelversion.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 56,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 560,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "label": "ShopLookDialog.tsx",
-      "norm_label": "shoplookdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 560,
-      "file_type": "code",
-      "id": "shoplookdialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 561,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "label": "ShopLookImageUploader.tsx",
-      "norm_label": "shoplookimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 561,
-      "file_type": "code",
-      "id": "shoplookimageuploader_shoplookimageuploader",
-      "label": "ShopLookImageUploader()",
-      "norm_label": "shoplookimageuploader()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 562,
-      "file_type": "code",
-      "id": "index_jointeam",
-      "label": "JoinTeam()",
-      "norm_label": "jointeam()",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 562,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_join_team_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 563,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
-      "label": "StockAdjustmentWorkspace.test.tsx",
-      "norm_label": "stockadjustmentworkspace.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 563,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
-      "label": "renderStockAdjustmentWorkspace()",
-      "norm_label": "renderstockadjustmentworkspace()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 564,
-      "file_type": "code",
-      "id": "customerdetailsview_customerdetailsview",
-      "label": "CustomerDetailsView()",
-      "norm_label": "customerdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 564,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 565,
-      "file_type": "code",
-      "id": "emailstatusview_handlesendorderemail",
-      "label": "handleSendOrderEmail()",
-      "norm_label": "handlesendorderemail()",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 565,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "label": "EmailStatusView.tsx",
-      "norm_label": "emailstatusview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "label": "RefundsView.tsx",
-      "norm_label": "refundsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "refundsview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
-      "label": "useGetActiveOnlineOrder.ts",
-      "norm_label": "usegetactiveonlineorder.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "label": "useGetActiveOnlineOrder()",
-      "norm_label": "usegetactiveonlineorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 57,
       "file_type": "code",
       "id": "gettransactions_getcompletedtransactions",
       "label": "getCompletedTransactions()",
@@ -78277,7 +78103,7 @@
       "source_location": "L116"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_getrecenttransactionswithcustomers",
       "label": "getRecentTransactionsWithCustomers()",
@@ -78286,7 +78112,7 @@
       "source_location": "L283"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_gettodaysummary",
       "label": "getTodaySummary()",
@@ -78295,7 +78121,7 @@
       "source_location": "L318"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_gettransaction",
       "label": "getTransaction()",
@@ -78304,7 +78130,7 @@
       "source_location": "L91"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_gettransactionbyid",
       "label": "getTransactionById()",
@@ -78313,7 +78139,7 @@
       "source_location": "L164"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_gettransactionsbystore",
       "label": "getTransactionsByStore()",
@@ -78322,7 +78148,7 @@
       "source_location": "L106"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_liststaffnames",
       "label": "listStaffNames()",
@@ -78331,7 +78157,7 @@
       "source_location": "L74"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_loadcorrectionevents",
       "label": "loadCorrectionEvents()",
@@ -78340,7 +78166,7 @@
       "source_location": "L55"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_loadcustomerprofile",
       "label": "loadCustomerProfile()",
@@ -78349,7 +78175,7 @@
       "source_location": "L46"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "gettransactions_summarizecashiername",
       "label": "summarizeCashierName()",
@@ -78358,7 +78184,7 @@
       "source_location": "L16"
     },
     {
-      "community": 57,
+      "community": 56,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
       "label": "getTransactions.ts",
@@ -78367,187 +78193,187 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 560,
       "file_type": "code",
-      "id": "data_table_toolbar_handleclearfilters",
-      "label": "handleClearFilters()",
-      "norm_label": "handleclearfilters()",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
-      "source_location": "L34"
+      "id": "landingpagereelversion_handleupdateconfig",
+      "label": "handleUpdateConfig()",
+      "norm_label": "handleupdateconfig()",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L83"
     },
     {
-      "community": 570,
+      "community": 560,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
+      "label": "LandingPageReelVersion.tsx",
+      "norm_label": "landingpagereelversion.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 561,
       "file_type": "code",
-      "id": "ordercolumns_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 571,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
-      "label": "orderColumns.tsx",
-      "norm_label": "ordercolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
+      "label": "ShopLookDialog.tsx",
+      "norm_label": "shoplookdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 561,
       "file_type": "code",
-      "id": "organization_switcher_organizationswitcher",
-      "label": "OrganizationSwitcher()",
-      "norm_label": "organizationswitcher()",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
-      "source_location": "L37"
+      "id": "shoplookdialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L35"
     },
     {
-      "community": 572,
+      "community": 562,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
-      "label": "organization-switcher.tsx",
-      "norm_label": "organization-switcher.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
+      "label": "ShopLookImageUploader.tsx",
+      "norm_label": "shoplookimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 562,
       "file_type": "code",
-      "id": "cartitems_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
-      "source_location": "L215"
+      "id": "shoplookimageuploader_shoplookimageuploader",
+      "label": "ShopLookImageUploader()",
+      "norm_label": "shoplookimageuploader()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L28"
     },
     {
-      "community": 573,
+      "community": 563,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "label": "CartItems.tsx",
-      "norm_label": "cartitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "id": "index_jointeam",
+      "label": "JoinTeam()",
+      "norm_label": "jointeam()",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_join_team_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 564,
       "file_type": "code",
-      "id": "debugproducts_debugproducts",
-      "label": "DebugProducts()",
-      "norm_label": "debugproducts()",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 574,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
-      "label": "DebugProducts.tsx",
-      "norm_label": "debugproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
+      "label": "StockAdjustmentWorkspace.test.tsx",
+      "norm_label": "stockadjustmentworkspace.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 564,
       "file_type": "code",
-      "id": "noresultsmessage_noresultsmessage",
-      "label": "NoResultsMessage()",
-      "norm_label": "noresultsmessage()",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
-      "source_location": "L7"
+      "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
+      "label": "renderStockAdjustmentWorkspace()",
+      "norm_label": "renderstockadjustmentworkspace()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
+      "source_location": "L88"
     },
     {
-      "community": 575,
+      "community": 565,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
-      "label": "NoResultsMessage.tsx",
-      "norm_label": "noresultsmessage.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 576,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 576,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "id": "customerdetailsview_customerdetailsview",
+      "label": "CustomerDetailsView()",
+      "norm_label": "customerdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L13"
     },
     {
-      "community": 577,
+      "community": 565,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 566,
       "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L39"
+      "id": "emailstatusview_handlesendorderemail",
+      "label": "handleSendOrderEmail()",
+      "norm_label": "handlesendorderemail()",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L43"
     },
     {
-      "community": 578,
+      "community": 566,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
+      "label": "EmailStatusView.tsx",
+      "norm_label": "emailstatusview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 567,
       "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
     },
     {
-      "community": 579,
+      "community": 567,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1"
     },
     {
-      "community": 579,
+      "community": 568,
       "file_type": "code",
-      "id": "productcard_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L14"
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
     },
     {
-      "community": 58,
+      "community": 568,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
+      "label": "RefundsView.tsx",
+      "norm_label": "refundsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "refundsview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 57,
       "file_type": "code",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
       "label": "OrdersTableToolbarProvider()",
@@ -78556,7 +78382,7 @@
       "source_location": "L16"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
       "label": "useOrdersTableToolbar()",
@@ -78565,7 +78391,7 @@
       "source_location": "L46"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78574,7 +78400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78583,7 +78409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78592,7 +78418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78601,7 +78427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78610,7 +78436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78619,7 +78445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78628,7 +78454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78637,7 +78463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 58,
+      "community": 57,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -78646,187 +78472,187 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 570,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
-      "label": "SearchResultsSection.test.tsx",
-      "norm_label": "searchresultssection.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx",
+      "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
+      "label": "useGetActiveOnlineOrder.ts",
+      "norm_label": "usegetactiveonlineorder.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 570,
       "file_type": "code",
-      "id": "searchresultssection_test_buildproduct",
-      "label": "buildProduct()",
-      "norm_label": "buildproduct()",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx",
-      "source_location": "L12"
+      "id": "usegetactiveonlineorder_usegetactiveonlineorder",
+      "label": "useGetActiveOnlineOrder()",
+      "norm_label": "usegetactiveonlineorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
+      "source_location": "L6"
     },
     {
-      "community": 581,
+      "community": 571,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
-      "label": "SessionDemo.tsx",
-      "norm_label": "sessiondemo.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 581,
-      "file_type": "code",
-      "id": "sessiondemo_sessiondemo",
-      "label": "SessionDemo()",
-      "norm_label": "sessiondemo()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 582,
-      "file_type": "code",
-      "id": "expensecompletionpanel_expensecompletionpanel",
-      "label": "ExpenseCompletionPanel()",
-      "norm_label": "expensecompletionpanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 582,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
-      "label": "ExpenseCompletionPanel.tsx",
-      "norm_label": "expensecompletionpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 583,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
-      "label": "RegisterCustomerAttribution.test.tsx",
-      "norm_label": "registercustomerattribution.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 583,
-      "file_type": "code",
-      "id": "registercustomerattribution_test_makecustomer",
-      "label": "makeCustomer()",
-      "norm_label": "makecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 584,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
-      "label": "RegisterCustomerPanel.tsx",
-      "norm_label": "registercustomerpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 584,
-      "file_type": "code",
-      "id": "registercustomerpanel_registercustomerpanel",
-      "label": "RegisterCustomerPanel()",
-      "norm_label": "registercustomerpanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 585,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
-      "label": "RegisterDrawerGate.test.tsx",
-      "norm_label": "registerdrawergate.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 585,
-      "file_type": "code",
-      "id": "registerdrawergate_test_rendergate",
-      "label": "renderGate()",
-      "norm_label": "rendergate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 586,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
-      "label": "RegisterSessionPanel.tsx",
-      "norm_label": "registersessionpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 586,
-      "file_type": "code",
-      "id": "registersessionpanel_registersessionpanel",
-      "label": "RegisterSessionPanel()",
-      "norm_label": "registersessionpanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
-      "label": "transactionColumns.test.tsx",
-      "norm_label": "transactioncolumns.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "transactioncolumns_test_rendertransactioncell",
-      "label": "renderTransactionCell()",
-      "norm_label": "rendertransactioncell()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "id": "data_table_toolbar_handleclearfilters",
+      "label": "handleClearFilters()",
+      "norm_label": "handleclearfilters()",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34"
     },
     {
-      "community": 588,
+      "community": 571,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 572,
       "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L26"
+      "id": "ordercolumns_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L89"
     },
     {
-      "community": 589,
+      "community": 572,
       "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
+      "label": "orderColumns.tsx",
+      "norm_label": "ordercolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 59,
+      "community": 573,
+      "file_type": "code",
+      "id": "organization_switcher_organizationswitcher",
+      "label": "OrganizationSwitcher()",
+      "norm_label": "organizationswitcher()",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
+      "label": "organization-switcher.tsx",
+      "norm_label": "organization-switcher.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 574,
+      "file_type": "code",
+      "id": "cartitems_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "source_location": "L215"
+    },
+    {
+      "community": 574,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
+      "label": "CartItems.tsx",
+      "norm_label": "cartitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 575,
+      "file_type": "code",
+      "id": "debugproducts_debugproducts",
+      "label": "DebugProducts()",
+      "norm_label": "debugproducts()",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 575,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
+      "label": "DebugProducts.tsx",
+      "norm_label": "debugproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 576,
+      "file_type": "code",
+      "id": "noresultsmessage_noresultsmessage",
+      "label": "NoResultsMessage()",
+      "norm_label": "noresultsmessage()",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 576,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
+      "label": "NoResultsMessage.tsx",
+      "norm_label": "noresultsmessage.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 577,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 577,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 578,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 578,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 58,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
       "label": "RegisterCustomerAttribution.tsx",
@@ -78835,7 +78661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_buildcustomercreateinput",
       "label": "buildCustomerCreateInput()",
@@ -78844,7 +78670,7 @@
       "source_location": "L48"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_cancelpendingadd",
       "label": "cancelPendingAdd()",
@@ -78853,7 +78679,7 @@
       "source_location": "L122"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_cn",
       "label": "cn()",
@@ -78862,7 +78688,7 @@
       "source_location": "L363"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_commitcustomer",
       "label": "commitCustomer()",
@@ -78871,7 +78697,7 @@
       "source_location": "L127"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_getsecondaryidentifier",
       "label": "getSecondaryIdentifier()",
@@ -78880,7 +78706,7 @@
       "source_location": "L75"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_handleaddfromsearch",
       "label": "handleAddFromSearch()",
@@ -78889,7 +78715,7 @@
       "source_location": "L156"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_handleclearcustomer",
       "label": "handleClearCustomer()",
@@ -78898,7 +78724,7 @@
       "source_location": "L144"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_handleselectcustomer",
       "label": "handleSelectCustomer()",
@@ -78907,7 +78733,7 @@
       "source_location": "L132"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_tocustomerinfo",
       "label": "toCustomerInfo()",
@@ -78916,7 +78742,7 @@
       "source_location": "L79"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "registercustomerattribution_trimcustomerinfo",
       "label": "trimCustomerInfo()",
@@ -78925,7 +78751,304 @@
       "source_location": "L39"
     },
     {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "productcard_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
+      "label": "SearchResultsSection.test.tsx",
+      "norm_label": "searchresultssection.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "searchresultssection_test_buildproduct",
+      "label": "buildProduct()",
+      "norm_label": "buildproduct()",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
+      "label": "SessionDemo.tsx",
+      "norm_label": "sessiondemo.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "sessiondemo_sessiondemo",
+      "label": "SessionDemo()",
+      "norm_label": "sessiondemo()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
+      "id": "expensecompletionpanel_expensecompletionpanel",
+      "label": "ExpenseCompletionPanel()",
+      "norm_label": "expensecompletionpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
+      "label": "ExpenseCompletionPanel.tsx",
+      "norm_label": "expensecompletionpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 584,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
+      "label": "RegisterCustomerAttribution.test.tsx",
+      "norm_label": "registercustomerattribution.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 584,
+      "file_type": "code",
+      "id": "registercustomerattribution_test_makecustomer",
+      "label": "makeCustomer()",
+      "norm_label": "makecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 585,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
+      "label": "RegisterCustomerPanel.tsx",
+      "norm_label": "registercustomerpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 585,
+      "file_type": "code",
+      "id": "registercustomerpanel_registercustomerpanel",
+      "label": "RegisterCustomerPanel()",
+      "norm_label": "registercustomerpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 586,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
+      "label": "RegisterDrawerGate.test.tsx",
+      "norm_label": "registerdrawergate.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 586,
+      "file_type": "code",
+      "id": "registerdrawergate_test_rendergate",
+      "label": "renderGate()",
+      "norm_label": "rendergate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 587,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "label": "RegisterSessionPanel.tsx",
+      "norm_label": "registersessionpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 587,
+      "file_type": "code",
+      "id": "registersessionpanel_registersessionpanel",
+      "label": "RegisterSessionPanel()",
+      "norm_label": "registersessionpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 588,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
+      "label": "transactionColumns.test.tsx",
+      "norm_label": "transactioncolumns.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 588,
+      "file_type": "code",
+      "id": "transactioncolumns_test_rendertransactioncell",
+      "label": "renderTransactionCell()",
+      "norm_label": "rendertransactioncell()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 590,
+      "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -78934,7 +79057,7 @@
       "source_location": "L6"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -78943,7 +79066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -78952,7 +79075,7 @@
       "source_location": "L37"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -78961,7 +79084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -78970,7 +79093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -78979,7 +79102,7 @@
       "source_location": "L11"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -78988,7 +79111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -78997,7 +79120,7 @@
       "source_location": "L10"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -79006,16 +79129,16 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
-      "id": "product_actions_usedeleteproduct",
-      "label": "useDeleteProduct()",
-      "norm_label": "usedeleteproduct()",
+      "id": "product_actions_usearchiveproduct",
+      "label": "useArchiveProduct()",
+      "norm_label": "usearchiveproduct()",
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -79024,7 +79147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -79033,7 +79156,7 @@
       "source_location": "L5"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -79042,7 +79165,7 @@
       "source_location": "L17"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -79051,7 +79174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -79060,7 +79183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -79069,7 +79192,7 @@
       "source_location": "L4"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -79078,31 +79201,13 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
       "norm_label": "togglediscounttype()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L23"
     },
     {
       "community": 6,
@@ -79359,104 +79464,122 @@
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L1"
     },
     {
       "community": 600,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -79465,7 +79588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -79474,7 +79597,7 @@
       "source_location": "L37"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -79483,7 +79606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -79492,7 +79615,7 @@
       "source_location": "L9"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -79501,7 +79624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -79510,7 +79633,7 @@
       "source_location": "L23"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -79519,7 +79642,7 @@
       "source_location": "L5"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -79528,7 +79651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -79537,7 +79660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -79546,7 +79669,7 @@
       "source_location": "L4"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -79555,7 +79678,7 @@
       "source_location": "L13"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -79564,7 +79687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -79573,7 +79696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -79582,7 +79705,7 @@
       "source_location": "L29"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -79591,7 +79714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -79600,7 +79723,7 @@
       "source_location": "L20"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -79609,31 +79732,13 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
       "source_location": "L63"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "servicecatalogview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L30"
     },
     {
       "community": 61,
@@ -79737,6 +79842,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "servicecatalogview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
       "norm_label": "serviceintakeform.tsx",
@@ -79744,7 +79867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -79753,7 +79876,7 @@
       "source_location": "L59"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -79762,7 +79885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -79771,7 +79894,7 @@
       "source_location": "L45"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -79780,7 +79903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -79789,7 +79912,7 @@
       "source_location": "L47"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -79798,7 +79921,7 @@
       "source_location": "L29"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -79807,7 +79930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -79816,7 +79939,7 @@
       "source_location": "L3"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -79825,7 +79948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -79834,7 +79957,7 @@
       "source_location": "L4"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -79843,7 +79966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -79852,7 +79975,7 @@
       "source_location": "L4"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -79861,7 +79984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -79870,7 +79993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -79879,7 +80002,7 @@
       "source_location": "L9"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -79888,30 +80011,12 @@
       "source_location": "L9"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
       "norm_label": "contactview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1"
     },
     {
@@ -80016,6 +80121,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
       "norm_label": "maintenanceview()",
@@ -80023,7 +80146,7 @@
       "source_location": "L11"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -80032,7 +80155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -80041,7 +80164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -80050,7 +80173,7 @@
       "source_location": "L25"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -80059,7 +80182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -80068,7 +80191,7 @@
       "source_location": "L21"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -80077,7 +80200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -80086,7 +80209,7 @@
       "source_location": "L63"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -80095,7 +80218,7 @@
       "source_location": "L7"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -80104,7 +80227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -80113,7 +80236,7 @@
       "source_location": "L25"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -80122,7 +80245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -80131,7 +80254,7 @@
       "source_location": "L15"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -80140,7 +80263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -80149,7 +80272,7 @@
       "source_location": "L21"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -80158,7 +80281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -80167,30 +80290,12 @@
       "source_location": "L6"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -80286,6 +80391,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
@@ -80293,7 +80416,7 @@
       "source_location": "L49"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -80302,7 +80425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -80311,7 +80434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -80320,7 +80443,7 @@
       "source_location": "L63"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -80329,7 +80452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -80338,7 +80461,7 @@
       "source_location": "L5"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -80347,7 +80470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -80356,7 +80479,7 @@
       "source_location": "L12"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -80365,7 +80488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -80374,7 +80497,7 @@
       "source_location": "L15"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -80383,7 +80506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -80392,7 +80515,7 @@
       "source_location": "L3"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -80401,7 +80524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -80410,7 +80533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -80419,7 +80542,7 @@
       "source_location": "L5"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -80428,7 +80551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -80437,30 +80560,12 @@
       "source_location": "L11"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
       "norm_label": "bagitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1"
     },
     {
@@ -80556,6 +80661,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
       "norm_label": "string()",
@@ -80563,7 +80686,7 @@
       "source_location": "L102"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -80572,7 +80695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -80581,7 +80704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -80590,7 +80713,7 @@
       "source_location": "L13"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -80599,7 +80722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -80608,7 +80731,7 @@
       "source_location": "L7"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -80617,7 +80740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -80626,7 +80749,7 @@
       "source_location": "L11"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -80635,7 +80758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -80644,7 +80767,7 @@
       "source_location": "L7"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -80653,7 +80776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -80662,7 +80785,7 @@
       "source_location": "L45"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -80671,7 +80794,7 @@
       "source_location": "L13"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -80680,7 +80803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -80689,7 +80812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -80698,7 +80821,7 @@
       "source_location": "L7"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -80707,30 +80830,12 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
       "norm_label": "useismobile()",
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5"
     },
     {
@@ -80826,6 +80931,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
       "norm_label": "use-navigation-keyboard-shortcuts.ts",
@@ -80833,7 +80956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -80842,7 +80965,7 @@
       "source_location": "L7"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -80851,7 +80974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -80860,7 +80983,7 @@
       "source_location": "L11"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -80869,7 +80992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -80878,7 +81001,7 @@
       "source_location": "L6"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -80887,7 +81010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -80896,7 +81019,7 @@
       "source_location": "L168"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -80905,7 +81028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -80914,7 +81037,7 @@
       "source_location": "L5"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -80923,7 +81046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -80932,7 +81055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -80941,7 +81064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -80950,7 +81073,7 @@
       "source_location": "L6"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -80959,7 +81082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -80968,7 +81091,7 @@
       "source_location": "L12"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -80977,31 +81100,13 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
       "norm_label": "useexpenseoperations()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L24"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 66,
@@ -81096,6 +81201,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
       "norm_label": "usegetautheduser.ts",
@@ -81103,7 +81226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -81112,7 +81235,7 @@
       "source_location": "L4"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -81121,7 +81244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -81130,7 +81253,7 @@
       "source_location": "L5"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -81139,7 +81262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -81148,7 +81271,7 @@
       "source_location": "L5"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -81157,7 +81280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -81166,7 +81289,7 @@
       "source_location": "L4"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -81175,7 +81298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -81184,7 +81307,7 @@
       "source_location": "L5"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -81193,7 +81316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -81202,7 +81325,7 @@
       "source_location": "L5"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -81211,7 +81334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -81220,7 +81343,7 @@
       "source_location": "L8"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -81229,7 +81352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -81238,7 +81361,7 @@
       "source_location": "L13"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -81247,31 +81370,13 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
       "norm_label": "useprint()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L27"
     },
     {
       "community": 67,
@@ -81366,6 +81471,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
       "norm_label": "useproductwithnoimagesnotification.tsx",
@@ -81373,7 +81496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -81382,7 +81505,7 @@
       "source_location": "L7"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -81391,7 +81514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -81400,7 +81523,7 @@
       "source_location": "L5"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -81409,7 +81532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -81418,7 +81541,7 @@
       "source_location": "L12"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -81427,7 +81550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -81436,7 +81559,7 @@
       "source_location": "L12"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -81445,7 +81568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -81454,7 +81577,7 @@
       "source_location": "L5"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -81463,7 +81586,7 @@
       "source_location": "L48"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -81472,7 +81595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -81481,7 +81604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -81490,7 +81613,7 @@
       "source_location": "L7"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -81499,7 +81622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -81508,7 +81631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -81517,30 +81640,12 @@
       "source_location": "L5"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
       "norm_label": "additem.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "bootstrapregister_bootstrapregister",
-      "label": "bootstrapRegister()",
-      "norm_label": "bootstrapregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
-      "label": "bootstrapRegister.ts",
-      "norm_label": "bootstrapregister.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
       "source_location": "L1"
     },
     {
@@ -81636,6 +81741,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "bootstrapregister_bootstrapregister",
+      "label": "bootstrapRegister()",
+      "norm_label": "bootstrapregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
+      "label": "bootstrapRegister.ts",
+      "norm_label": "bootstrapregister.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
       "norm_label": "holdsession()",
@@ -81643,7 +81766,7 @@
       "source_location": "L5"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -81652,7 +81775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -81661,7 +81784,7 @@
       "source_location": "L5"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -81670,7 +81793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -81679,7 +81802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -81688,7 +81811,7 @@
       "source_location": "L5"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -81697,7 +81820,7 @@
       "source_location": "L10"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -81706,7 +81829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
       "label": "useRegisterCatalogIndex.ts",
@@ -81715,7 +81838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "useregistercatalogindex_useregistercatalogindex",
       "label": "useRegisterCatalogIndex()",
@@ -81724,7 +81847,7 @@
       "source_location": "L8"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -81733,7 +81856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -81742,7 +81865,7 @@
       "source_location": "L12"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -81751,7 +81874,7 @@
       "source_location": "L6"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -81760,7 +81883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -81769,7 +81892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -81778,7 +81901,7 @@
       "source_location": "L6"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -81787,31 +81910,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 69,
@@ -81906,6 +82011,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "approvals_approvalsroute",
       "label": "ApprovalsRoute()",
       "norm_label": "approvalsroute()",
@@ -81913,7 +82036,7 @@
       "source_location": "L11"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_approvals_tsx",
       "label": "approvals.tsx",
@@ -81922,7 +82045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "open_work_openworkroute",
       "label": "OpenWorkRoute()",
@@ -81931,7 +82054,7 @@
       "source_location": "L11"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
       "label": "open-work.tsx",
@@ -81940,7 +82063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
       "label": "stock-adjustments.tsx",
@@ -81949,7 +82072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "stock_adjustments_stockadjustmentsroute",
       "label": "StockAdjustmentsRoute()",
@@ -81958,7 +82081,7 @@
       "source_location": "L25"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -81967,7 +82090,7 @@
       "source_location": "L6"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -81976,7 +82099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -81985,7 +82108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -81994,7 +82117,7 @@
       "source_location": "L9"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -82003,7 +82126,7 @@
       "source_location": "L13"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -82012,7 +82135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -82021,7 +82144,7 @@
       "source_location": "L4"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -82030,7 +82153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -82039,7 +82162,7 @@
       "source_location": "L13"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -82048,7 +82171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -82057,31 +82180,13 @@
       "source_location": "L5"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
-      "label": "view-patterns.tsx",
-      "norm_label": "view-patterns.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "view_patterns_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.tsx",
-      "source_location": "L142"
     },
     {
       "community": 7,
@@ -82428,6 +82533,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
+      "label": "view-patterns.tsx",
+      "norm_label": "view-patterns.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "view_patterns_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.tsx",
+      "source_location": "L142"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
       "norm_label": "controlsshowcase()",
@@ -82435,7 +82558,7 @@
       "source_location": "L17"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -82444,7 +82567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -82453,7 +82576,7 @@
       "source_location": "L15"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -82462,7 +82585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -82471,7 +82594,7 @@
       "source_location": "L12"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -82480,7 +82603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -82489,7 +82612,7 @@
       "source_location": "L5"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -82498,7 +82621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -82507,7 +82630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -82516,7 +82639,7 @@
       "source_location": "L13"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -82525,7 +82648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -82534,7 +82657,7 @@
       "source_location": "L14"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -82543,7 +82666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -82552,7 +82675,7 @@
       "source_location": "L13"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -82561,7 +82684,7 @@
       "source_location": "L5"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -82570,7 +82693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -82579,30 +82702,12 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
       "norm_label": "formatnumber.ts",
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "bannermessage_getbannermessage",
-      "label": "getBannerMessage()",
-      "norm_label": "getbannermessage()",
-      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -82698,6 +82803,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "bannermessage_getbannermessage",
+      "label": "getBannerMessage()",
+      "norm_label": "getbannermessage()",
+      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
       "norm_label": "jsonresponse()",
@@ -82705,7 +82828,7 @@
       "source_location": "L27"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -82714,7 +82837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -82723,7 +82846,7 @@
       "source_location": "L4"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -82732,7 +82855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -82741,7 +82864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -82750,7 +82873,7 @@
       "source_location": "L5"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -82759,7 +82882,7 @@
       "source_location": "L10"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -82768,7 +82891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -82777,7 +82900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -82786,7 +82909,7 @@
       "source_location": "L10"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -82795,7 +82918,7 @@
       "source_location": "L4"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -82804,7 +82927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -82813,7 +82936,7 @@
       "source_location": "L39"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -82822,7 +82945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -82831,7 +82954,7 @@
       "source_location": "L18"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -82840,7 +82963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -82849,31 +82972,13 @@
       "source_location": "L71"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
       "norm_label": "checkoutprovider.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
-      "label": "PickupOptions.tsx",
-      "norm_label": "pickupoptions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "pickupoptions_iswithinrestrictiontime",
-      "label": "isWithinRestrictionTime()",
-      "norm_label": "iswithinrestrictiontime()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
-      "source_location": "L12"
     },
     {
       "community": 72,
@@ -82959,6 +83064,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
+      "label": "PickupOptions.tsx",
+      "norm_label": "pickupoptions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "pickupoptions_iswithinrestrictiontime",
+      "label": "isWithinRestrictionTime()",
+      "norm_label": "iswithinrestrictiontime()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
       "norm_label": "enteredbillingaddressdetails()",
@@ -82966,7 +83089,7 @@
       "source_location": "L6"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -82975,7 +83098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -82984,7 +83107,7 @@
       "source_location": "L18"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -82993,7 +83116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -83002,7 +83125,7 @@
       "source_location": "L10"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -83011,7 +83134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -83020,7 +83143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -83029,7 +83152,7 @@
       "source_location": "L8"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -83038,7 +83161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -83047,7 +83170,7 @@
       "source_location": "L27"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -83056,7 +83179,7 @@
       "source_location": "L40"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -83065,7 +83188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -83074,7 +83197,7 @@
       "source_location": "L3"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -83083,7 +83206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -83092,7 +83215,7 @@
       "source_location": "L8"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -83101,7 +83224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -83110,31 +83233,13 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
       "norm_label": "getissuemap()",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "customerdetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "label": "CustomerDetailsForm.tsx",
-      "norm_label": "customerdetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
     },
     {
       "community": 73,
@@ -83220,6 +83325,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "customerdetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
+      "label": "CustomerDetailsForm.tsx",
+      "norm_label": "customerdetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
@@ -83227,7 +83350,7 @@
       "source_location": "L161"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -83236,7 +83359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -83245,7 +83368,7 @@
       "source_location": "L3"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -83254,7 +83377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -83263,7 +83386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -83272,7 +83395,7 @@
       "source_location": "L4"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -83281,7 +83404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -83290,7 +83413,7 @@
       "source_location": "L14"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -83299,7 +83422,7 @@
       "source_location": "L27"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -83308,7 +83431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -83317,7 +83440,7 @@
       "source_location": "L17"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -83326,7 +83449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -83335,7 +83458,7 @@
       "source_location": "L13"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -83344,7 +83467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -83353,7 +83476,7 @@
       "source_location": "L47"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -83362,7 +83485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -83371,31 +83494,13 @@
       "source_location": "L7"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
       "norm_label": "mobilebagmenu.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "label": "SiteBanner.tsx",
-      "norm_label": "sitebanner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "sitebanner_sitebanner",
-      "label": "SiteBanner()",
-      "norm_label": "sitebanner()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L17"
     },
     {
       "community": 74,
@@ -83481,6 +83586,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
+      "label": "SiteBanner.tsx",
+      "norm_label": "sitebanner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "sitebanner_sitebanner",
+      "label": "SiteBanner()",
+      "norm_label": "sitebanner()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
       "norm_label": "notificationpill()",
@@ -83488,7 +83611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -83497,7 +83620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -83506,7 +83629,7 @@
       "source_location": "L12"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -83515,7 +83638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -83524,7 +83647,7 @@
       "source_location": "L7"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -83533,7 +83656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -83542,7 +83665,7 @@
       "source_location": "L45"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -83551,7 +83674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -83560,7 +83683,7 @@
       "source_location": "L5"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -83569,7 +83692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -83578,7 +83701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -83587,7 +83710,7 @@
       "source_location": "L17"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -83596,7 +83719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -83605,7 +83728,7 @@
       "source_location": "L3"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -83614,7 +83737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -83623,7 +83746,7 @@
       "source_location": "L37"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -83632,31 +83755,13 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
       "norm_label": "showshippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L79"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "label": "ProductReview.tsx",
-      "norm_label": "productreview.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "productreview_handlehelpful",
-      "label": "handleHelpful()",
-      "norm_label": "handlehelpful()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L87"
     },
     {
       "community": 75,
@@ -83742,6 +83847,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
+      "label": "ProductReview.tsx",
+      "norm_label": "productreview.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "productreview_handlehelpful",
+      "label": "handleHelpful()",
+      "norm_label": "handlehelpful()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
       "norm_label": "reviewsummary.tsx",
@@ -83749,7 +83872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -83758,7 +83881,7 @@
       "source_location": "L8"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -83767,7 +83890,7 @@
       "source_location": "L12"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -83776,7 +83899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -83785,7 +83908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -83794,7 +83917,7 @@
       "source_location": "L18"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -83803,7 +83926,7 @@
       "source_location": "L10"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -83812,7 +83935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -83821,7 +83944,7 @@
       "source_location": "L11"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -83830,7 +83953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -83839,7 +83962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -83848,7 +83971,7 @@
       "source_location": "L59"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -83857,7 +83980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -83866,7 +83989,7 @@
       "source_location": "L33"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -83875,7 +83998,7 @@
       "source_location": "L19"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -83884,7 +84007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -83893,30 +84016,12 @@
       "source_location": "L4"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
       "norm_label": "checkoutunavailable.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "errorboundary_errorboundary",
-      "label": "ErrorBoundary()",
-      "norm_label": "errorboundary()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
-      "label": "ErrorBoundary.tsx",
-      "norm_label": "errorboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1"
     },
     {
@@ -84003,6 +84108,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "errorboundary_errorboundary",
+      "label": "ErrorBoundary()",
+      "norm_label": "errorboundary()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
+      "label": "ErrorBoundary.tsx",
+      "norm_label": "errorboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
       "norm_label": "scrolldownbutton.tsx",
@@ -84010,7 +84133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -84019,7 +84142,7 @@
       "source_location": "L11"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -84028,7 +84151,7 @@
       "source_location": "L3"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -84037,7 +84160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -84046,7 +84169,7 @@
       "source_location": "L3"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -84055,7 +84178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -84064,7 +84187,7 @@
       "source_location": "L9"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -84073,7 +84196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -84082,7 +84205,7 @@
       "source_location": "L66"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -84091,7 +84214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -84100,7 +84223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -84109,7 +84232,7 @@
       "source_location": "L19"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -84118,7 +84241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -84127,7 +84250,7 @@
       "source_location": "L13"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -84136,7 +84259,7 @@
       "source_location": "L46"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -84145,7 +84268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -84154,31 +84277,13 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
       "norm_label": "getmodalconfig()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
-      "label": "webp-jpg.tsx",
-      "norm_label": "webp-jpg.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "webp_jpg_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
-      "source_location": "L1"
     },
     {
       "community": 77,
@@ -84264,6 +84369,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
+      "label": "webp-jpg.tsx",
+      "norm_label": "webp-jpg.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
+      "file_type": "code",
+      "id": "webp_jpg_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
       "norm_label": "useformsubmission()",
@@ -84271,7 +84394,7 @@
       "source_location": "L15"
     },
     {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -84280,7 +84403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -84289,7 +84412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -84298,7 +84421,7 @@
       "source_location": "L5"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -84307,7 +84430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -84316,7 +84439,7 @@
       "source_location": "L14"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -84325,7 +84448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -84334,7 +84457,7 @@
       "source_location": "L29"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -84343,7 +84466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -84352,7 +84475,7 @@
       "source_location": "L5"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -84361,7 +84484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -84370,7 +84493,7 @@
       "source_location": "L5"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -84379,7 +84502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -84388,7 +84511,7 @@
       "source_location": "L3"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -84397,7 +84520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -84406,7 +84529,7 @@
       "source_location": "L4"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -84415,31 +84538,13 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
       "norm_label": "usegetstore()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
-      "label": "useInventoryStatus.ts",
-      "norm_label": "useinventorystatus.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "useinventorystatus_useinventorystatus",
-      "label": "useInventoryStatus()",
-      "norm_label": "useinventorystatus()",
-      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
-      "source_location": "L9"
     },
     {
       "community": 78,
@@ -84525,6 +84630,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
+      "label": "useInventoryStatus.ts",
+      "norm_label": "useinventorystatus.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
+      "file_type": "code",
+      "id": "useinventorystatus_useinventorystatus",
+      "label": "useInventoryStatus()",
+      "norm_label": "useinventorystatus()",
+      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
       "norm_label": "useleaveareviewmodal.tsx",
@@ -84532,7 +84655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -84541,7 +84664,7 @@
       "source_location": "L17"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -84550,7 +84673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -84559,7 +84682,7 @@
       "source_location": "L5"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -84568,7 +84691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -84577,7 +84700,7 @@
       "source_location": "L15"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -84586,7 +84709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -84595,7 +84718,7 @@
       "source_location": "L18"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -84604,7 +84727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -84613,7 +84736,7 @@
       "source_location": "L9"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -84622,7 +84745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -84631,7 +84754,7 @@
       "source_location": "L16"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -84640,7 +84763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -84649,7 +84772,7 @@
       "source_location": "L3"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -84658,7 +84781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -84667,7 +84790,7 @@
       "source_location": "L11"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -84676,31 +84799,13 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
       "norm_label": "usescrolltotop()",
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
-      "label": "useTrackAction.ts",
-      "norm_label": "usetrackaction.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "usetrackaction_usetrackaction",
-      "label": "useTrackAction()",
-      "norm_label": "usetrackaction()",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
-      "source_location": "L7"
     },
     {
       "community": 79,
@@ -84786,6 +84891,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
+      "label": "useTrackAction.ts",
+      "norm_label": "usetrackaction.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
+      "file_type": "code",
+      "id": "usetrackaction_usetrackaction",
+      "label": "useTrackAction()",
+      "norm_label": "usetrackaction()",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
       "norm_label": "usetrackevent.ts",
@@ -84793,7 +84916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -84802,7 +84925,7 @@
       "source_location": "L4"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -84811,7 +84934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -84820,7 +84943,7 @@
       "source_location": "L14"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -84829,7 +84952,7 @@
       "source_location": "L4"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -84838,7 +84961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -84847,7 +84970,7 @@
       "source_location": "L7"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -84856,7 +84979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -84865,7 +84988,7 @@
       "source_location": "L6"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -84874,7 +84997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -84883,7 +85006,7 @@
       "source_location": "L10"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -84892,7 +85015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -84901,7 +85024,7 @@
       "source_location": "L6"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -84910,7 +85033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -84919,7 +85042,7 @@
       "source_location": "L5"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -84928,7 +85051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -84937,31 +85060,13 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
       "norm_label": "usepostransactionqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/posTransaction.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "product_useproductqueries",
-      "label": "useProductQueries()",
-      "norm_label": "useproductqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
-      "source_location": "L14"
     },
     {
       "community": 8,
@@ -85272,6 +85377,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 800,
+      "file_type": "code",
+      "id": "product_useproductqueries",
+      "label": "useProductQueries()",
+      "norm_label": "useproductqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
@@ -85279,7 +85402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 800,
+      "community": 801,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -85288,7 +85411,7 @@
       "source_location": "L9"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -85297,7 +85420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -85306,7 +85429,7 @@
       "source_location": "L10"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -85315,7 +85438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -85324,7 +85447,7 @@
       "source_location": "L11"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -85333,7 +85456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -85342,7 +85465,7 @@
       "source_location": "L6"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -85351,7 +85474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -85360,7 +85483,7 @@
       "source_location": "L5"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -85369,7 +85492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -85378,7 +85501,7 @@
       "source_location": "L6"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -85387,7 +85510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -85396,7 +85519,7 @@
       "source_location": "L10"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -85405,7 +85528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -85414,7 +85537,7 @@
       "source_location": "L15"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -85423,31 +85546,13 @@
       "source_location": "L14"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_router_tsx",
-      "label": "router.tsx",
-      "norm_label": "router.tsx",
-      "source_file": "packages/storefront-webapp/src/router.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "router_createrouter",
-      "label": "createRouter()",
-      "norm_label": "createrouter()",
-      "source_file": "packages/storefront-webapp/src/router.tsx",
-      "source_location": "L6"
     },
     {
       "community": 81,
@@ -85524,6 +85629,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_router_tsx",
+      "label": "router.tsx",
+      "norm_label": "router.tsx",
+      "source_file": "packages/storefront-webapp/src/router.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
+      "file_type": "code",
+      "id": "router_createrouter",
+      "label": "createRouter()",
+      "norm_label": "createrouter()",
+      "source_file": "packages/storefront-webapp/src/router.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
       "norm_label": "loadhomepagedata()",
@@ -85531,7 +85654,7 @@
       "source_location": "L14"
     },
     {
-      "community": 810,
+      "community": 811,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -85540,7 +85663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -85549,7 +85672,7 @@
       "source_location": "L8"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -85558,7 +85681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -85567,7 +85690,7 @@
       "source_location": "L14"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -85576,7 +85699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -85585,7 +85708,7 @@
       "source_location": "L13"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -85594,7 +85717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -85603,7 +85726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -85612,7 +85735,7 @@
       "source_location": "L9"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -85621,7 +85744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -85630,7 +85753,7 @@
       "source_location": "L15"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -85639,7 +85762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -85648,7 +85771,7 @@
       "source_location": "L16"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -85657,7 +85780,7 @@
       "source_location": "L6"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -85666,7 +85789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -85675,30 +85798,12 @@
       "source_location": "L10"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "canceled_checkoutcanceledview",
-      "label": "CheckoutCanceledView()",
-      "norm_label": "checkoutcanceledview()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
-      "label": "canceled.tsx",
-      "norm_label": "canceled.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1"
     },
     {
@@ -85776,6 +85881,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "canceled_checkoutcanceledview",
+      "label": "CheckoutCanceledView()",
+      "norm_label": "checkoutcanceledview()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 820,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
+      "label": "canceled.tsx",
+      "norm_label": "canceled.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
       "norm_label": "checkoutcomplete()",
@@ -85783,7 +85906,7 @@
       "source_location": "L33"
     },
     {
-      "community": 820,
+      "community": 821,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -85792,7 +85915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -85801,7 +85924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -85810,7 +85933,7 @@
       "source_location": "L193"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -85819,7 +85942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -85828,7 +85951,7 @@
       "source_location": "L7"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -85837,7 +85960,7 @@
       "source_location": "L10"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -85846,7 +85969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -85855,7 +85978,7 @@
       "source_location": "L32"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -85864,7 +85987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "deploy_qa_vps_test_readrepofile",
       "label": "readRepoFile()",
@@ -85873,7 +85996,7 @@
       "source_location": "L7"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "scripts_deploy_qa_vps_test_ts",
       "label": "deploy-qa-vps.test.ts",
@@ -85882,7 +86005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
@@ -85891,7 +86014,7 @@
       "source_location": "L16"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
@@ -85900,7 +86023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -85909,7 +86032,7 @@
       "source_location": "L211"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -85918,7 +86041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -85927,30 +86050,12 @@
       "source_location": "L85"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
       "norm_label": "sample-app.ts",
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
       "source_location": "L1"
     },
     {
@@ -86028,6 +86133,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 830,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
       "norm_label": "api.d.ts",
@@ -86035,7 +86158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -86044,7 +86167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -86053,7 +86176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -86062,7 +86185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -86071,7 +86194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -86080,7 +86203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -86089,7 +86212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -86098,21 +86221,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
-      "label": "r2.test.ts",
-      "norm_label": "r2.test.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.test.ts",
       "source_location": "L1"
     },
     {
@@ -86190,6 +86304,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
+      "label": "r2.test.ts",
+      "norm_label": "r2.test.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
@@ -86197,7 +86320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -86206,7 +86329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -86215,7 +86338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -86224,7 +86347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -86233,7 +86356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -86242,7 +86365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -86251,7 +86374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -86260,21 +86383,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
       "norm_label": "posreceiptemail.tsx",
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/athena-webapp/convex/env.ts",
       "source_location": "L1"
     },
     {
@@ -86352,6 +86466,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/athena-webapp/convex/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
@@ -86359,7 +86482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -86368,7 +86491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -86377,7 +86500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
@@ -86386,7 +86509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
       "label": "index.ts",
@@ -86395,7 +86518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
       "label": "organizations.ts",
@@ -86404,7 +86527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
@@ -86413,7 +86536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -86422,21 +86545,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/bag.ts",
       "source_location": "L1"
     },
     {
@@ -86514,6 +86628,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
@@ -86521,7 +86644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
@@ -86530,7 +86653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
@@ -86539,7 +86662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
@@ -86548,7 +86671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -86557,7 +86680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
       "label": "paystack.ts",
@@ -86566,7 +86689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -86575,7 +86698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -86584,21 +86707,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/savedBag.ts",
       "source_location": "L1"
     },
     {
@@ -86676,6 +86790,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
       "norm_label": "security.test.ts",
@@ -86683,7 +86806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
@@ -86692,7 +86815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
@@ -86701,7 +86824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
@@ -86710,7 +86833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -86719,7 +86842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
       "label": "index.ts",
@@ -86728,7 +86851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -86737,7 +86860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -86746,21 +86869,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
       "norm_label": "athenauser.ts",
       "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -86838,6 +86952,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
       "norm_label": "bestseller.ts",
@@ -86845,7 +86968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -86854,7 +86977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -86863,7 +86986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -86872,7 +86995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
@@ -86881,7 +87004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -86890,7 +87013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -86899,7 +87022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -86908,21 +87031,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "label": "pos.ts",
-      "norm_label": "pos.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1"
     },
     {
@@ -87000,6 +87114,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_pos_ts",
+      "label": "pos.ts",
+      "norm_label": "pos.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
       "norm_label": "poscustomers.ts",
@@ -87007,7 +87130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -87016,7 +87139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -87025,7 +87148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
@@ -87034,7 +87157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -87043,7 +87166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -87052,7 +87175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -87061,7 +87184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -87070,21 +87193,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
       "norm_label": "commandresultvalidators.test.ts",
       "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "label": "currency.test.ts",
-      "norm_label": "currency.test.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1"
     },
     {
@@ -87378,6 +87492,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
+      "label": "currency.test.ts",
+      "norm_label": "currency.test.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
       "norm_label": "storeinsights.ts",
@@ -87385,7 +87508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -87394,7 +87517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -87403,7 +87526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -87412,7 +87535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -87421,7 +87544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -87430,7 +87553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -87439,7 +87562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -87448,21 +87571,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
       "norm_label": "inventorymovements.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
-      "label": "paymentAllocations.test.ts",
-      "norm_label": "paymentallocations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
       "source_location": "L1"
     },
     {
@@ -87540,6 +87654,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
+      "label": "paymentAllocations.test.ts",
+      "norm_label": "paymentallocations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
       "norm_label": "emailotp.test.ts",
@@ -87547,7 +87670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -87556,7 +87679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
@@ -87565,7 +87688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
@@ -87574,7 +87697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -87583,7 +87706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -87592,7 +87715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -87601,7 +87724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -87610,21 +87733,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/convex/pos/domain/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
-      "label": "registerSessionRepository.test.ts",
-      "norm_label": "registersessionrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts",
       "source_location": "L1"
     },
     {
@@ -87702,6 +87816,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
+      "label": "registerSessionRepository.test.ts",
+      "norm_label": "registersessionrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
@@ -87709,7 +87832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -87718,7 +87841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -87727,7 +87850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -87736,7 +87859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -87745,7 +87868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -87754,7 +87877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -87763,7 +87886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -87772,21 +87895,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
       "norm_label": "bestseller.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
       "source_location": "L1"
     },
     {
@@ -87864,6 +87978,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
@@ -87871,7 +87994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -87880,7 +88003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -87889,7 +88012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -87898,7 +88021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
@@ -87907,7 +88030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -87916,7 +88039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -87925,7 +88048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -87934,21 +88057,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
       "source_location": "L1"
     },
     {
@@ -88026,6 +88140,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
@@ -88033,7 +88156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -88042,7 +88165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -88051,7 +88174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -88060,7 +88183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -88069,7 +88192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -88078,7 +88201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -88087,7 +88210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -88096,21 +88219,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
       "norm_label": "customerprofile.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/customerProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
       "source_location": "L1"
     },
     {
@@ -88188,6 +88302,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
       "norm_label": "inventorymovement.ts",
@@ -88195,7 +88318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -88204,7 +88327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -88213,7 +88336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -88222,7 +88345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -88231,7 +88354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -88240,7 +88363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -88249,7 +88372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -88258,21 +88381,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
       "norm_label": "mtncollections.ts",
       "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
       "source_location": "L1"
     },
     {
@@ -88350,6 +88464,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
       "norm_label": "expensesession.ts",
@@ -88357,7 +88480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -88366,7 +88489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -88375,7 +88498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -88384,7 +88507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -88393,7 +88516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -88402,7 +88525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -88411,7 +88534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -88420,21 +88543,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
-      "label": "posTransactionItem.ts",
-      "norm_label": "postransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
       "source_location": "L1"
     },
     {
@@ -88512,6 +88626,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
+      "label": "posTransactionItem.ts",
+      "norm_label": "postransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -88519,7 +88642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -88528,7 +88651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -88537,7 +88660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -88546,7 +88669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -88555,7 +88678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -88564,7 +88687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
@@ -88573,7 +88696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -88582,21 +88705,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
       "norm_label": "purchaseorder.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
-      "label": "purchaseOrderLineItem.ts",
-      "norm_label": "purchaseorderlineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
       "source_location": "L1"
     },
     {
@@ -88674,6 +88788,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
+      "label": "purchaseOrderLineItem.ts",
+      "norm_label": "purchaseorderlineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
       "norm_label": "receivingbatch.ts",
@@ -88681,7 +88804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -88690,7 +88813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -88699,7 +88822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -88708,7 +88831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -88717,7 +88840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -88726,7 +88849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -88735,7 +88858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -88744,21 +88867,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
       "source_location": "L1"
     },
     {
@@ -88836,6 +88950,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
       "norm_label": "offer.ts",
@@ -88843,7 +88966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -88852,7 +88975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -88861,7 +88984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -88870,7 +88993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -88879,7 +89002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -88888,7 +89011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -88897,7 +89020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -88906,21 +89029,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "label": "storeFrontVerificationCode.ts",
-      "norm_label": "storefrontverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1588
-- Graph nodes: 4389
-- Graph edges: 4118
-- Communities: 1516
+- Code files discovered: 1591
+- Graph nodes: 4395
+- Graph edges: 4123
+- Communities: 1519
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/convex/http/domains/core/routes/products.ts
+++ b/packages/athena-webapp/convex/http/domains/core/routes/products.ts
@@ -57,6 +57,7 @@ productRoutes.get("/bestSellers", async (c) => {
 
   const res = await c.env.runQuery(api.inventory.bestSeller.getAll, {
     storeId: storeId as Id<"store">,
+    isVisible: true,
   });
 
   return c.json(res);

--- a/packages/athena-webapp/convex/inventory/bestSeller.test.ts
+++ b/packages/athena-webapp/convex/inventory/bestSeller.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { QueryCtx } from "../_generated/server";
+import { getAll } from "./bestSeller";
+
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
+
+describe("best-seller product visibility", () => {
+  it("filters archived product SKUs from public best-seller results", async () => {
+    const bestSellers = [
+      {
+        _id: "bestSeller-live",
+        productSkuId: "sku-live",
+        storeId: "store123",
+      },
+      {
+        _id: "bestSeller-archived",
+        productSkuId: "sku-archived",
+        storeId: "store123",
+      },
+    ];
+    const skus = new Map([
+      [
+        "sku-live",
+        {
+          _id: "sku-live",
+          isVisible: true,
+          product: { availability: "live" },
+        },
+      ],
+      [
+        "sku-archived",
+        {
+          _id: "sku-archived",
+          isVisible: true,
+          product: { availability: "archived" },
+        },
+      ],
+    ]);
+
+    const ctx = {
+      db: {
+        query() {
+          return {
+            filter() {
+              return {
+                collect: async () => bestSellers,
+              };
+            },
+          };
+        },
+      },
+      runQuery: vi.fn(async (_ref, args: { id: string }) => skus.get(args.id)),
+    } as unknown as QueryCtx;
+
+    const results = await getHandler(getAll)(ctx, {
+      storeId: "store123",
+      isVisible: true,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]._id).toBe("bestSeller-live");
+    expect(results[0].productSku._id).toBe("sku-live");
+  });
+});

--- a/packages/athena-webapp/convex/inventory/bestSeller.ts
+++ b/packages/athena-webapp/convex/inventory/bestSeller.ts
@@ -77,11 +77,13 @@ export const getAll = query({
         );
 
         const sku =
-          args.isVisible !== undefined
-            ? args.isVisible === productSku?.isVisible
-              ? productSku
-              : undefined
-            : productSku;
+          productSku?.product?.availability === "archived"
+            ? undefined
+            : args.isVisible !== undefined
+              ? args.isVisible === productSku?.isVisible
+                ? productSku
+                : undefined
+              : productSku;
 
         return {
           ...item,
@@ -90,7 +92,7 @@ export const getAll = query({
       })
     );
 
-    return enrichedItems;
+    return enrichedItems.filter((item) => item.productSku);
   },
 });
 
@@ -115,11 +117,13 @@ export const getAllInternal = internalQuery({
         );
 
         const sku =
-          args.isVisible !== undefined
-            ? args.isVisible === productSku?.isVisible
-              ? productSku
-              : undefined
-            : productSku;
+          productSku?.product?.availability === "archived"
+            ? undefined
+            : args.isVisible !== undefined
+              ? args.isVisible === productSku?.isVisible
+                ? productSku
+                : undefined
+              : productSku;
 
         return {
           ...item,
@@ -128,7 +132,7 @@ export const getAllInternal = internalQuery({
       })
     );
 
-    return enrichedItems;
+    return enrichedItems.filter((item) => item.productSku);
   },
 });
 

--- a/packages/athena-webapp/convex/inventory/featuredItem.ts
+++ b/packages/athena-webapp/convex/inventory/featuredItem.ts
@@ -44,7 +44,7 @@ export const create = mutation({
       type: args.type,
     });
 
-    return await ctx.db.get(id);
+    return await ctx.db.get(entity, id);
   },
 });
 
@@ -53,7 +53,7 @@ export const remove = mutation({
     id: v.id(entity),
   },
   handler: async (ctx, args) => {
-    await ctx.db.delete(args.id);
+    await ctx.db.delete(entity, args.id);
 
     return true;
   },
@@ -64,7 +64,7 @@ export const getById = query({
     id: v.id(entity),
   },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id);
+    return await ctx.db.get(entity, args.id);
   },
 });
 
@@ -82,7 +82,7 @@ export const getAll = query({
           args.type ? q.eq(q.field("type"), args.type) : q.eq(1, 1)
         );
       })
-      .collect();
+      .take(100);
 
     const enrichedItems: any[] = await Promise.all(
       items.map(async (item) => {
@@ -94,13 +94,16 @@ export const getAll = query({
             {
               identifier: item.productId,
               storeId: args.storeId,
+              filters: {
+                isVisible: true,
+              },
             }
           );
           enrichedData.product = product;
         }
 
         if (item.categoryId) {
-          const category = await ctx.db.get(item.categoryId);
+          const category = await ctx.db.get("category", item.categoryId);
           enrichedData.category = category;
 
           // Get first 5 products from this category
@@ -110,7 +113,8 @@ export const getAll = query({
               q.and(
                 q.eq(q.field("categoryId"), item.categoryId),
                 q.eq(q.field("storeId"), args.storeId),
-                q.eq(q.field("isVisible"), true)
+                q.eq(q.field("isVisible"), true),
+                q.neq(q.field("availability"), "archived")
               )
             )
             .take(5);
@@ -133,7 +137,10 @@ export const getAll = query({
         }
 
         if (item.subcategoryId) {
-          const subcategory = await ctx.db.get(item.subcategoryId);
+          const subcategory = await ctx.db.get(
+            "subcategory",
+            item.subcategoryId
+          );
           enrichedData.subcategory = subcategory;
 
           // Get first 5 products from this subcategory
@@ -143,7 +150,8 @@ export const getAll = query({
               q.and(
                 q.eq(q.field("subcategoryId"), item.subcategoryId),
                 q.eq(q.field("storeId"), args.storeId),
-                q.eq(q.field("isVisible"), true)
+                q.eq(q.field("isVisible"), true),
+                q.neq(q.field("availability"), "archived")
               )
             )
             .take(5);
@@ -180,7 +188,7 @@ export const updateRanks = mutation({
   handler: async (ctx, args) => {
     await Promise.all(
       args.ranks.map(async (item) => {
-        await ctx.db.patch(item.id, {
+        await ctx.db.patch(entity, item.id, {
           rank: item.rank,
         });
       })

--- a/packages/athena-webapp/convex/inventory/productUtil.test.ts
+++ b/packages/athena-webapp/convex/inventory/productUtil.test.ts
@@ -15,18 +15,20 @@ describe("buildAllProductsCacheKey", () => {
         ...baseArgs,
         isVisible: true,
         excludeStorefrontHidden: true,
+        availability: "live",
       }),
     ).toBe(
-      "all:products:{store-1}:category:lace-fronts:subcategory:closures:isVisible:true:excludeStorefrontHidden:true",
+      "all:products:{store-1}:category:lace-fronts:subcategory:closures:isVisible:true:availability:live:excludeStorefrontHidden:true",
     );
 
     expect(
       buildAllProductsCacheKey({
         ...baseArgs,
         isVisible: false,
+        availability: "archived",
       }),
     ).toBe(
-      "all:products:{store-1}:category:lace-fronts:subcategory:closures:isVisible:false",
+      "all:products:{store-1}:category:lace-fronts:subcategory:closures:isVisible:false:availability:archived",
     );
   });
 });

--- a/packages/athena-webapp/convex/inventory/productUtil.ts
+++ b/packages/athena-webapp/convex/inventory/productUtil.ts
@@ -12,6 +12,7 @@ export function buildAllProductsCacheKey(args: {
   category?: string[];
   subcategory?: string[];
   isVisible?: boolean;
+  availability?: "archived" | "draft" | "live";
   excludeStorefrontHidden?: boolean;
 }) {
   const colorParam = args.color ? `:color:${args.color.join(",")}` : "";
@@ -24,11 +25,14 @@ export function buildAllProductsCacheKey(args: {
     : "";
   const isVisibleParam =
     args.isVisible === undefined ? "" : `:isVisible:${args.isVisible}`;
+  const availabilityParam = args.availability
+    ? `:availability:${args.availability}`
+    : ":availability:active";
   const storefrontHiddenParam = args.excludeStorefrontHidden
     ? ":excludeStorefrontHidden:true"
     : "";
 
-  return `all:products:{${args.storeId}}${colorParam}${lengthParam}${categoryParam}${subcategoryParam}${isVisibleParam}${storefrontHiddenParam}`;
+  return `all:products:{${args.storeId}}${colorParam}${lengthParam}${categoryParam}${subcategoryParam}${isVisibleParam}${availabilityParam}${storefrontHiddenParam}`;
 }
 
 export const getAllProducts = internalAction({
@@ -39,6 +43,9 @@ export const getAllProducts = internalAction({
     category: v.optional(v.array(v.string())),
     subcategory: v.optional(v.array(v.string())),
     isVisible: v.optional(v.boolean()),
+    availability: v.optional(
+      v.union(v.literal("draft"), v.literal("live"), v.literal("archived"))
+    ),
     excludeStorefrontHidden: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { Id } from "../_generated/dataModel";
-import type { MutationCtx } from "../_generated/server";
-import { createSku, updateSku } from "./products";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { archive, createSku, getAll, updateSku } from "./products";
 
-type TableName = "product" | "productSku";
+const mocks = vi.hoisted(() => ({
+  requireStoreFullAdminAccess: vi.fn(),
+}));
+
+vi.mock("../stockOps/access", () => ({
+  requireStoreFullAdminAccess: mocks.requireStoreFullAdminAccess,
+}));
+
+type TableName = "category" | "product" | "productSku" | "subcategory";
 type Row = Record<string, unknown> & { _id: string };
 
 function getHandler(definition: unknown) {
@@ -13,12 +21,18 @@ function getHandler(definition: unknown) {
 
 function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
   const tables: Record<TableName, Map<string, Row>> = {
+    category: new Map((seed.category ?? []).map((row) => [row._id, row])),
     product: new Map((seed.product ?? []).map((row) => [row._id, row])),
     productSku: new Map((seed.productSku ?? []).map((row) => [row._id, row])),
+    subcategory: new Map(
+      (seed.subcategory ?? []).map((row) => [row._id, row]),
+    ),
   };
   const counters: Record<TableName, number> = {
+    category: 0,
     product: 0,
     productSku: seed.productSku?.length ?? 0,
+    subcategory: 0,
   };
 
   function createIndexedQuery(
@@ -54,6 +68,9 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
 
         tables[table].set(id, { ...existing, ...value });
       },
+      async delete(table: TableName, id: string) {
+        tables[table].delete(id);
+      },
       query(table: TableName) {
         return {
           filter() {
@@ -82,9 +99,68 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
         };
       },
     },
+    scheduler: {
+      runAfter: vi.fn(),
+    },
   } as unknown as MutationCtx;
 
   return { ctx, tables };
+}
+
+function createProductsQueryCtx(seed: Partial<Record<TableName, Row[]>>) {
+  const { ctx, tables } = createSkuMutationCtx(seed);
+  const queryCtx = ctx as unknown as QueryCtx;
+
+  queryCtx.db.query = ((table: TableName) => ({
+    filter(applyFilter?: (queryBuilder: unknown) => (row: Row) => boolean) {
+      const predicate = applyFilter
+        ? applyFilter({
+            field: (field: string) => field,
+            eq: (field: string, value: unknown) => (row: Row) =>
+              row[field] === value,
+            and:
+              (...predicates: Array<(row: Row) => boolean>) =>
+              (row: Row) =>
+                predicates.every((predicate) => predicate(row)),
+            or:
+              (...predicates: Array<(row: Row) => boolean>) =>
+              (row: Row) =>
+                predicates.some((predicate) => predicate(row)),
+          })
+        : () => true;
+
+      const matches = Array.from(tables[table].values()).filter(predicate);
+      return {
+        collect: async () => matches,
+        first: async () => matches[0] ?? null,
+      };
+    },
+    withIndex(
+      _index: string,
+      applyIndex: (queryBuilder: {
+        eq: (field: string, value: unknown) => unknown;
+      }) => unknown,
+    ) {
+      const filters: Array<[string, unknown]> = [];
+      const queryBuilder = {
+        eq(field: string, value: unknown) {
+          filters.push([field, value]);
+          return queryBuilder;
+        },
+      };
+
+      applyIndex(queryBuilder);
+      const matches = Array.from(tables[table].values()).filter((row) =>
+        filters.every(([field, value]) => row[field] === value),
+      );
+      return {
+        collect: async () => matches,
+        first: async () => matches[0] ?? null,
+      };
+    },
+  })) as unknown as QueryCtx["db"]["query"];
+
+  return { ctx: queryCtx, tables };
 }
 
 describe("inventory SKU generation", () => {
@@ -144,5 +220,106 @@ describe("inventory SKU generation", () => {
       "productSku001",
       expect.objectContaining({ sku: result.sku }),
     );
+  });
+});
+
+describe("product archiving", () => {
+  it("archives a product without deleting the product record", async () => {
+    mocks.requireStoreFullAdminAccess.mockResolvedValue({});
+
+    const { ctx, tables } = createSkuMutationCtx({
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+    const deleteSpy = vi.spyOn(ctx.db, "delete");
+
+    const result = await getHandler(archive)(ctx, {
+      id: "product001" as Id<"product">,
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    expect(mocks.requireStoreFullAdminAccess).toHaveBeenCalledWith(
+      ctx,
+      "storezzzz",
+    );
+    expect(result).toMatchObject({
+      _id: "product001",
+      availability: "archived",
+    });
+    expect(tables.product.get("product001")).toMatchObject({
+      availability: "archived",
+    });
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("product catalog visibility", () => {
+  it("excludes archived products by default and returns only archived products when requested", async () => {
+    const seed = {
+      product: [
+        {
+          _id: "product-live",
+          availability: "live",
+          categoryId: "category-1",
+          isVisible: true,
+          name: "Live Product",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-1",
+        },
+        {
+          _id: "product-archived",
+          availability: "archived",
+          categoryId: "category-1",
+          isVisible: true,
+          name: "Archived Product",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-live",
+          images: ["live.jpg"],
+          inventoryCount: 1,
+          price: 1000,
+          productId: "product-live",
+          quantityAvailable: 1,
+          storeId: "storezzzz",
+        },
+        {
+          _id: "sku-archived",
+          images: ["archived.jpg"],
+          inventoryCount: 1,
+          price: 1000,
+          productId: "product-archived",
+          quantityAvailable: 1,
+          storeId: "storezzzz",
+        },
+      ],
+    };
+
+    const activeCtx = createProductsQueryCtx(seed).ctx;
+    const defaultProducts = await getHandler(getAll)(activeCtx, {
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    expect(defaultProducts.map((product: Row) => product._id)).toEqual([
+      "product-live",
+    ]);
+
+    const archivedCtx = createProductsQueryCtx(seed).ctx;
+    const archivedProducts = await getHandler(getAll)(archivedCtx, {
+      storeId: "storezzzz" as Id<"store">,
+      availability: "archived",
+    });
+
+    expect(archivedProducts.map((product: Row) => product._id)).toEqual([
+      "product-archived",
+    ]);
   });
 });

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @convex-dev/no-collect-in-query -- Query refactors are tracked in V26-168, V26-169, and V26-170; this PR only hardens API boundaries. */
 import {
-  action,
+  internalAction,
   internalMutation,
   internalQuery,
   mutation,
@@ -12,6 +12,7 @@ import { ProductSku } from "../../types";
 import { Id } from "../_generated/dataModel";
 import { api, internal } from "../_generated/api";
 import { deleteDirectoryInR2 } from "../cloudflare/r2";
+import { requireStoreFullAdminAccess } from "../stockOps/access";
 
 const entity = "product";
 
@@ -80,6 +81,9 @@ export const getAll = query({
     category: v.optional(v.array(v.string())),
     subcategory: v.optional(v.array(v.string())),
     isVisible: v.optional(v.boolean()),
+    availability: v.optional(
+      v.union(v.literal("draft"), v.literal("live"), v.literal("archived"))
+    ),
     excludeStorefrontHidden: v.optional(v.boolean()),
     filters: v.optional(
       v.object({
@@ -167,8 +171,18 @@ export const getAll = query({
         );
     }
 
+    const requestedAvailability = args.availability;
+
     // Filter by category/subcategory in memory
     const products = allProducts.filter((product) => {
+      if (requestedAvailability) {
+        if (product.availability !== requestedAvailability) {
+          return false;
+        }
+      } else if (product.availability === "archived") {
+        return false;
+      }
+
       if (
         storefrontHiddenCategoryIds.has(product.categoryId) ||
         storefrontHiddenSubcategoryIds.has(product.subcategoryId)
@@ -518,6 +532,10 @@ export const getByIdOrSlug = query({
       return null;
     }
 
+    if (product.availability === "archived") {
+      return null;
+    }
+
     const skusWithCategory = skus
       .map((sku) => ({
         ...sku,
@@ -848,7 +866,35 @@ export const update = mutation({
   },
 });
 
-export const remove = mutation({
+export const archive = mutation({
+  args: {
+    id: v.id(entity),
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    await requireStoreFullAdminAccess(ctx, args.storeId);
+
+    const product = await ctx.db.get("product", args.id);
+
+    if (!product || product.storeId !== args.storeId) {
+      return null;
+    }
+
+    await ctx.db.patch("product", args.id, { availability: "archived" });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.inventory.productUtil.invalidateProductCache,
+      {
+        storeId: product.storeId,
+      }
+    );
+
+    return await ctx.db.get("product", args.id);
+  },
+});
+
+export const remove = internalMutation({
   args: {
     id: v.id(entity),
   },
@@ -862,20 +908,28 @@ export const remove = mutation({
 export const removeInternal = internalMutation({
   args: {
     id: v.id(entity),
+    storeId: v.id("store"),
   },
   handler: async (ctx, args) => {
+    const product = await ctx.db.get("product", args.id);
+
+    if (!product || product.storeId !== args.storeId) {
+      return { message: "OK" };
+    }
+
     await ctx.db.delete("product", args.id);
 
     return { message: "OK" };
   },
 });
 
-export const clear = action({
+export const clear = internalAction({
   args: { id: v.id(entity), storeId: v.id("store") },
   handler: async (ctx, args) => {
     await Promise.all([
       await ctx.runMutation(internal.inventory.products.removeInternal, {
         id: args.id,
+        storeId: args.storeId,
       }),
       await deleteDirectoryInR2(`stores/${args.storeId}/products/${args.id}`),
     ]);

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -163,6 +163,14 @@ describe("listRegisterCatalog", () => {
           description: "Should not leak",
           name: "Other Store Wig",
         },
+        {
+          _id: "product-archived",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Archived product",
+          name: "Archived Wig",
+          availability: "archived",
+        },
       ],
       productSku: [
         {
@@ -193,6 +201,16 @@ describe("listRegisterCatalog", () => {
           productId: "product-other-store",
           sku: "OTHER-STORE",
           barcode: "999",
+          images: [],
+          price: 1000,
+          quantityAvailable: 9,
+        },
+        {
+          _id: "sku-archived",
+          storeId: "store-a",
+          productId: "product-archived",
+          sku: "ARCHIVED-WIG",
+          barcode: "888",
           images: [],
           price: 1000,
           quantityAvailable: 9,

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -113,7 +113,11 @@ export async function listRegisterCatalog(
       productCache.set(sku.productId, product);
     }
 
-    if (!product || product.storeId !== args.storeId) {
+    if (
+      !product ||
+      product.storeId !== args.storeId ||
+      product.availability === "archived"
+    ) {
       continue;
     }
 

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
@@ -39,7 +39,11 @@ async function mapSkuToCatalogResult(
     categoryName?: string;
   },
 ): Promise<CatalogResult | null> {
-  if (!args.product || !args.sku.netPrice) {
+  if (
+    !args.product ||
+    args.product.availability === "archived" ||
+    !args.sku.netPrice
+  ) {
     return null;
   }
 
@@ -85,7 +89,7 @@ export async function searchProducts(
   if (isConvexProductId(query)) {
     const product = await getProductById(ctx, query as Id<"product">);
 
-    if (product?.storeId === args.storeId) {
+    if (product?.storeId === args.storeId && product.availability !== "archived") {
       const productSkus = await listProductSkusByProductId(ctx, product._id);
       const categoryName =
         (await getCategoryById(ctx, product.categoryId))?.name || "";
@@ -144,7 +148,7 @@ export async function lookupByBarcode(
       ? await getProductById(ctx, args.barcode as Id<"product">)
       : null;
 
-    if (product?.storeId === args.storeId) {
+    if (product?.storeId === args.storeId && product.availability !== "archived") {
       const allSkus = await listProductSkusByProductId(ctx, product._id);
       const categoryName =
         (await getCategoryById(ctx, product.categoryId))?.name || "";
@@ -167,7 +171,7 @@ export async function lookupByBarcode(
   }
 
   const product = await getProductById(ctx, sku.productId);
-  if (!product) {
+  if (!product || product.availability === "archived") {
     return null;
   }
 

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts
@@ -109,7 +109,11 @@ export async function listMatchingStoreSkus(
       productCache.set(sku.productId, product);
     }
 
-    if (!product || product.storeId !== args.storeId) {
+    if (
+      !product ||
+      product.storeId !== args.storeId ||
+      product.availability === "archived"
+    ) {
       continue;
     }
 

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -123,6 +123,10 @@ async function listProductSkusForStockAdjustmentScopeWithCtx(
 
   return productSkus.filter((productSku) => {
     const product = productMap.get(productSku.productId);
+    if (product?.availability === "archived") {
+      return false;
+    }
+
     const category = product?.categoryId
       ? categoryMap.get(product.categoryId)
       : null;
@@ -455,8 +459,13 @@ export async function listInventorySnapshotWithCtx(
     }
   });
 
+  const activeProductSkus = productSkus.filter((productSku) => {
+    const product = productMap.get(productSku.productId);
+    return product?.availability !== "archived";
+  });
+
   const rows = await Promise.all(
-    productSkus.map(async (productSku) => {
+    activeProductSkus.map(async (productSku) => {
         const product = productMap.get(productSku.productId);
         const category = product?.categoryId
           ? categoryMap.get(product.categoryId)

--- a/packages/athena-webapp/convex/storeFront/checkoutSession.ts
+++ b/packages/athena-webapp/convex/storeFront/checkoutSession.ts
@@ -111,9 +111,11 @@ export const create = mutation({
       };
     }
 
-    // Check if products are visible
+    // Check if products are available for checkout
     const invisibleProducts = productExistenceChecks.filter(
-      (product) => product && product.isVisible === false,
+      (product) =>
+        product &&
+        (product.isVisible === false || product.availability === "archived"),
     );
 
     if (invisibleProducts.length > 0) {

--- a/packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts
@@ -132,4 +132,15 @@ describe("commerce query indexing", () => {
     expect(helperSource).toContain('.withIndex("by_externalTransactionId"');
     expect(analyticsSource).toContain('.withIndex("by_promoCodeId"');
   });
+
+  it("rejects archived products before checkout sessions can be created", () => {
+    const checkoutSessionSource = getSource("./checkoutSession.ts");
+
+    expect(checkoutSessionSource).toContain(
+      'product.availability === "archived"',
+    );
+    expect(checkoutSessionSource).toContain(
+      "Some items in your bag are no longer available",
+    );
+  });
 });

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -6,8 +6,8 @@ This key-folder index highlights the main directories agents are likely to need 
 
 ## Core app surfaces
 
-- [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 74 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 529 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 75 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 530 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 9 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, OperationsQueueView.auth.test.tsx, OperationsQueueView.test.tsx, OperationsQueueView.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 386 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 387 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/route-index.md
+++ b/packages/athena-webapp/docs/agent/route-index.md
@@ -60,6 +60,7 @@ This route index enumerates the current files under `src/routes` so agents can o
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx)
+- [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx)

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -29,6 +29,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/http/domains/customerChannel/routes/storefrontCors.test.ts`](../../convex/http/domains/customerChannel/routes/storefrontCors.test.ts)
 - [`convex/http/health.test.ts`](../../convex/http/health.test.ts)
 - [`convex/http/routerComposition.test.ts`](../../convex/http/routerComposition.test.ts)
+- [`convex/inventory/bestSeller.test.ts`](../../convex/inventory/bestSeller.test.ts)
 - [`convex/inventory/expenseSessions.test.ts`](../../convex/inventory/expenseSessions.test.ts)
 - [`convex/inventory/expenseTransactions.test.ts`](../../convex/inventory/expenseTransactions.test.ts)
 - [`convex/inventory/helpers/inventoryHolds.test.ts`](../../convex/inventory/helpers/inventoryHolds.test.ts)

--- a/packages/athena-webapp/src/components/add-product/ProductView.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.tsx
@@ -64,7 +64,7 @@ function ProductViewContent() {
   const createProduct = useMutation(api.inventory.products.create);
   const createSku = useMutation(api.inventory.products.createSku);
   const updateProduct = useMutation(api.inventory.products.update);
-  const deleteProduct = useAction(api.inventory.products.clear);
+  const archiveProduct = useMutation(api.inventory.products.archive);
   const deleteSku = useMutation(api.inventory.products.removeSku);
   const updateSku = useMutation(api.inventory.products.updateSku);
 
@@ -82,13 +82,13 @@ function ProductViewContent() {
 
   const deleteActiveProduct = async () => {
     if (!activeProduct?._id || !activeStore)
-      throw new Error("Missing data required to delete product");
+      throw new Error("Missing data required to archive product");
 
     try {
       setIsDeleteMutationPending(true);
-      await deleteProduct({ id: activeProduct._id, storeId: activeStore._id });
+      await archiveProduct({ id: activeProduct._id, storeId: activeStore._id });
 
-      toast(`Product '${activeProduct.name}' deleted`, {
+      toast(`Product '${activeProduct.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -492,7 +492,7 @@ function ProductViewContent() {
                   onClick={() => setIsDeleteModalOpen(true)}
                   disabled={isUpdatingProduct}
                 >
-                  <p>Delete</p>
+                  <p>Archive</p>
                   <TrashIcon className="w-3.5 h-3.5" />
                 </LoadingButton>
 
@@ -555,7 +555,7 @@ function ProductViewContent() {
   return (
     <View header={<Navigation />}>
       <AlertModal
-        title="Delete product?"
+        title="Archive product?"
         isOpen={isDeleteModalOpen}
         loading={isDeleteMutationPending}
         onClose={() => {

--- a/packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx
@@ -39,7 +39,7 @@ export function DataTableRowActions<TData>({
       setIsDeleteMutationPending(true);
       await deleteRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -88,7 +88,7 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
+        title="Archive product?"
         isOpen={isDeleteModalOpen}
         loading={isDeleteMutationPending}
         onClose={() => {
@@ -126,7 +126,7 @@ export function DataTableRowActions<TData>({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx
@@ -39,7 +39,7 @@ export function DataTableRowActions<TData>({
       setIsDeleteMutationPending(true);
       await deleteRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -88,7 +88,7 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
+        title="Archive product?"
         isOpen={isDeleteModalOpen}
         loading={isDeleteMutationPending}
         onClose={() => {
@@ -126,7 +126,7 @@ export function DataTableRowActions<TData>({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx
@@ -39,7 +39,7 @@ export function DataTableRowActions<TData>({
       setIsDeleteMutationPending(true);
       await deleteRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -88,7 +88,7 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
+        title="Archive product?"
         isOpen={isDeleteModalOpen}
         loading={isDeleteMutationPending}
         onClose={() => {
@@ -126,7 +126,7 @@ export function DataTableRowActions<TData>({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 import { Ban } from "lucide-react";
 import { useState } from "react";
 import { AlertModal } from "@/components/ui/modals/alert-modal";
-import { useDeleteProduct } from "../../product-actions";
+import { useArchiveProduct } from "../../product-actions";
 import { Product } from "~/types";
 
 interface DataTableRowActionsProps<TData> {
@@ -25,21 +25,22 @@ interface DataTableRowActionsProps<TData> {
 export function DataTableRowActions<TData>({
   row,
 }: DataTableRowActionsProps<TData>) {
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [isDeleteMutationPending, setIsDeleteMutationPending] = useState(false);
+  const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
+  const [isArchiveMutationPending, setIsArchiveMutationPending] =
+    useState(false);
 
   const navigate = useNavigate();
 
   const product = row.original as Product;
 
-  const deleteRowItem = useDeleteProduct(product._id);
+  const archiveRowItem = useArchiveProduct(product._id);
 
-  const deleteItem = async () => {
+  const archiveItem = async () => {
     try {
-      setIsDeleteMutationPending(true);
-      await deleteRowItem();
+      setIsArchiveMutationPending(true);
+      await archiveRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -57,8 +58,8 @@ export function DataTableRowActions<TData>({
         description: (e as Error).message,
       });
     } finally {
-      setIsDeleteMutationPending(false);
-      setIsDeleteModalOpen(false);
+      setIsArchiveMutationPending(false);
+      setIsArchiveModalOpen(false);
     }
   };
 
@@ -88,14 +89,14 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
-        isOpen={isDeleteModalOpen}
-        loading={isDeleteMutationPending}
+        title="Archive product?"
+        isOpen={isArchiveModalOpen}
+        loading={isArchiveMutationPending}
         onClose={() => {
-          setIsDeleteModalOpen(false);
+          setIsArchiveModalOpen(false);
         }}
         onConfirm={() => {
-          deleteItem();
+          archiveItem();
         }}
       />
       <DropdownMenu>
@@ -125,8 +126,8 @@ export function DataTableRowActions<TData>({
             Edit
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+          <DropdownMenuItem onClick={() => setIsArchiveModalOpen(true)}>
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/components/product-actions.tsx
+++ b/packages/athena-webapp/src/components/product-actions.tsx
@@ -1,13 +1,15 @@
-import { useAction } from "convex/react";
+import { useMutation } from "convex/react";
 import useGetActiveStore from "../hooks/useGetActiveStore";
 import { api } from "~/convex/_generated/api";
 import { Id } from "~/convex/_generated/dataModel";
 
-export const useDeleteProduct = (productId: Id<"product">) => {
-  const deleteProduct = useAction(api.inventory.products.clear);
+export const useArchiveProduct = (productId: Id<"product">) => {
+  const archiveProduct = useMutation(api.inventory.products.archive);
   const { activeStore } = useGetActiveStore();
 
   return async () => {
-    await deleteProduct({ id: productId, storeId: activeStore!._id });
+    await archiveProduct({ id: productId, storeId: activeStore!._id });
   };
 };
+
+export const useDeleteProduct = useArchiveProduct;

--- a/packages/athena-webapp/src/components/product/ProductStatus.test.tsx
+++ b/packages/athena-webapp/src/components/product/ProductStatus.test.tsx
@@ -58,4 +58,19 @@ describe("ProductStatus", () => {
 
     expect(screen.getByText("Live")).toBeInTheDocument();
   });
+
+  it("shows archived status before stock or visibility status", () => {
+    render(
+      <ProductStatus
+        product={makeProduct({
+          availability: "archived",
+          inventoryCount: 0,
+          isVisible: false,
+        })}
+        productVariant={makeVariant({ isVisible: false, stock: 0 })}
+      />,
+    );
+
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+  });
 });

--- a/packages/athena-webapp/src/components/product/ProductStatus.tsx
+++ b/packages/athena-webapp/src/components/product/ProductStatus.tsx
@@ -1,4 +1,4 @@
-import { AlertOctagonIcon, AlertTriangle, EyeOff } from "lucide-react";
+import { AlertOctagonIcon, AlertTriangle, Archive, EyeOff } from "lucide-react";
 import { Product } from "~/types";
 import { ProductVariant } from "../add-product/ProductStock";
 import { Badge } from "../ui/badge";
@@ -16,8 +16,16 @@ export const ProductStatus = ({
     product.isVisible !== false && productVariant?.isVisible !== false;
   const inventoryCount = productVariant?.stock ?? product.inventoryCount;
   const quantityAvailable = productVariant?.quantityAvailable ?? inventoryCount;
+  const isArchived = product.availability === "archived";
 
   const getBadgeStyles = () => {
+    if (isArchived) {
+      return {
+        bg: "bg-zinc-100 text-zinc-700",
+        text: "text-zinc-700",
+      };
+    }
+
     if (!isVisible) {
       return {
         bg: "bg-zinc-100 text-zinc-700",
@@ -51,6 +59,17 @@ export const ProductStatus = ({
   const { bg, text } = getBadgeStyles();
 
   const visibility = isVisible ? "Live" : "Hidden";
+
+  if (isArchived) {
+    return (
+      <Badge variant="outline" className={`${bg}`}>
+        <div className="flex items-center text-xs">
+          <Archive className="w-3.5 h-3.5 mr-2 text-zinc-700" />
+          <p className={text}>Archived</p>
+        </div>
+      </Badge>
+    );
+  }
 
   if (!isVisible) {
     return (

--- a/packages/athena-webapp/src/components/products/ArchivedProducts.tsx
+++ b/packages/athena-webapp/src/components/products/ArchivedProducts.tsx
@@ -1,0 +1,118 @@
+import { useMemo, useState } from "react";
+import { Link, useSearch } from "@tanstack/react-router";
+import { Archive, ArrowLeftIcon, CircleHelp, PackageOpen } from "lucide-react";
+import { useGetArchivedProducts } from "~/src/hooks/useGetProducts";
+import { useNavigateBack } from "~/src/hooks/use-navigate-back";
+import { getOrigin } from "~/src/lib/navigationUtils";
+import View from "../View";
+import { FadeIn } from "../common/FadeIn";
+import { GenericDataTable } from "../base/table/data-table";
+import { productColumns } from "./products-table/components/productColumns";
+import { EmptyState } from "../states/empty/empty-state";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+const Navigation = () => {
+  const navigateBack = useNavigateBack();
+  const { o } = useSearch({ strict: false });
+
+  return (
+    <div className="container mx-auto flex gap-2">
+      <div className="flex items-center gap-2">
+        {o && (
+          <Button variant="ghost" onClick={navigateBack}>
+            <ArrowLeftIcon className="w-4 h-4" />
+          </Button>
+        )}
+        <p className="font-medium">Archived Products</p>
+        <Link
+          to={"/$orgUrlSlug/store/$storeUrlSlug/products"}
+          params={(prev) => ({
+            ...prev,
+            orgUrlSlug: prev.orgUrlSlug!,
+            storeUrlSlug: prev.storeUrlSlug!,
+          })}
+          search={{ o: getOrigin() }}
+        >
+          <Button variant="outline">Active products</Button>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export const ArchivedProducts = () => {
+  const products = useGetArchivedProducts();
+  const [searchValue, setSearchValue] = useState("");
+
+  const filteredProducts = useMemo(() => {
+    if (!products) return null;
+    if (!searchValue.trim()) return products;
+
+    const searchLower = searchValue.toLowerCase();
+    return products.filter((product) => {
+      const productName = product.name.toLowerCase();
+      if (productName.includes(searchLower)) {
+        return true;
+      }
+
+      return product.skus.some((sku) =>
+        sku.sku?.toLowerCase().includes(searchLower),
+      );
+    });
+  }, [products, searchValue]);
+
+  if (!products) return null;
+
+  const hasSearchInput = searchValue.trim().length > 0;
+
+  const EmptyStateIcon = hasSearchInput ? (
+    <CircleHelp className="w-16 h-16 text-muted-foreground" />
+  ) : (
+    <PackageOpen className="w-16 h-16 text-muted-foreground" />
+  );
+
+  return (
+    <View
+      hideBorder
+      hideHeaderBottomBorder
+      className="bg-background"
+      header={<Navigation />}
+    >
+      <FadeIn className="py-8 space-y-4">
+        <div className="flex items-center gap-3">
+          <Archive className="h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter by name or SKU..."
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            className="w-[320px]"
+          />
+        </div>
+        {filteredProducts && filteredProducts.length > 0 && (
+          <GenericDataTable
+            data={filteredProducts}
+            columns={productColumns}
+            tableId="archived-products"
+          />
+        )}
+        {filteredProducts && filteredProducts.length == 0 && (
+          <div className="flex items-center justify-center min-h-[60vh] w-full">
+            <EmptyState
+              icon={EmptyStateIcon}
+              title={
+                <div className="flex gap-1 text-sm">
+                  <p className="text-muted-foreground">
+                    {hasSearchInput
+                      ? "No archived products match your search"
+                      : "No archived products"}
+                  </p>
+                </div>
+              }
+            />
+          </div>
+        )}
+      </FadeIn>
+    </View>
+  );
+};

--- a/packages/athena-webapp/src/components/products/Products.tsx
+++ b/packages/athena-webapp/src/components/products/Products.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { useGetCategories } from "~/src/hooks/useGetCategories";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { Button } from "../ui/button";
-import { PlusIcon, PackageXIcon } from "lucide-react";
+import { ArchiveIcon, PlusIcon, PackageXIcon } from "lucide-react";
 import {
   useGetUnresolvedProducts,
   useGetProducts,
@@ -96,6 +96,24 @@ export default function Products() {
                 </Button>
               </Link>
             ))}
+          </div>
+
+          <div>
+            <Link
+              to={"/$orgUrlSlug/store/$storeUrlSlug/products/archived"}
+              params={(prev) => ({
+                ...prev,
+                orgUrlSlug: prev.orgUrlSlug!,
+                storeUrlSlug: prev.storeUrlSlug!,
+              })}
+              search={{ o: getOrigin() }}
+              className="inline-flex"
+            >
+              <Button variant="outline">
+                <ArchiveIcon className="w-4 h-4" />
+                <p className="text-md">Archived products</p>
+              </Button>
+            </Link>
           </div>
 
           {Boolean(unresolvedProducts?.length) && (

--- a/packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 import { Ban } from "lucide-react";
 import { useState } from "react";
 import { AlertModal } from "@/components/ui/modals/alert-modal";
-import { useDeleteProduct } from "../../../product-actions";
+import { useArchiveProduct } from "../../../product-actions";
 import { Product } from "~/types";
 
 interface DataTableRowActionsProps<TData> {
@@ -25,21 +25,22 @@ interface DataTableRowActionsProps<TData> {
 export function DataTableRowActions<TData>({
   row,
 }: DataTableRowActionsProps<TData>) {
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [isDeleteMutationPending, setIsDeleteMutationPending] = useState(false);
+  const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
+  const [isArchiveMutationPending, setIsArchiveMutationPending] =
+    useState(false);
 
   const navigate = useNavigate();
 
   const product = row.original as Product;
 
-  const deleteRowItem = useDeleteProduct(product._id);
+  const archiveRowItem = useArchiveProduct(product._id);
 
-  const deleteItem = async () => {
+  const archiveItem = async () => {
     try {
-      setIsDeleteMutationPending(true);
-      await deleteRowItem();
+      setIsArchiveMutationPending(true);
+      await archiveRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -57,8 +58,8 @@ export function DataTableRowActions<TData>({
         description: (e as Error).message,
       });
     } finally {
-      setIsDeleteMutationPending(false);
-      setIsDeleteModalOpen(false);
+      setIsArchiveMutationPending(false);
+      setIsArchiveModalOpen(false);
     }
   };
 
@@ -88,14 +89,14 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
-        isOpen={isDeleteModalOpen}
-        loading={isDeleteMutationPending}
+        title="Archive product?"
+        isOpen={isArchiveModalOpen}
+        loading={isArchiveMutationPending}
         onClose={() => {
-          setIsDeleteModalOpen(false);
+          setIsArchiveModalOpen(false);
         }}
         onConfirm={() => {
-          deleteItem();
+          archiveItem();
         }}
       />
       <DropdownMenu>
@@ -125,8 +126,8 @@ export function DataTableRowActions<TData>({
             Edit
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+          <DropdownMenuItem onClick={() => setIsArchiveModalOpen(true)}>
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx
@@ -40,7 +40,7 @@ export function DataTableRowActions<TData>({
       setIsDeleteMutationPending(true);
       await deleteRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -88,7 +88,7 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
+        title="Archive product?"
         isOpen={isDeleteModalOpen}
         loading={isDeleteMutationPending}
         onClose={() => {
@@ -126,7 +126,7 @@ export function DataTableRowActions<TData>({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx
+++ b/packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx
@@ -39,7 +39,7 @@ export function DataTableRowActions<TData>({
       setIsDeleteMutationPending(true);
       await deleteRowItem();
 
-      toast(`Product '${product.name}' deleted`, {
+      toast(`Product '${product.name}' archived`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
@@ -88,7 +88,7 @@ export function DataTableRowActions<TData>({
   return (
     <>
       <AlertModal
-        title="Delete product?"
+        title="Archive product?"
         isOpen={isDeleteModalOpen}
         loading={isDeleteMutationPending}
         onClose={() => {
@@ -126,7 +126,7 @@ export function DataTableRowActions<TData>({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setIsDeleteModalOpen(true)}>
-            Delete
+            Archive
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/athena-webapp/src/hooks/useGetProducts.ts
+++ b/packages/athena-webapp/src/hooks/useGetProducts.ts
@@ -2,12 +2,16 @@ import { useQuery } from "convex/react";
 import useGetActiveStore from "./useGetActiveStore";
 import { api } from "~/convex/_generated/api";
 
+type ProductAvailability = "archived" | "draft" | "live";
+
 export const useGetProducts = ({
   subcategorySlug,
   categorySlug,
+  availability,
 }: {
   subcategorySlug?: string;
   categorySlug?: string;
+  availability?: ProductAvailability;
 } = {}) => {
   const { activeStore } = useGetActiveStore();
 
@@ -18,6 +22,7 @@ export const useGetProducts = ({
           storeId: activeStore._id,
           subcategory: subcategorySlug ? [subcategorySlug] : undefined,
           category: categorySlug ? [categorySlug] : undefined,
+          availability,
           filters: {
             isPriceZero: true,
           },
@@ -26,6 +31,10 @@ export const useGetProducts = ({
   );
 
   return products?.sort((a: any, b: any) => a.name.localeCompare(b.name));
+};
+
+export const useGetArchivedProducts = () => {
+  return useGetProducts({ availability: "archived" });
 };
 
 export const useGetUnresolvedProducts = () => {

--- a/packages/athena-webapp/src/routeTree.gen.ts
+++ b/packages/athena-webapp/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesNewRouteImport } fr
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesPromoCodeSlugRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new'
+import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugOperationsApprovalsRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/approvals'
@@ -281,6 +282,12 @@ const AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute =
     path: '/$orgUrlSlug/store/$storeUrlSlug/products/new',
     getParentRoute: () => AuthedRoute,
   } as any)
+const AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute =
+  AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRouteImport.update({
+    id: '/$orgUrlSlug/store/$storeUrlSlug/products/archived',
+    path: '/$orgUrlSlug/store/$storeUrlSlug/products/archived',
+    getParentRoute: () => AuthedRoute,
+  } as any)
 const AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute =
   AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRouteImport.update(
     {
@@ -510,6 +517,7 @@ export interface FileRoutesByFullPath {
   '/$orgUrlSlug/store/$storeUrlSlug/operations/approvals': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsApprovalsRoute
   '/$orgUrlSlug/store/$storeUrlSlug/operations/open-work': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRoute
   '/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute
+  '/$orgUrlSlug/store/$storeUrlSlug/products/archived': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute
   '/$orgUrlSlug/store/$storeUrlSlug/products/new': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute
   '/$orgUrlSlug/store/$storeUrlSlug/products/unresolved': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRoute
   '/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug': typeof AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesPromoCodeSlugRoute
@@ -578,6 +586,7 @@ export interface FileRoutesByTo {
   '/$orgUrlSlug/store/$storeUrlSlug/operations/approvals': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsApprovalsRoute
   '/$orgUrlSlug/store/$storeUrlSlug/operations/open-work': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRoute
   '/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute
+  '/$orgUrlSlug/store/$storeUrlSlug/products/archived': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute
   '/$orgUrlSlug/store/$storeUrlSlug/products/new': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute
   '/$orgUrlSlug/store/$storeUrlSlug/products/unresolved': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRoute
   '/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug': typeof AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesPromoCodeSlugRoute
@@ -649,6 +658,7 @@ export interface FileRoutesById {
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/approvals': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsApprovalsRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments': typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute
+  '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved': typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug': typeof AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesPromoCodeSlugRoute
@@ -720,6 +730,7 @@ export interface FileRouteTypes {
     | '/$orgUrlSlug/store/$storeUrlSlug/operations/approvals'
     | '/$orgUrlSlug/store/$storeUrlSlug/operations/open-work'
     | '/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments'
+    | '/$orgUrlSlug/store/$storeUrlSlug/products/archived'
     | '/$orgUrlSlug/store/$storeUrlSlug/products/new'
     | '/$orgUrlSlug/store/$storeUrlSlug/products/unresolved'
     | '/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug'
@@ -788,6 +799,7 @@ export interface FileRouteTypes {
     | '/$orgUrlSlug/store/$storeUrlSlug/operations/approvals'
     | '/$orgUrlSlug/store/$storeUrlSlug/operations/open-work'
     | '/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments'
+    | '/$orgUrlSlug/store/$storeUrlSlug/products/archived'
     | '/$orgUrlSlug/store/$storeUrlSlug/products/new'
     | '/$orgUrlSlug/store/$storeUrlSlug/products/unresolved'
     | '/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug'
@@ -858,6 +870,7 @@ export interface FileRouteTypes {
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/approvals'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments'
+    | '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug'
@@ -1164,6 +1177,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived': {
+      id: '/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived'
+      path: '/$orgUrlSlug/store/$storeUrlSlug/products/archived'
+      fullPath: '/$orgUrlSlug/store/$storeUrlSlug/products/archived'
+      preLoaderRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments': {
       id: '/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments'
       path: '/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments'
@@ -1412,6 +1432,7 @@ interface AuthedRouteChildren {
   AuthedOrgUrlSlugStoreStoreUrlSlugOperationsApprovalsRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsApprovalsRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute
+  AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesPromoCodeSlugRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugPromoCodesPromoCodeSlugRoute
@@ -1488,6 +1509,8 @@ const AuthedRouteChildren: AuthedRouteChildren = {
     AuthedOrgUrlSlugStoreStoreUrlSlugOperationsOpenWorkRoute,
   AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute:
     AuthedOrgUrlSlugStoreStoreUrlSlugOperationsStockAdjustmentsRoute,
+  AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute:
+    AuthedOrgUrlSlugStoreStoreUrlSlugProductsArchivedRoute,
   AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute:
     AuthedOrgUrlSlugStoreStoreUrlSlugProductsNewRoute,
   AuthedOrgUrlSlugStoreStoreUrlSlugProductsUnresolvedRoute:

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ArchivedProducts } from "~/src/components/products/ArchivedProducts";
+
+export const Route = createFileRoute(
+  "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived",
+)({
+  component: ArchivedProducts,
+});


### PR DESCRIPTION
## Summary
- Changes product deletion flows to archive products by setting `availability: "archived"` instead of deleting product records.
- Hides archived products from active catalog reads, storefront public product/detail/best-seller paths, POS catalog/search, and stock adjustment/product lookup surfaces.
- Adds an authenticated archived products route under Products with archive status presentation and active/archived query hooks.
- Hardens direct backend paths: archive requires store full-admin access, public destructive product delete is no longer exported, old clear/delete is internal-only, and checkout rejects archived products from stale or crafted sessions.

## Linear
- V26-479: Archive products instead of deleting catalog records
- V26-480: Hide archived products from active catalog surfaces
- V26-481: Add archived products route under Products

## Validation
- `bun run --filter '@athena/webapp' test -- convex/inventory/products.sku.test.ts convex/inventory/bestSeller.test.ts convex/inventory/productUtil.test.ts convex/pos/application/queries/listRegisterCatalog.test.ts convex/storeFront/commerceQueryIndexes.test.ts src/components/product/ProductStatus.test.tsx src/routeTree.browser-boundary.test.ts`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run --filter '@athena/webapp' lint`
- `bun --cwd packages/athena-webapp vite build`
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' test`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `bun run pre-commit:generated-artifacts`
- `bun run harness:review`
- `git push` pre-push review suite
