### PR TITLE
Make preview handoff optional

### DIFF
--- a/.agents/skills/compound-delivery-kernel/SKILL.md
+++ b/.agents/skills/compound-delivery-kernel/SKILL.md
@@ -128,7 +128,7 @@ Every delivery handoff should include:
 
 - what changed
 - validation evidence from repo sensors
-- for web app or app-surface changes, a browser preview URL from `scripts/preview-worktree.ts start athena`; if no preview is available, state the exact blocker instead of omitting it
+- for web app or app-surface changes, include a browser preview URL only when a preview was already started for inspection or explicitly requested; preview startup is optional and is not a handoff requirement
 - post-merge production deploy command and result when local CD applies, or the explicit reason it did not run
 - review status and remaining risk
 - compounding decision: documented, skill updated, follow-up filed, or no durable learning

--- a/.agents/skills/deliver-work/SKILL.md
+++ b/.agents/skills/deliver-work/SKILL.md
@@ -38,7 +38,7 @@ When none of those routes is a better fit, continue here.
 5. Run the narrowest relevant sensor after each meaningful slice, then the broader merge-level sensor set before handoff.
 6. Review the diff against acceptance criteria, tests, repo sensors, and project standards. Use specialized review skills or agents when risk warrants it.
 7. Apply the kernel's proactive-ticket policy for evidence-backed follow-up work. Do not expand current scope silently.
-8. For web app or app-surface changes, start or reuse a local browser preview with `scripts/preview-worktree.ts start athena` before handoff.
+8. For web app or app-surface changes, use `scripts/preview-worktree.ts start athena` only when a browser preview is useful for inspection or explicitly requested. A preview URL is not required for handoff.
 9. Make the compound decision before final handoff: solution doc, skill update, follow-up ticket, missing sensor request, or no durable learning.
 
 ## Handoff
@@ -47,7 +47,7 @@ Report:
 
 - what changed
 - tests and repo sensors run
-- browser preview URL for app-surface changes, or the exact blocker if `scripts/preview-worktree.ts start athena` could not provide one
+- browser preview URL only when one was started for inspection or explicitly requested
 - review result and residual risk
 - proactive tickets created or deferred
 - compounding decision

--- a/.agents/skills/execute/SKILL.md
+++ b/.agents/skills/execute/SKILL.md
@@ -31,7 +31,7 @@ Do not use this skill when:
 - Delivery always includes remote merge and local fast-forward unless the user explicitly opts out, asks to rely on auto-merge, or permissions prevent it.
 - Delivery also means you leave the local repo tidy, back on `main`, and reflecting the merged remote state.
 - Do not stop at "PR open" or "ready for review" unless the user explicitly asked for that narrower handoff.
-- For Athena web app or app-surface changes, delivery handoff must include a browser preview URL from `scripts/preview-worktree.ts start athena`, or the exact blocker that prevented starting the preview.
+- For Athena web app or app-surface changes, a browser preview URL is optional. Include one only when a preview was already started for inspection or explicitly requested.
 - Only treat something as a blocker when it genuinely requires user input.
 - Document significant scope decisions in Linear as you work.
 
@@ -145,7 +145,7 @@ Use this resolution order before asking the user for context:
 
 - Run the smallest targeted test first, then the relevant suite, typecheck, build, lint, repo preflight, and `git diff --check`.
 - Match validation to the ticket's expected sensors and supplement with discovered repo sensors when the ticket is incomplete.
-- For Athena web app or app-surface changes, run `scripts/preview-worktree.ts start athena` after implementation validation so the final handoff can include a live local preview URL.
+- For Athena web app or app-surface changes, run `scripts/preview-worktree.ts start athena` after implementation validation only when browser inspection is useful or explicitly requested; final handoff does not require a live local preview URL.
 - If the repo defines a PR-equivalent command, run that before trusting local parity with remote CI.
 - If the repo has generated-artifact repair hooks, run them before the final commit and inspect the diff. For Athena, `bun run pre-commit:generated-artifacts` refreshes harness docs, Convex generated API files, graphify artifacts, and tracked generated changes so new Convex modules do not leave `_generated/api.d.ts` drift for a follow-up PR.
 - When harness or repo validation fails, first classify it as deterministic repairable drift or a semantic blocker.

--- a/scripts/preview-worktree.test.ts
+++ b/scripts/preview-worktree.test.ts
@@ -146,7 +146,7 @@ describe("preview-worktree", () => {
     await stopPreview(previewOptions(stateDir, worktreeOne));
   });
 
-  it("keeps repo-local delivery skills explicit about preview handoff", async () => {
+  it("keeps repo-local delivery skills from requiring preview handoff", async () => {
     const deliverWork = await readFile(
       path.join(import.meta.dirname, "../.agents/skills/deliver-work/SKILL.md"),
       "utf8"
@@ -161,8 +161,10 @@ describe("preview-worktree", () => {
     );
 
     for (const skill of [deliverWork, execute, kernel]) {
-      expect(skill).toContain("browser preview URL");
-      expect(skill).toContain("scripts/preview-worktree.ts start athena");
+      expect(skill).toContain("preview");
+      expect(skill).toContain("not required");
+      expect(skill).not.toContain("handoff must include a browser preview URL");
+      expect(skill).not.toContain("a browser preview URL from `scripts/preview-worktree.ts start athena`; if no preview is available");
     }
   });
 


### PR DESCRIPTION
## Summary
- Make browser preview URLs optional in repo-local delivery handoffs
- Update deliver-work, execute, and compound-delivery-kernel workflow text so previews are only included when already started or explicitly requested
- Update the preview-worktree guard test to prevent required preview handoff language from returning

## Validation
- bun test scripts/preview-worktree.test.ts
- bun run graphify:check
- git push pre-push suite: graphify:check, harness:self-review, architecture:check, harness:review, coverage, harness:inferential-review