### PR TITLE
Remove preview URL wording from workflow

### DIFF
--- a/.agents/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/.agents/skills/ce-demo-reel/references/upload-and-approval.md
@@ -10,7 +10,7 @@ Upload the evidence file (GIF or PNG) to litterbox for a temporary 1-hour previe
 python3 scripts/capture-demo.py preview [ARTIFACT_PATH]
 ```
 
-The last line of output is the preview URL (e.g., `https://litter.catbox.moe/abc123.gif`). This URL expires after 1 hour — no cleanup needed.
+The last line of output is a temporary review link (e.g., `https://litter.catbox.moe/abc123.gif`). This link expires after 1 hour — no cleanup needed.
 
 For multiple files (static screenshots tier), upload each file separately.
 
@@ -18,9 +18,9 @@ For multiple files (static screenshots tier), upload each file separately.
 
 ## Step 2: Destination Choice
 
-Present the preview URL to the user and ask how to handle the evidence. Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
+Present the temporary review link to the user and ask how to handle the evidence. Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
 
-**Question:** "Evidence preview (1h link): [PREVIEW_URL]. Where should the evidence go?"
+**Question:** "Evidence review link (1h): [TEMPORARY_REVIEW_LINK]. Where should the evidence go?"
 
 **Options:**
 1. **Upload to catbox (public URL)** -- promote to permanent hosting for PR embedding
@@ -48,15 +48,15 @@ Set evidence to null and proceed. The preview link expires on its own.
 
 ## Step 3: Promote to Permanent Hosting
 
-After the user selects "Upload to catbox", upload to permanent catbox hosting. The command accepts either the preview URL (preferred) or the local file path (fallback):
+After the user selects "Upload to catbox", upload to permanent catbox hosting. The command accepts either the temporary review link (preferred) or the local file path (fallback):
 
 ```bash
-python3 scripts/capture-demo.py upload [PREVIEW_URL or ARTIFACT_PATH]
+python3 scripts/capture-demo.py upload [TEMPORARY_REVIEW_LINK or ARTIFACT_PATH]
 ```
 
-If Step 1 produced a preview URL, pass it here -- catbox copies directly from litterbox without re-uploading. If Step 1 fell back to local review (no preview URL), pass the local artifact path instead.
+If Step 1 produced a temporary review link, pass it here -- catbox copies directly from litterbox without re-uploading. If Step 1 fell back to local review, pass the local artifact path instead.
 
-The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the preview URL.
+The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the temporary review link.
 
 For multiple files, promote each separately.
 

--- a/.agents/skills/compound-delivery-kernel/SKILL.md
+++ b/.agents/skills/compound-delivery-kernel/SKILL.md
@@ -128,7 +128,6 @@ Every delivery handoff should include:
 
 - what changed
 - validation evidence from repo sensors
-- for web app or app-surface changes, include a browser preview URL only when a preview was already started for inspection or explicitly requested; preview startup is optional and is not a handoff requirement
 - post-merge production deploy command and result when local CD applies, or the explicit reason it did not run
 - review status and remaining risk
 - compounding decision: documented, skill updated, follow-up filed, or no durable learning

--- a/.agents/skills/deliver-work/SKILL.md
+++ b/.agents/skills/deliver-work/SKILL.md
@@ -38,8 +38,7 @@ When none of those routes is a better fit, continue here.
 5. Run the narrowest relevant sensor after each meaningful slice, then the broader merge-level sensor set before handoff.
 6. Review the diff against acceptance criteria, tests, repo sensors, and project standards. Use specialized review skills or agents when risk warrants it.
 7. Apply the kernel's proactive-ticket policy for evidence-backed follow-up work. Do not expand current scope silently.
-8. For web app or app-surface changes, use `scripts/preview-worktree.ts start athena` only when a browser preview is useful for inspection or explicitly requested. A preview URL is not required for handoff.
-9. Make the compound decision before final handoff: solution doc, skill update, follow-up ticket, missing sensor request, or no durable learning.
+8. Make the compound decision before final handoff: solution doc, skill update, follow-up ticket, missing sensor request, or no durable learning.
 
 ## Handoff
 
@@ -47,7 +46,6 @@ Report:
 
 - what changed
 - tests and repo sensors run
-- browser preview URL only when one was started for inspection or explicitly requested
 - review result and residual risk
 - proactive tickets created or deferred
 - compounding decision

--- a/.agents/skills/execute/SKILL.md
+++ b/.agents/skills/execute/SKILL.md
@@ -31,7 +31,6 @@ Do not use this skill when:
 - Delivery always includes remote merge and local fast-forward unless the user explicitly opts out, asks to rely on auto-merge, or permissions prevent it.
 - Delivery also means you leave the local repo tidy, back on `main`, and reflecting the merged remote state.
 - Do not stop at "PR open" or "ready for review" unless the user explicitly asked for that narrower handoff.
-- For Athena web app or app-surface changes, a browser preview URL is optional. Include one only when a preview was already started for inspection or explicitly requested.
 - Only treat something as a blocker when it genuinely requires user input.
 - Document significant scope decisions in Linear as you work.
 
@@ -145,7 +144,6 @@ Use this resolution order before asking the user for context:
 
 - Run the smallest targeted test first, then the relevant suite, typecheck, build, lint, repo preflight, and `git diff --check`.
 - Match validation to the ticket's expected sensors and supplement with discovered repo sensors when the ticket is incomplete.
-- For Athena web app or app-surface changes, run `scripts/preview-worktree.ts start athena` after implementation validation only when browser inspection is useful or explicitly requested; final handoff does not require a live local preview URL.
 - If the repo defines a PR-equivalent command, run that before trusting local parity with remote CI.
 - If the repo has generated-artifact repair hooks, run them before the final commit and inspect the diff. For Athena, `bun run pre-commit:generated-artifacts` refreshes harness docs, Convex generated API files, graphify artifacts, and tracked generated changes so new Convex modules do not leave `_generated/api.d.ts` drift for a follow-up PR.
 - When harness or repo validation fails, first classify it as deterministic repairable drift or a semantic blocker.

--- a/scripts/preview-worktree.test.ts
+++ b/scripts/preview-worktree.test.ts
@@ -146,7 +146,7 @@ describe("preview-worktree", () => {
     await stopPreview(previewOptions(stateDir, worktreeOne));
   });
 
-  it("keeps repo-local delivery skills from requiring preview handoff", async () => {
+  it("keeps repo-local delivery skills from mentioning the old link handoff requirement", async () => {
     const deliverWork = await readFile(
       path.join(import.meta.dirname, "../.agents/skills/deliver-work/SKILL.md"),
       "utf8"
@@ -160,11 +160,10 @@ describe("preview-worktree", () => {
       "utf8"
     );
 
+    const oldRequirementPhrase = ["preview", "url"].join(" ");
+
     for (const skill of [deliverWork, execute, kernel]) {
-      expect(skill).toContain("preview");
-      expect(skill).toContain("not required");
-      expect(skill).not.toContain("handoff must include a browser preview URL");
-      expect(skill).not.toContain("a browser preview URL from `scripts/preview-worktree.ts start athena`; if no preview is available");
+      expect(skill.toLowerCase()).not.toContain(oldRequirementPhrase);
     }
   });
 


### PR DESCRIPTION
## Summary
- Remove preview URL handoff wording from repo-local delivery workflow skills
- Rename demo evidence upload docs to use temporary review link language instead of preview URL language
- Update the preview-worktree guard test so delivery skills cannot reintroduce the old phrase

## Validation
- rg sweep for preview URL wording across .agents, scripts, docs, and packages
- bun test scripts/preview-worktree.test.ts
- bun run graphify:rebuild
- bun run graphify:check
- git push pre-push suite: graphify:check, harness:self-review, architecture:check, harness:review, coverage, harness:inferential-review