### PR TITLE
Normalize product SKU visibility

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -10955,7 +10955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L110",
+      "source_location": "L112",
       "target": "products_sku_test_createproductsqueryctx",
       "weight": 1
     },
@@ -10967,7 +10967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L22",
+      "source_location": "L23",
       "target": "products_sku_test_createskumutationctx",
       "weight": 1
     },
@@ -10979,7 +10979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L18",
+      "source_location": "L19",
       "target": "products_sku_test_gethandler",
       "weight": 1
     },
@@ -20363,7 +20363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_add_product_productview_tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L372",
+      "source_location": "L373",
       "target": "productview_handlekeydown",
       "weight": 1
     },
@@ -20387,7 +20387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_add_product_productview_tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L361",
+      "source_location": "L362",
       "target": "productview_onsubmit",
       "weight": 1
     },
@@ -20411,7 +20411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_add_product_productview_tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L423",
+      "source_location": "L424",
       "target": "productview_updateproductvisibility",
       "weight": 1
     },
@@ -20423,7 +20423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_add_product_productview_tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L294",
+      "source_location": "L295",
       "target": "productview_updatevariantsku",
       "weight": 1
     },
@@ -39203,7 +39203,7 @@
       "relation": "calls",
       "source": "products_sku_test_createskumutationctx",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L111",
+      "source_location": "L113",
       "target": "products_sku_test_createproductsqueryctx",
       "weight": 1
     },
@@ -39227,7 +39227,7 @@
       "relation": "calls",
       "source": "productview_modifyproduct",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L362",
+      "source_location": "L363",
       "target": "productview_onsubmit",
       "weight": 1
     },
@@ -39239,7 +39239,7 @@
       "relation": "calls",
       "source": "productview_saveproduct",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L363",
+      "source_location": "L364",
       "target": "productview_onsubmit",
       "weight": 1
     },
@@ -64465,7 +64465,7 @@
       "label": "createProductsQueryCtx()",
       "norm_label": "createproductsqueryctx()",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L110"
+      "source_location": "L112"
     },
     {
       "community": 230,
@@ -64474,7 +64474,7 @@
       "label": "createSkuMutationCtx()",
       "norm_label": "createskumutationctx()",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L22"
+      "source_location": "L23"
     },
     {
       "community": 230,
@@ -64483,7 +64483,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L18"
+      "source_location": "L19"
     },
     {
       "community": 231,
@@ -83536,7 +83536,7 @@
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L372"
+      "source_location": "L373"
     },
     {
       "community": 74,
@@ -83554,7 +83554,7 @@
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L361"
+      "source_location": "L362"
     },
     {
       "community": 74,
@@ -83572,7 +83572,7 @@
       "label": "updateProductVisibility()",
       "norm_label": "updateproductvisibility()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L423"
+      "source_location": "L424"
     },
     {
       "community": 74,
@@ -83581,7 +83581,7 @@
       "label": "updateVariantSku()",
       "norm_label": "updatevariantsku()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L294"
+      "source_location": "L295"
     },
     {
       "community": 740,

--- a/packages/athena-webapp/convex/inventory/productSku.ts
+++ b/packages/athena-webapp/convex/inventory/productSku.ts
@@ -194,3 +194,42 @@ export const makeAllProductsVisible = mutation({
     return { success: true, updatedCount: productSkus.length };
   },
 });
+
+export const backfillUndefinedSkuVisibilityFromProducts = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const productSkus = await ctx.db.query("productSku").collect();
+    let updatedCount = 0;
+    let skippedMissingProductCount = 0;
+    let skippedParentWithoutVisibilityCount = 0;
+
+    for (const sku of productSkus) {
+      if (sku.isVisible !== undefined) continue;
+
+      const product = await ctx.db.get("product", sku.productId);
+
+      if (!product) {
+        skippedMissingProductCount += 1;
+        continue;
+      }
+
+      if (typeof product.isVisible !== "boolean") {
+        skippedParentWithoutVisibilityCount += 1;
+        continue;
+      }
+
+      await ctx.db.patch("productSku", sku._id, {
+        isVisible: product.isVisible,
+      });
+      updatedCount += 1;
+    }
+
+    return {
+      success: true,
+      scannedCount: productSkus.length,
+      updatedCount,
+      skippedMissingProductCount,
+      skippedParentWithoutVisibilityCount,
+    };
+  },
+});

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { backfillUndefinedSkuVisibilityFromProducts } from "./productSku";
 import { archive, createSku, getAll, updateSku } from "./products";
 
 const mocks = vi.hoisted(() => ({
@@ -73,6 +74,7 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
       },
       query(table: TableName) {
         return {
+          collect: async () => Array.from(tables[table].values()),
           filter() {
             return createIndexedQuery(
               table,
@@ -321,5 +323,76 @@ describe("product catalog visibility", () => {
     expect(archivedProducts.map((product: Row) => product._id)).toEqual([
       "product-archived",
     ]);
+  });
+});
+
+describe("product SKU visibility backfill", () => {
+  it("patches only undefined SKU visibility from the parent product visibility", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      product: [
+        {
+          _id: "product-visible",
+          isVisible: true,
+        },
+        {
+          _id: "product-hidden",
+          isVisible: false,
+        },
+        {
+          _id: "product-unknown",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-visible-parent",
+          productId: "product-visible",
+        },
+        {
+          _id: "sku-hidden-parent",
+          productId: "product-hidden",
+        },
+        {
+          _id: "sku-already-visible",
+          isVisible: true,
+          productId: "product-hidden",
+        },
+        {
+          _id: "sku-missing-product",
+          productId: "product-missing",
+        },
+        {
+          _id: "sku-parent-without-visibility",
+          productId: "product-unknown",
+        },
+      ],
+    });
+
+    const result = await getHandler(backfillUndefinedSkuVisibilityFromProducts)(
+      ctx,
+      {},
+    );
+
+    expect(result).toEqual({
+      success: true,
+      scannedCount: 5,
+      updatedCount: 2,
+      skippedMissingProductCount: 1,
+      skippedParentWithoutVisibilityCount: 1,
+    });
+    expect(tables.productSku.get("sku-visible-parent")).toMatchObject({
+      isVisible: true,
+    });
+    expect(tables.productSku.get("sku-hidden-parent")).toMatchObject({
+      isVisible: false,
+    });
+    expect(tables.productSku.get("sku-already-visible")).toMatchObject({
+      isVisible: true,
+    });
+    expect(tables.productSku.get("sku-missing-product")).not.toHaveProperty(
+      "isVisible",
+    );
+    expect(
+      tables.productSku.get("sku-parent-without-visibility"),
+    ).not.toHaveProperty("isVisible");
   });
 });

--- a/packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts
@@ -143,4 +143,12 @@ describe("commerce query indexing", () => {
       "Some items in your bag are no longer available",
     );
   });
+
+  it("only returns live products from viewed-product upsells", () => {
+    const userSource = getSource("./user.ts");
+
+    expect(
+      userSource.match(/product\?\.availability !== "live"/g) ?? [],
+    ).toHaveLength(3);
+  });
 });

--- a/packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts
+++ b/packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts
@@ -118,7 +118,7 @@ describe("V26-169 time/query refactors", () => {
       userSource.match(
         /\.filter\(\(q\) => q\.neq\(q\.field\("origin"\), SYNTHETIC_MONITOR_ORIGIN\)\)/g
       )
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(
       userSource.match(
         /SYNTHETIC_MONITOR_ORIGIN/g

--- a/packages/athena-webapp/convex/storeFront/user.ts
+++ b/packages/athena-webapp/convex/storeFront/user.ts
@@ -15,12 +15,12 @@ const entity = "storeFrontUser";
 
 async function getStoreFrontActorById(
   ctx: QueryCtx,
-  id: Id<"storeFrontUser"> | Id<"guest">
+  id: Id<"storeFrontUser"> | Id<"guest">,
 ) {
   try {
     const storeFrontUser = await ctx.db.get(
       "storeFrontUser",
-      id as Id<"storeFrontUser">
+      id as Id<"storeFrontUser">,
     );
 
     if (storeFrontUser) {
@@ -123,7 +123,10 @@ export const findLinkedAccounts = query({
     const storeFrontUsers = await ctx.db
       .query("storeFrontUser")
       .filter((q) =>
-        q.and(q.eq(q.field("email"), email), q.neq(q.field("_id"), args.userId))
+        q.and(
+          q.eq(q.field("email"), email),
+          q.neq(q.field("_id"), args.userId),
+        ),
       )
       .collect();
 
@@ -149,7 +152,7 @@ export const getAllUserActivity = query({
     const analytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
       .filter((q) => q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN))
       .collect();
@@ -170,7 +173,10 @@ export const getAllUserActivity = query({
     for (const id of idArray) {
       try {
         // Try to get from storeFrontUser table
-        const user = await ctx.db.get("storeFrontUser", id as Id<"storeFrontUser">);
+        const user = await ctx.db.get(
+          "storeFrontUser",
+          id as Id<"storeFrontUser">,
+        );
         if (user) {
           userMap[id] = { email: user.email };
           continue; // Found in storeFrontUser table, skip to next ID
@@ -209,7 +215,7 @@ export const getAllUserActivityInternal = internalQuery({
     const analytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
       .filter((q) => q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN))
       .collect();
@@ -224,7 +230,10 @@ export const getAllUserActivityInternal = internalQuery({
 
     for (const id of idArray) {
       try {
-        const user = await ctx.db.get("storeFrontUser", id as Id<"storeFrontUser">);
+        const user = await ctx.db.get(
+          "storeFrontUser",
+          id as Id<"storeFrontUser">,
+        );
         if (user) {
           userMap[id] = { email: user.email };
           continue;
@@ -262,21 +271,25 @@ export const getLastViewedProduct = query({
     const isSkuAvailable = async (
       productId: Id<"product">,
       storeId: Id<"store">,
-      skuToCheck: string
+      skuToCheck: string,
     ) => {
       const product: any = await ctx.runQuery(
         internal.inventory.products.getByIdInternal,
         {
           id: productId,
           storeId,
-        }
+        },
       );
+
+      if (product?.availability !== "live") {
+        return null;
+      }
 
       return product?.skus?.find(
         (sku: any) =>
           sku.sku === skuToCheck &&
           (!args.category || sku.productCategory === args.category) &&
-          sku.quantityAvailable > 0
+          sku.quantityAvailable > 0,
       );
     };
 
@@ -284,14 +297,14 @@ export const getLastViewedProduct = query({
     const analytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
       .filter((q) =>
         q.and(
           q.eq(q.field("action"), "viewed_product"),
           q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN),
-          q.lte(q.field("_creationTime"), cutoff)
-        )
+          q.lte(q.field("_creationTime"), cutoff),
+        ),
       )
       .order("desc")
       .take(100);
@@ -306,7 +319,7 @@ export const getLastViewedProduct = query({
         .filter((q) => q.eq(q.field("storeFrontUserId"), args.id))
         .collect()
         .then((items) =>
-          items.filter((item) => productSkus.includes(item.productSku))
+          items.filter((item) => productSkus.includes(item.productSku)),
         );
 
       // Create a Set of SKUs that are in the bag for faster lookup
@@ -321,19 +334,19 @@ export const getLastViewedProduct = query({
         const availableSku = await isSkuAvailable(
           analytic.data.product,
           analytic.storeId,
-          analytic.data.productSku
+          analytic.data.productSku,
         );
 
         if (availableSku) {
           console.log(
-            `Found available upsell product for user ${args.id}: ${availableSku.sku}`
+            `Found available upsell product for user ${args.id}: ${availableSku.sku}`,
           );
           return availableSku;
         }
       }
 
       console.log(
-        `No available products found in recent views for user ${args.id}`
+        `No available products found in recent views for user ${args.id}`,
       );
       return null;
     }
@@ -342,14 +355,14 @@ export const getLastViewedProduct = query({
     const allTimeAnalytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
       .filter((q) =>
         q.and(
           q.eq(q.field("action"), "viewed_product"),
           q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN),
-          q.lte(q.field("_creationTime"), cutoff)
-        )
+          q.lte(q.field("_creationTime"), cutoff),
+        ),
       )
       .order("desc")
       .take(200); // check up to 20 most recent all-time views
@@ -357,7 +370,7 @@ export const getLastViewedProduct = query({
     if (allTimeAnalytics.length) {
       // Get all the product SKUs from analytics
       const productSkus = allTimeAnalytics.map(
-        (analytic) => analytic.data.productSku
+        (analytic) => analytic.data.productSku,
       );
 
       // Find all bag items for these SKUs
@@ -366,7 +379,7 @@ export const getLastViewedProduct = query({
         .filter((q) => q.eq(q.field("storeFrontUserId"), args.id))
         .collect()
         .then((items) =>
-          items.filter((item) => productSkus.includes(item.productSku))
+          items.filter((item) => productSkus.includes(item.productSku)),
         );
 
       // Create a Set of SKUs that are in the bag for faster lookup
@@ -379,12 +392,12 @@ export const getLastViewedProduct = query({
         const availableSku = await isSkuAvailable(
           analytic.data.product,
           analytic.storeId,
-          analytic.data.productSku
+          analytic.data.productSku,
         );
 
         if (availableSku) {
           console.log(
-            `Found available upsell product for user ${args.id}: ${availableSku.sku}`
+            `Found available upsell product for user ${args.id}: ${availableSku.sku}`,
           );
           return availableSku;
         }
@@ -410,21 +423,25 @@ export const getLastViewedProducts = query({
     const isSkuAvailable = async (
       productId: Id<"product">,
       storeId: Id<"store">,
-      skuToCheck: string
+      skuToCheck: string,
     ) => {
       const product: any = await ctx.runQuery(
         internal.inventory.products.getByIdInternal,
         {
           id: productId,
           storeId,
-        }
+        },
       );
+
+      if (product?.availability !== "live") {
+        return null;
+      }
 
       return product?.skus?.find(
         (sku: any) =>
           sku.sku === skuToCheck &&
           (!args.category || sku.productCategory === args.category) &&
-          sku.quantityAvailable > 0
+          sku.quantityAvailable > 0,
       );
     };
 
@@ -432,13 +449,13 @@ export const getLastViewedProducts = query({
     const analytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
       .filter((q) =>
         q.and(
           q.eq(q.field("action"), "viewed_product"),
-          q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN)
-        )
+          q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN),
+        ),
       )
       .order("desc")
       .take(200); // Increased limit to get more products
@@ -464,14 +481,14 @@ export const getLastViewedProducts = query({
         const availableSku = await isSkuAvailable(
           analytic.data.product,
           analytic.storeId,
-          analytic.data.productSku
+          analytic.data.productSku,
         );
 
         if (availableSku) {
           availableProducts.push(availableSku);
           addedSkus.add(analytic.data.productSku);
           console.log(
-            `Found available product ${availableProducts.length}/${args.limit} for user ${args.id}: ${availableSku.sku}`
+            `Found available product ${availableProducts.length}/${args.limit} for user ${args.id}: ${availableSku.sku}`,
           );
         }
       }
@@ -482,20 +499,20 @@ export const getLastViewedProducts = query({
       const allTimeAnalytics = await ctx.db
         .query("analytics")
         .withIndex("by_storeFrontUserId", (q) =>
-          q.eq("storeFrontUserId", args.id)
+          q.eq("storeFrontUserId", args.id),
         )
         .filter((q) =>
           q.and(
             q.eq(q.field("action"), "viewed_product"),
-            q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN)
-          )
+            q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN),
+          ),
         )
         .order("desc")
         .take(500); // Check more all-time views
 
       if (allTimeAnalytics.length) {
         const addedSkus = new Set(
-          availableProducts.map((product) => product.sku)
+          availableProducts.map((product) => product.sku),
         );
 
         // Try each analytic in order until we reach the limit
@@ -512,14 +529,14 @@ export const getLastViewedProducts = query({
           const availableSku = await isSkuAvailable(
             analytic.data.product,
             analytic.storeId,
-            analytic.data.productSku
+            analytic.data.productSku,
           );
 
           if (availableSku) {
             availableProducts.push(availableSku);
             addedSkus.add(analytic.data.productSku);
             console.log(
-              `Found available product ${availableProducts.length}/${args.limit} for user ${args.id}: ${availableSku.sku}`
+              `Found available product ${availableProducts.length}/${args.limit} for user ${args.id}: ${availableSku.sku}`,
             );
           }
         }
@@ -527,7 +544,7 @@ export const getLastViewedProducts = query({
     }
 
     console.log(
-      `Found ${availableProducts.length} available products for user ${args.id}`
+      `Found ${availableProducts.length} available products for user ${args.id}`,
     );
     return availableProducts;
   },
@@ -546,34 +563,38 @@ export const getLastViewedProductsInternal = internalQuery({
     const isSkuAvailable = async (
       productId: Id<"product">,
       storeId: Id<"store">,
-      skuToCheck: string
+      skuToCheck: string,
     ) => {
       const product: any = await ctx.runQuery(
         internal.inventory.products.getByIdInternal,
         {
           id: productId,
           storeId,
-        }
+        },
       );
+
+      if (product?.availability !== "live") {
+        return null;
+      }
 
       return product?.skus?.find(
         (sku: any) =>
           sku.sku === skuToCheck &&
           (!args.category || sku.productCategory === args.category) &&
-          sku.quantityAvailable > 0
+          sku.quantityAvailable > 0,
       );
     };
 
     const analytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
       .filter((q) =>
         q.and(
           q.eq(q.field("action"), "viewed_product"),
-          q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN)
-        )
+          q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN),
+        ),
       )
       .order("desc")
       .take(200);
@@ -593,7 +614,7 @@ export const getLastViewedProductsInternal = internalQuery({
         const availableSku = await isSkuAvailable(
           analytic.data.product,
           analytic.storeId,
-          analytic.data.productSku
+          analytic.data.productSku,
         );
 
         if (availableSku) {
@@ -626,11 +647,9 @@ export const getMostRecentActivity = query({
     const analytics = await ctx.db
       .query("analytics")
       .withIndex("by_storeFrontUserId", (q) =>
-        q.eq("storeFrontUserId", args.id)
+        q.eq("storeFrontUserId", args.id),
       )
-      .filter((q) =>
-        q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN)
-      )
+      .filter((q) => q.neq(q.field("origin"), SYNTHETIC_MONITOR_ORIGIN))
       .order("desc") // Most recent first
       .first();
 

--- a/packages/athena-webapp/src/components/add-product/ProductView.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.tsx
@@ -287,6 +287,7 @@ function ProductViewContent() {
       weight: variant.weight,
       attributes: variant.attributes || {},
       storeId: activeStore!._id,
+      isVisible: variant.isVisible,
       images,
     });
   };


### PR DESCRIPTION
## Summary
- Add a product SKU visibility backfill mutation that copies parent product visibility onto SKUs where the SKU flag is undefined
- Persist SKU visibility during product creation so new SKUs do not rely on implicit visible defaults
- Prevent recently viewed upsells from returning products that are not live
- Refresh graphify output for the changed code graph

## Validation
- bun run --filter '@athena/webapp' test convex/storeFront/timeQueryRefactors.test.ts convex/storeFront/commerceQueryIndexes.test.ts convex/inventory/products.sku.test.ts
- bun run --filter '@athena/webapp' typecheck
- bun run graphify:check
- git push pre-push suite: graphify:check, harness:self-review, architecture:check, @athena/webapp tests, Convex audit/lint, selected runtime behavior scenarios, inferential review