### PR TITLE
Refine procurement workspace navigation

### DIFF
--- a/docs/solutions/logic-errors/athena-procurement-stock-continuity-2026-05-05.md
+++ b/docs/solutions/logic-errors/athena-procurement-stock-continuity-2026-05-05.md
@@ -72,6 +72,24 @@ as the row being received and open a compact receiving panel in the rail. After 
 successful receipt, close that panel instead of leaving an empty 0-unit workflow
 behind. This keeps the workspace focused on the remaining stock-continuity work.
 
+Parent navigation should land on the first useful child surface. If the sidebar
+shows a grouped area like Products, Orders, or Operations, clicking the parent
+should still navigate to the canonical route for that work area instead of only
+toggling disclosure. Disclosure can remain available, but the parent label must
+not become a dead end.
+
+Keep tab state in a domain-specific search parameter. Procurement uses
+`procurementMode`; stock adjustments use `mode` for cycle count/manual
+adjustment. Reusing a generic search key across sibling workspaces can make
+TanStack Router validate one workspace's tab as another workspace's enum and
+break navigation.
+
+Paginate long stock-pressure lists, but preserve workflow jumps. The visible
+rows can be limited to ten at a time, while counts still reflect the full
+filtered tab. When a right-rail purchase-order summary navigates to a row, first
+move to the tab and page containing that row, then perform the row-target scroll.
+Direct row selection should not auto-scroll away from the operator's cursor.
+
 ## Why This Works
 
 Operators think in terms of stock risk: what is exposed, what is already being

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4477 nodes · 4271 edges · 1522 communities detected
+- 4487 nodes · 4286 edges · 1522 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1568,32 +1568,32 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 2 - "Community 2"
+Cohesion: 0.07
+Nodes (14): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), handleAdvancePurchaseOrderToOrdered(), handleCreateDraftPurchaseOrders(), handleModeChange() (+6 more)
+
+### Community 3 - "Community 3"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 3 - "Community 3"
+### Community 4 - "Community 4"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 4 - "Community 4"
+### Community 5 - "Community 5"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
 Cohesion: 0.1
 Nodes (17): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), handleAuthenticatedCloseoutStaff(), handleOpeningFloatApprovalApproved(), handleRecordDeposit() (+9 more)
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
-
-### Community 8 - "Community 8"
-Cohesion: 0.09
-Nodes (8): formatStatus(), formatUnitCount(), getRecommendationStateNote(), handleUpdatePurchaseOrderStatus(), hasInboundPurchaseOrderCover(), hasMixedPurchaseOrderCover(), hasPlannedPurchaseOrderCover(), isRecommendationVisible()
 
 ### Community 9 - "Community 9"
 Cohesion: 0.15
@@ -1800,24 +1800,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 60 - "Community 60"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 61 - "Community 61"
 Cohesion: 0.25
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 64 - "Community 64"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 65 - "Community 65"
 Cohesion: 0.18
@@ -2156,16 +2156,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 149 - "Community 149"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 150 - "Community 150"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 151 - "Community 151"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 152 - "Community 152"
 Cohesion: 0.33
@@ -2180,12 +2180,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 155 - "Community 155"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 156 - "Community 156"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.33
@@ -2196,36 +2196,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 159 - "Community 159"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 160 - "Community 160"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 161 - "Community 161"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 166 - "Community 166"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.53
@@ -2321,7 +2321,7 @@ Nodes (0):
 
 ### Community 190 - "Community 190"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 191 - "Community 191"
 Cohesion: 0.4
@@ -2332,16 +2332,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 194 - "Community 194"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.5
 Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+
+### Community 195 - "Community 195"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 196 - "Community 196"
 Cohesion: 0.4
@@ -2353,7 +2353,7 @@ Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.5
@@ -8142,1283 +8142,1283 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 697`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 698`** (2 nodes): `procurement.index.tsx`, `ProcurementRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 699`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 700`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 701`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 702`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 703`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 704`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 705`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 706`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 707`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 708`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 709`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 710`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 711`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 712`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 713`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 714`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 715`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 716`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 717`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 718`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 719`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 720`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 721`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 722`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 723`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 724`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 725`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 726`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 727`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 728`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 729`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 730`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 731`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 732`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 733`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 734`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 735`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 736`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 737`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 738`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 739`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 740`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 741`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 742`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 743`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 744`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 745`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 746`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 747`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 748`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 749`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 750`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 751`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 752`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 753`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 754`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 755`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 756`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 757`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 758`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 759`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 760`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 761`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 762`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 763`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 764`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 765`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 766`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 767`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 768`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 769`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 770`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 771`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 772`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 773`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 774`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 775`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 776`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 777`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 778`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 779`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 780`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 781`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 782`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 783`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 784`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 785`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 786`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 787`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 788`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 789`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 790`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 791`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 792`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 793`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 794`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 795`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 796`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 797`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 798`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 799`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 800`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 801`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 802`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 803`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 804`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 805`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 806`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 807`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 808`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 809`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 810`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 811`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 812`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 813`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 814`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 815`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 816`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 817`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 818`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 819`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 820`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 821`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 822`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 823`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 824`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 825`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 826`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 827`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 828`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 829`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 830`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 831`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 832`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 833`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `api.d.ts`
+- **Thin community `Community 834`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `api.js`
+- **Thin community `Community 835`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 836`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `server.d.ts`
+- **Thin community `Community 837`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `server.js`
+- **Thin community `Community 838`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `app.ts`
+- **Thin community `Community 839`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `auth.config.js`
+- **Thin community `Community 840`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `auth.ts`
+- **Thin community `Community 841`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 842`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 843`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `countries.ts`
+- **Thin community `Community 844`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `email.ts`
+- **Thin community `Community 845`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `ghana.ts`
+- **Thin community `Community 846`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `payment.ts`
+- **Thin community `Community 847`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `crons.ts`
+- **Thin community `Community 848`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 849`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 850`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 851`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 852`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `env.ts`
+- **Thin community `Community 853`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `analytics.ts`
+- **Thin community `Community 854`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `auth.ts`
+- **Thin community `Community 855`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 856`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `colors.ts`
+- **Thin community `Community 857`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `index.ts`
+- **Thin community `Community 858`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `organizations.ts`
+- **Thin community `Community 859`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `products.ts`
+- **Thin community `Community 860`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 861`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `stores.ts`
+- **Thin community `Community 862`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `bag.ts`
+- **Thin community `Community 863`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `guest.ts`
+- **Thin community `Community 864`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `index.ts`
+- **Thin community `Community 865`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `me.ts`
+- **Thin community `Community 866`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `offers.ts`
+- **Thin community `Community 867`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 868`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `paystack.ts`
+- **Thin community `Community 869`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 870`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `reviews.ts`
+- **Thin community `Community 871`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `rewards.ts`
+- **Thin community `Community 872`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 873`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `security.test.ts`
+- **Thin community `Community 874`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `storefront.ts`
+- **Thin community `Community 875`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `upsells.ts`
+- **Thin community `Community 876`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `user.ts`
+- **Thin community `Community 877`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 878`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `index.ts`
+- **Thin community `Community 879`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `health.test.ts`
+- **Thin community `Community 880`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `http.ts`
+- **Thin community `Community 881`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 882`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 883`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 884`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `categories.ts`
+- **Thin community `Community 885`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `colors.ts`
+- **Thin community `Community 886`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 887`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 888`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 889`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 890`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 891`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `organizations.ts`
+- **Thin community `Community 892`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `pos.ts`
+- **Thin community `Community 893`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 894`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 895`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `productSku.ts`
+- **Thin community `Community 896`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 897`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 898`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 899`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 900`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 901`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 902`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 903`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 904`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 905`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 906`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `client.test.ts`
+- **Thin community `Community 907`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `config.test.ts`
+- **Thin community `Community 908`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 909`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `types.ts`
+- **Thin community `Community 910`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 911`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 912`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 913`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 914`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 915`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 916`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 917`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `dto.ts`
+- **Thin community `Community 918`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 919`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 920`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 921`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `types.ts`
+- **Thin community `Community 922`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 923`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `catalog.ts`
+- **Thin community `Community 924`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `customers.ts`
+- **Thin community `Community 925`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `register.ts`
+- **Thin community `Community 926`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `terminals.ts`
+- **Thin community `Community 927`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `schema.ts`
+- **Thin community `Community 928`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 929`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 930`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 931`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 932`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `category.ts`
+- **Thin community `Community 933`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `color.ts`
+- **Thin community `Community 934`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 935`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 936`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `index.ts`
+- **Thin community `Community 937`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 938`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 939`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `organization.ts`
+- **Thin community `Community 940`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 941`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `product.ts`
+- **Thin community `Community 942`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 943`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 944`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `store.ts`
+- **Thin community `Community 945`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 946`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `index.ts`
+- **Thin community `Community 947`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 948`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 949`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 950`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 951`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 952`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `index.ts`
+- **Thin community `Community 953`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 954`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 955`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 956`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 957`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 958`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 959`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 960`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 961`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 962`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `customer.ts`
+- **Thin community `Community 963`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 964`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 965`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 966`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 967`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `index.ts`
+- **Thin community `Community 968`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `posSession.ts`
+- **Thin community `Community 969`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 970`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 971`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 972`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 973`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `index.ts`
+- **Thin community `Community 974`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 975`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 976`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 977`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 978`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 979`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 980`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `index.ts`
+- **Thin community `Community 981`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 982`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 983`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 984`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 985`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `vendor.ts`
+- **Thin community `Community 986`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `analytics.ts`
+- **Thin community `Community 987`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `bag.ts`
+- **Thin community `Community 988`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 989`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 990`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 991`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `guest.ts`
+- **Thin community `Community 992`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `index.ts`
+- **Thin community `Community 993`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `offer.ts`
+- **Thin community `Community 994`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 995`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 996`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `review.ts`
+- **Thin community `Community 997`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `rewards.ts`
+- **Thin community `Community 998`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 999`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1000`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1001`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1002`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1003`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1004`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1005`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `bag.ts`
+- **Thin community `Community 1006`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1007`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `customer.ts`
+- **Thin community `Community 1008`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `guest.ts`
+- **Thin community `Community 1009`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1010`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1011`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `payment.ts`
+- **Thin community `Community 1012`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1013`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1014`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1015`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `users.ts`
+- **Thin community `Community 1016`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `payment.ts`
+- **Thin community `Community 1017`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1018`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1020`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1021`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `index.ts`
+- **Thin community `Community 1022`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1023`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1024`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `auth.ts`
+- **Thin community `Community 1025`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1026`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1028`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1029`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1030`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1031`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1032`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1033`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1034`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1035`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `constants.ts`
+- **Thin community `Community 1036`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1037`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1038`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `types.ts`
+- **Thin community `Community 1040`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1041`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1042`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1043`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1044`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1045`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1046`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1049`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1050`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1051`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1052`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1053`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1054`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1055`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1056`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1057`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1058`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1059`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1060`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `constants.ts`
+- **Thin community `Community 1061`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1062`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1063`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1064`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `data.ts`
+- **Thin community `Community 1065`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1066`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1067`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1068`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1069`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1070`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1071`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1072`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1073`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1074`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `constants.ts`
+- **Thin community `Community 1075`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1076`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1077`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1078`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `data.ts`
+- **Thin community `Community 1079`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1080`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1081`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1082`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1083`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1084`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1085`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1086`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1087`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `constants.ts`
+- **Thin community `Community 1090`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1091`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1092`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1093`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1094`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1095`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1096`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1097`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1098`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1099`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1100`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1101`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1102`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1103`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1104`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1105`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1106`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1107`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1109`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1110`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1111`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1112`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1113`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1114`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1115`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1116`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `constants.ts`
+- **Thin community `Community 1117`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1118`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1119`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1120`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `data.ts`
+- **Thin community `Community 1121`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1122`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `constants.ts`
+- **Thin community `Community 1123`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1124`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1126`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1127`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `data.ts`
+- **Thin community `Community 1128`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1129`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `constants.ts`
+- **Thin community `Community 1130`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1131`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1132`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1133`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1134`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data.ts`
+- **Thin community `Community 1135`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1137`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1138`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1139`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1140`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1141`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1142`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1143`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1144`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1145`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1146`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1147`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1148`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1149`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1150`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1151`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1152`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1153`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1154`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1155`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1156`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1157`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1158`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1159`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `types.ts`
+- **Thin community `Community 1160`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1161`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1162`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1163`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1164`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1165`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1166`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1167`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1168`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1169`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1170`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1171`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1172`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1173`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1174`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1177`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `data.ts`
+- **Thin community `Community 1178`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1179`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1180`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1181`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1182`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1183`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1185`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1186`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1187`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1188`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1189`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1190`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `constants.ts`
+- **Thin community `Community 1191`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1192`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `data.ts`
+- **Thin community `Community 1195`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `types.ts`
+- **Thin community `Community 1196`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1197`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1198`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1199`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1200`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `index.tsx`
+- **Thin community `Community 1201`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1202`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1203`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1204`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1205`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1206`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `index.tsx`
+- **Thin community `Community 1207`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1208`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1209`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1210`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `button.tsx`
+- **Thin community `Community 1211`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1212`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `card.tsx`
+- **Thin community `Community 1213`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1214`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1215`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `command.tsx`
+- **Thin community `Community 1216`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1217`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1218`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1219`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `form.tsx`
+- **Thin community `Community 1220`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1221`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1222`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `input.tsx`
+- **Thin community `Community 1223`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1224`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1225`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1226`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1227`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1228`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1229`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `select.tsx`
+- **Thin community `Community 1230`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1231`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1232`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1233`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `table.tsx`
+- **Thin community `Community 1234`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1235`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1236`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1237`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1238`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1239`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1240`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1241`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1242`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `constants.ts`
+- **Thin community `Community 1243`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1244`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1246`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data.ts`
+- **Thin community `Community 1247`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1249`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1250`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1251`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1253`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1254`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1256`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1257`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1258`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1259`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `index.ts`
+- **Thin community `Community 1260`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1262`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1263`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1264`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1265`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1267`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `aws.ts`
+- **Thin community `Community 1268`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `constants.ts`
+- **Thin community `Community 1269`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `countries.ts`
+- **Thin community `Community 1270`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1272`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1273`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1274`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1275`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1276`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `dto.ts`
+- **Thin community `Community 1277`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `ports.ts`
+- **Thin community `Community 1278`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `constants.ts`
+- **Thin community `Community 1279`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `index.ts`
+- **Thin community `Community 1282`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `types.ts`
+- **Thin community `Community 1284`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1287`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
+- **Thin community `Community 1288`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1290`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1291`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `category.ts`
+- **Thin community `Community 1292`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `product.ts`
+- **Thin community `Community 1293`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `store.ts`
+- **Thin community `Community 1294`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1295`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `user.ts`
+- **Thin community `Community 1296`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1300`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1301`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `index.tsx`
+- **Thin community `Community 1302`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1303`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1304`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1305`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1306`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1307`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1308`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1309`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `index.tsx`
+- **Thin community `Community 1310`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1311`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1312`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1313`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `home.tsx`
+- **Thin community `Community 1314`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1315`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1316`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1317`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `index.tsx`
+- **Thin community `Community 1318`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1319`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1320`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1321`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1322`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `index.tsx`
+- **Thin community `Community 1323`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1324`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1325`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1326`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1327`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1328`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1329`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `index.tsx`
+- **Thin community `Community 1330`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1331`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1332`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1333`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1334`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1335`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1336`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1337`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -9800,11 +9800,11 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
-- **Should `Community 3` be split into smaller, more focused modules?**
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
+- **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 6` be split into smaller, more focused modules?**
+- **Should `Community 7` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
-- **Should `Community 8` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 10` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -23435,7 +23435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L984",
+      "source_location": "L1060",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -23519,7 +23519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L974",
+      "source_location": "L1050",
       "target": "stockadjustmentworkspace_setdraftvalue",
       "weight": 1
     },
@@ -25751,7 +25751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L283",
+      "source_location": "L313",
       "target": "procurementview_test_choosedraftvendor",
       "weight": 1
     },
@@ -25763,7 +25763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L249",
+      "source_location": "L279",
       "target": "procurementview_test_installmutationmocks",
       "weight": 1
     },
@@ -25775,7 +25775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L606",
+      "source_location": "L788",
       "target": "procurementview_addrecommendationtodraft",
       "weight": 1
     },
@@ -25787,7 +25787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L476",
+      "source_location": "L496",
       "target": "procurementview_buildvendoroptions",
       "weight": 1
     },
@@ -25799,8 +25799,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L472",
+      "source_location": "L476",
       "target": "procurementview_canreceivepurchaseorder",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_cn",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1607",
+      "target": "procurementview_cn",
       "weight": 1
     },
     {
@@ -25811,7 +25823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L391",
+      "source_location": "L395",
       "target": "procurementview_countrecommendationsformode",
       "weight": 1
     },
@@ -25823,7 +25835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1290",
+      "source_location": "L1634",
       "target": "procurementview_formatlinecount",
       "weight": 1
     },
@@ -25835,7 +25847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L159",
+      "source_location": "L168",
       "target": "procurementview_formatoptionaldate",
       "weight": 1
     },
@@ -25847,7 +25859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1000",
+      "source_location": "L1250",
       "target": "procurementview_formatpurchaseordercount",
       "weight": 1
     },
@@ -25859,7 +25871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L170",
+      "source_location": "L179",
       "target": "procurementview_formatstatus",
       "weight": 1
     },
@@ -25871,7 +25883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1104",
+      "source_location": "L1359",
       "target": "procurementview_formatunitcount",
       "weight": 1
     },
@@ -25883,7 +25895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L176",
+      "source_location": "L185",
       "target": "procurementview_getcontinuitystatecopy",
       "weight": 1
     },
@@ -25895,7 +25907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L400",
+      "source_location": "L404",
       "target": "procurementview_getmodeemptystatecopy",
       "weight": 1
     },
@@ -25907,8 +25919,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L455",
+      "source_location": "L459",
       "target": "procurementview_getnextlifecycleactions",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_getpurchaseordermode",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L480",
+      "target": "procurementview_getpurchaseordermode",
       "weight": 1
     },
     {
@@ -25919,8 +25943,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L435",
+      "source_location": "L439",
       "target": "procurementview_getrecommendationcountcopy",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_getrecommendationforpurchaseorder",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L724",
+      "target": "procurementview_getrecommendationforpurchaseorder",
       "weight": 1
     },
     {
@@ -25931,7 +25967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L313",
+      "source_location": "L322",
       "target": "procurementview_getrecommendationstatenote",
       "weight": 1
     },
@@ -25943,7 +25979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L247",
+      "source_location": "L256",
       "target": "procurementview_getuniquepurchaseorderreferences",
       "weight": 1
     },
@@ -25955,7 +25991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L266",
+      "source_location": "L275",
       "target": "procurementview_getuniquevendorcount",
       "weight": 1
     },
@@ -25967,7 +26003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L814",
+      "source_location": "L1002",
       "target": "procurementview_handleadvancepurchaseordertoordered",
       "weight": 1
     },
@@ -25979,8 +26015,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L699",
+      "source_location": "L883",
       "target": "procurementview_handlecreatedraftpurchaseorders",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_handlemodechange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L593",
+      "target": "procurementview_handlemodechange",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_handlepurchaseordersummaryclick",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L734",
+      "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
     {
@@ -25991,8 +26051,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L647",
+      "source_location": "L831",
       "target": "procurementview_handlequickaddvendor",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_handlerecommendationpagechange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L602",
+      "target": "procurementview_handlerecommendationpagechange",
       "weight": 1
     },
     {
@@ -26003,7 +26075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L787",
+      "source_location": "L975",
       "target": "procurementview_handleupdatepurchaseorderstatus",
       "weight": 1
     },
@@ -26015,7 +26087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L286",
+      "source_location": "L295",
       "target": "procurementview_hasinboundpurchaseordercover",
       "weight": 1
     },
@@ -26027,7 +26099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L298",
+      "source_location": "L307",
       "target": "procurementview_hasmixedpurchaseordercover",
       "weight": 1
     },
@@ -26039,8 +26111,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L274",
+      "source_location": "L283",
       "target": "procurementview_hasplannedpurchaseordercover",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_if",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1220",
+      "target": "procurementview_if",
       "weight": 1
     },
     {
@@ -26051,8 +26135,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L349",
+      "source_location": "L353",
       "target": "procurementview_isrecommendationvisible",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_parsedraftlinequantity",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L521",
+      "target": "procurementview_parsedraftlinequantity",
       "weight": 1
     },
     {
@@ -26063,8 +26159,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L641",
+      "source_location": "L825",
       "target": "procurementview_removedraftline",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "_tgt": "procurementview_sanitizedraftquantityinput",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L511",
+      "target": "procurementview_sanitizedraftquantityinput",
       "weight": 1
     },
     {
@@ -26075,7 +26183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L630",
+      "source_location": "L814",
       "target": "procurementview_updatedraftline",
       "weight": 1
     },
@@ -32317,6 +32425,18 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L6",
       "target": "expense_index_expenseroutecomponent",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "_tgt": "procurement_index_procurementroute",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L18",
+      "target": "procurement_index_procurementroute",
       "weight": 1
     },
     {
@@ -40139,7 +40259,7 @@
       "relation": "calls",
       "source": "procurementview_formatunitcount",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L327",
+      "source_location": "L331",
       "target": "procurementview_getrecommendationstatenote",
       "weight": 1
     },
@@ -40151,8 +40271,68 @@
       "relation": "calls",
       "source": "procurementview_hasmixedpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L321",
+      "source_location": "L330",
       "target": "procurementview_getrecommendationstatenote",
+      "weight": 1
+    },
+    {
+      "_src": "procurementview_handleadvancepurchaseordertoordered",
+      "_tgt": "procurementview_handlemodechange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "procurementview_handlemodechange",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1022",
+      "target": "procurementview_handleadvancepurchaseordertoordered",
+      "weight": 1
+    },
+    {
+      "_src": "procurementview_handlecreatedraftpurchaseorders",
+      "_tgt": "procurementview_handlemodechange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "procurementview_handlemodechange",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L968",
+      "target": "procurementview_handlecreatedraftpurchaseorders",
+      "weight": 1
+    },
+    {
+      "_src": "procurementview_handlepurchaseordersummaryclick",
+      "_tgt": "procurementview_getpurchaseordermode",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "procurementview_getpurchaseordermode",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L738",
+      "target": "procurementview_handlepurchaseordersummaryclick",
+      "weight": 1
+    },
+    {
+      "_src": "procurementview_handlepurchaseordersummaryclick",
+      "_tgt": "procurementview_getrecommendationforpurchaseorder",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "procurementview_getrecommendationforpurchaseorder",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L737",
+      "target": "procurementview_handlepurchaseordersummaryclick",
+      "weight": 1
+    },
+    {
+      "_src": "procurementview_handlepurchaseordersummaryclick",
+      "_tgt": "procurementview_handlemodechange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "procurementview_handlemodechange",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L745",
+      "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
     {
@@ -40163,7 +40343,7 @@
       "relation": "calls",
       "source": "procurementview_formatstatus",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L807",
+      "source_location": "L995",
       "target": "procurementview_handleupdatepurchaseorderstatus",
       "weight": 1
     },
@@ -40175,7 +40355,7 @@
       "relation": "calls",
       "source": "procurementview_hasinboundpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L309",
+      "source_location": "L318",
       "target": "procurementview_hasmixedpurchaseordercover",
       "weight": 1
     },
@@ -40187,7 +40367,7 @@
       "relation": "calls",
       "source": "procurementview_hasplannedpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L308",
+      "source_location": "L317",
       "target": "procurementview_hasmixedpurchaseordercover",
       "weight": 1
     },
@@ -40199,7 +40379,7 @@
       "relation": "calls",
       "source": "procurementview_hasinboundpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L371",
+      "source_location": "L375",
       "target": "procurementview_isrecommendationvisible",
       "weight": 1
     },
@@ -40211,7 +40391,7 @@
       "relation": "calls",
       "source": "procurementview_hasplannedpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L364",
+      "source_location": "L368",
       "target": "procurementview_isrecommendationvisible",
       "weight": 1
     },
@@ -49139,7 +49319,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_setdraftvalue",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L985",
+      "source_location": "L1061",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -52386,6 +52566,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
@@ -52393,7 +52582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -52402,7 +52591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -52411,7 +52600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -52420,7 +52609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -52429,7 +52618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -52438,7 +52627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -52447,7 +52636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -52456,21 +52645,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
       "source_location": "L1"
     },
     {
@@ -52548,6 +52728,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
       "norm_label": "onlineorderutilfns.ts",
@@ -52555,7 +52744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -52564,7 +52753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -52573,7 +52762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -52582,7 +52771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -52591,7 +52780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -52600,7 +52789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -52609,7 +52798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -52618,21 +52807,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
-      "label": "registerSession.test.ts",
-      "norm_label": "registersession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
       "source_location": "L1"
     },
     {
@@ -52710,6 +52890,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
+      "label": "registerSession.test.ts",
+      "norm_label": "registersession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
       "norm_label": "presentation.test.ts",
@@ -52717,7 +52906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -52726,7 +52915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -52735,7 +52924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -52744,7 +52933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
@@ -52753,7 +52942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -52762,7 +52951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -52771,7 +52960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -52780,21 +52969,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
       "norm_label": "registersessionstatus.test.ts",
       "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
-      "label": "staffDisplayName.test.ts",
-      "norm_label": "staffdisplayname.test.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
       "source_location": "L1"
     },
     {
@@ -52872,6 +53052,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
+      "label": "staffDisplayName.test.ts",
+      "norm_label": "staffdisplayname.test.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
       "norm_label": "genericcombobox.tsx",
@@ -52879,7 +53068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -52888,7 +53077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -52897,7 +53086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -52906,7 +53095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -52915,7 +53104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -52924,7 +53113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -52933,7 +53122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52942,21 +53131,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -53034,6 +53214,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -53041,7 +53230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -53050,7 +53239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -53059,7 +53248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -53068,7 +53257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53077,7 +53266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53086,7 +53275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -53095,7 +53284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53104,21 +53293,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -53196,6 +53376,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -53203,7 +53392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -53212,7 +53401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53221,7 +53410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -53230,7 +53419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53239,7 +53428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53248,7 +53437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -53257,7 +53446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -53266,21 +53455,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -53349,6 +53529,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -53356,7 +53545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -53365,7 +53554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53374,7 +53563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53383,7 +53572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53392,7 +53581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -53401,7 +53590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -53410,7 +53599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53419,21 +53608,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -53502,6 +53682,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -53509,7 +53698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53518,7 +53707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -53527,7 +53716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53536,7 +53725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -53545,7 +53734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -53554,7 +53743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53563,7 +53752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53572,21 +53761,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
       "source_location": "L1"
     },
     {
@@ -53655,6 +53835,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
       "norm_label": "defaultcatchboundary.test.tsx",
@@ -53662,7 +53851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -53671,7 +53860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -53680,7 +53869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -53689,7 +53878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -53698,7 +53887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53707,7 +53896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53716,7 +53905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -53725,21 +53914,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -53808,6 +53988,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -53815,7 +54004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53824,7 +54013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53833,7 +54022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53842,7 +54031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -53851,7 +54040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -53860,7 +54049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -53869,7 +54058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -53878,21 +54067,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
       "norm_label": "registersessionview.auth.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
-      "label": "RegisterSessionView.test.tsx",
-      "norm_label": "registersessionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -54159,6 +54339,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
+      "label": "RegisterSessionView.test.tsx",
+      "norm_label": "registersessionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
       "norm_label": "registersessionsview.test.tsx",
@@ -54166,7 +54355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -54175,7 +54364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -54184,7 +54373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -54193,7 +54382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -54202,7 +54391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
       "label": "PageLevelHeader.test.tsx",
@@ -54211,7 +54400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -54220,7 +54409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -54229,21 +54418,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
       "norm_label": "commandapprovaldialog.test.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
-      "label": "OperationsQueueView.auth.test.tsx",
-      "norm_label": "operationsqueueview.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
       "source_location": "L1"
     },
     {
@@ -54312,6 +54492,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
+      "label": "OperationsQueueView.auth.test.tsx",
+      "norm_label": "operationsqueueview.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
       "norm_label": "operationsqueueview.test.tsx",
@@ -54319,7 +54508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -54328,7 +54517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -54337,7 +54526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -54346,7 +54535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -54355,7 +54544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -54364,7 +54553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -54373,7 +54562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -54382,21 +54571,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -54465,6 +54645,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -54472,7 +54661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -54481,7 +54670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -54490,7 +54679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -54499,7 +54688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -54508,7 +54697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -54517,7 +54706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -54526,7 +54715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -54535,21 +54724,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "label": "inviteColumns.tsx",
-      "norm_label": "invitecolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -54618,6 +54798,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
+      "label": "inviteColumns.tsx",
+      "norm_label": "invitecolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -54625,7 +54814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -54634,7 +54823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -54643,7 +54832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -54652,7 +54841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -54661,7 +54850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -54670,7 +54859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -54679,7 +54868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -54688,21 +54877,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
       "norm_label": "cashierauthdialog.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1"
     },
     {
@@ -54771,6 +54951,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
@@ -54778,7 +54967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -54787,7 +54976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
@@ -54796,7 +54985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -54805,7 +54994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -54814,7 +55003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -54823,7 +55012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -54832,7 +55021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -54841,21 +55030,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
       "norm_label": "totalsdisplay.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1"
     },
     {
@@ -54924,6 +55104,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
       "norm_label": "expensereportsview.test.ts",
@@ -54931,7 +55120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -54940,7 +55129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -54949,7 +55138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -54958,7 +55147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -54967,7 +55156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -54976,7 +55165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -54985,7 +55174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
       "label": "POSSessionsView.test.tsx",
@@ -54994,21 +55183,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
       "norm_label": "possessioncolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/posSessionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -55077,6 +55257,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -55084,7 +55273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -55093,7 +55282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -55102,7 +55291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -55111,7 +55300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -55120,7 +55309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -55129,7 +55318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
       "label": "ArchivedProducts.tsx",
@@ -55138,7 +55327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -55147,21 +55336,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1"
     },
     {
@@ -55230,6 +55410,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
@@ -55237,7 +55426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -55246,7 +55435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -55255,7 +55444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -55264,7 +55453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -55273,7 +55462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -55282,7 +55471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -55291,7 +55480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -55300,21 +55489,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "label": "productColumns.tsx",
-      "norm_label": "productcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -55383,6 +55563,15 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
+      "label": "productColumns.tsx",
+      "norm_label": "productcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
       "norm_label": "promocodeheader.test.tsx",
@@ -55390,7 +55579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -55399,7 +55588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -55408,7 +55597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -55417,7 +55606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -55426,7 +55615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -55435,7 +55624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -55444,7 +55633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -55453,21 +55642,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -55536,6 +55716,15 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -55543,7 +55732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -55552,7 +55741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -55561,7 +55750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -55570,7 +55759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -55579,7 +55768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -55588,7 +55777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -55597,7 +55786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -55606,21 +55795,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
       "norm_label": "ratingstars.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "label": "ReviewCard.tsx",
-      "norm_label": "reviewcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1"
     },
     {
@@ -55887,6 +56067,15 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
+      "label": "ReviewCard.tsx",
+      "norm_label": "reviewcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
@@ -55894,7 +56083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -55903,7 +56092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -55912,7 +56101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -55921,7 +56110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -55930,7 +56119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -55939,7 +56128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -55948,7 +56137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -55957,21 +56146,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
       "norm_label": "workflowtraceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1"
     },
     {
@@ -56040,6 +56220,15 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
       "norm_label": "button.test.tsx",
@@ -56047,7 +56236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -56056,7 +56245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -56065,7 +56254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -56074,7 +56263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -56083,7 +56272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -56092,7 +56281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -56101,7 +56290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -56110,21 +56299,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -56193,6 +56373,15 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
       "norm_label": "form.tsx",
@@ -56200,7 +56389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -56209,7 +56398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -56218,7 +56407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -56227,7 +56416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -56236,7 +56425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -56245,7 +56434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -56254,7 +56443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -56263,21 +56452,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -56346,6 +56526,15 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -56353,7 +56542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -56362,7 +56551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -56371,7 +56560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -56380,7 +56569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -56389,7 +56578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -56398,7 +56587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -56407,7 +56596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -56416,21 +56605,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
@@ -56499,6 +56679,15 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
       "norm_label": "upload-button.tsx",
@@ -56506,7 +56695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -56515,7 +56704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -56524,7 +56713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -56533,7 +56722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56542,7 +56731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56551,7 +56740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56560,7 +56749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -56569,21 +56758,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
@@ -56652,6 +56832,15 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -56659,7 +56848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56668,7 +56857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56677,7 +56866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56686,7 +56875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56695,7 +56884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -56704,7 +56893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -56713,7 +56902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -56722,21 +56911,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
       "norm_label": "userinsightssection.tsx",
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1"
     },
     {
@@ -56805,6 +56985,15 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -56812,7 +57001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -56821,7 +57010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -56830,7 +57019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -56839,7 +57028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -56848,7 +57037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -56857,7 +57046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -56866,7 +57055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -56875,21 +57064,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
@@ -56958,6 +57138,15 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
@@ -56965,7 +57154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -56974,7 +57163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -56983,7 +57172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -56992,7 +57181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -57001,7 +57190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -57010,7 +57199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -57019,7 +57208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -57028,21 +57217,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
       "norm_label": "ports.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
       "source_location": "L1"
     },
     {
@@ -57111,6 +57291,15 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
       "norm_label": "displayamounts.test.ts",
@@ -57118,7 +57307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -57127,7 +57316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -57136,7 +57325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -57145,7 +57334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -57154,7 +57343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -57163,7 +57352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -57172,7 +57361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -57181,21 +57370,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "label": "useExpenseRegisterViewModel.test.ts",
       "norm_label": "useexpenseregisterviewmodel.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
-      "label": "catalogSearch.test.ts",
-      "norm_label": "catalogsearch.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts",
       "source_location": "L1"
     },
     {
@@ -57264,6 +57444,15 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
+      "label": "catalogSearch.test.ts",
+      "norm_label": "catalogsearch.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
       "norm_label": "registeruistate.ts",
@@ -57271,7 +57460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -57280,7 +57469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -57289,7 +57478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -57298,7 +57487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -57307,7 +57496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -57316,7 +57505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -57325,7 +57514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -57334,21 +57523,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
       "norm_label": "createworkflowtraceid.test.ts",
       "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -57615,6 +57795,15 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
@@ -57622,7 +57811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -57631,7 +57820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -57640,7 +57829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -57649,7 +57838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -57658,7 +57847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -57667,7 +57856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -57676,7 +57865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -57685,21 +57874,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
       "norm_label": "bags.$bagid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1"
     },
     {
@@ -57768,6 +57948,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -57775,7 +57964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -57784,7 +57973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -57793,7 +57982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -57802,7 +57991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -57811,7 +58000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -57820,7 +58009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -57829,7 +58018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -57838,21 +58027,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -57912,6 +58092,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
       "norm_label": "all.index.tsx",
@@ -57919,7 +58108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -57928,7 +58117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -57937,7 +58126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -57946,7 +58135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -57955,7 +58144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -57964,7 +58153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -57973,7 +58162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -57982,21 +58171,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
       "norm_label": "$reportid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1"
     },
     {
@@ -58056,6 +58236,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -58063,7 +58252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -58072,7 +58261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -58081,7 +58270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -58090,7 +58279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -58099,21 +58288,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1336,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
       "source_location": "L1"
     },
     {
@@ -60495,56 +60675,56 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1490,
@@ -60828,56 +61008,56 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1500,
@@ -60972,56 +61152,56 @@
     {
       "community": 151,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1510,
@@ -61116,56 +61296,56 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1520,
@@ -61188,6 +61368,60 @@
     {
       "community": 153,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
       "norm_label": "calculateengagementmetrics()",
@@ -61195,7 +61429,7 @@
       "source_location": "L173"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -61204,7 +61438,7 @@
       "source_location": "L71"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -61213,7 +61447,7 @@
       "source_location": "L251"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -61222,7 +61456,7 @@
       "source_location": "L36"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -61231,7 +61465,7 @@
       "source_location": "L277"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -61240,7 +61474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -61249,7 +61483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -61258,7 +61492,7 @@
       "source_location": "L122"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -61267,7 +61501,7 @@
       "source_location": "L68"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -61276,7 +61510,7 @@
       "source_location": "L85"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -61285,7 +61519,7 @@
       "source_location": "L51"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -61294,7 +61528,7 @@
       "source_location": "L102"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -61303,7 +61537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -61312,7 +61546,7 @@
       "source_location": "L3"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -61321,7 +61555,7 @@
       "source_location": "L20"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -61330,7 +61564,7 @@
       "source_location": "L14"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -61339,7 +61573,7 @@
       "source_location": "L7"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -61348,7 +61582,7 @@
       "source_location": "L27"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -61357,7 +61591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -61366,7 +61600,7 @@
       "source_location": "L28"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -61375,7 +61609,7 @@
       "source_location": "L37"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -61384,7 +61618,7 @@
       "source_location": "L12"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -61393,7 +61627,7 @@
       "source_location": "L6"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -61402,7 +61636,7 @@
       "source_location": "L49"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -61411,7 +61645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -61420,7 +61654,7 @@
       "source_location": "L171"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -61429,7 +61663,7 @@
       "source_location": "L302"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -61438,7 +61672,7 @@
       "source_location": "L319"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -61447,7 +61681,7 @@
       "source_location": "L312"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -61456,7 +61690,7 @@
       "source_location": "L293"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -61465,7 +61699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -61474,7 +61708,7 @@
       "source_location": "L12"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -61483,7 +61717,7 @@
       "source_location": "L21"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -61492,7 +61726,7 @@
       "source_location": "L101"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -61501,67 +61735,13 @@
       "source_location": "L35"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
       "norm_label": "workflowtracerouteshell()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 16,
@@ -61746,6 +61926,60 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
       "norm_label": "storesettingsview.tsx",
@@ -61753,7 +61987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -61762,7 +61996,7 @@
       "source_location": "L231"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -61771,7 +62005,7 @@
       "source_location": "L167"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -61780,7 +62014,7 @@
       "source_location": "L116"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -61789,7 +62023,7 @@
       "source_location": "L83"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -61798,7 +62032,7 @@
       "source_location": "L29"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -61807,7 +62041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -61816,7 +62050,7 @@
       "source_location": "L76"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -61825,7 +62059,7 @@
       "source_location": "L55"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -61834,7 +62068,7 @@
       "source_location": "L88"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -61843,7 +62077,7 @@
       "source_location": "L34"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -61852,7 +62086,7 @@
       "source_location": "L13"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -61861,7 +62095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -61870,7 +62104,7 @@
       "source_location": "L4"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -61879,7 +62113,7 @@
       "source_location": "L49"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -61888,7 +62122,7 @@
       "source_location": "L34"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -61897,7 +62131,7 @@
       "source_location": "L74"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -61906,7 +62140,7 @@
       "source_location": "L6"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -61915,7 +62149,7 @@
       "source_location": "L173"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -61924,7 +62158,7 @@
       "source_location": "L102"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -61933,7 +62167,7 @@
       "source_location": "L201"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -61942,7 +62176,7 @@
       "source_location": "L150"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -61951,7 +62185,7 @@
       "source_location": "L155"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -61960,7 +62194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -61969,7 +62203,7 @@
       "source_location": "L76"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -61978,7 +62212,7 @@
       "source_location": "L120"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -61987,7 +62221,7 @@
       "source_location": "L129"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -61996,7 +62230,7 @@
       "source_location": "L133"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -62005,7 +62239,7 @@
       "source_location": "L44"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -62014,7 +62248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -62023,7 +62257,7 @@
       "source_location": "L9"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -62032,7 +62266,7 @@
       "source_location": "L73"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -62041,7 +62275,7 @@
       "source_location": "L54"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -62050,7 +62284,7 @@
       "source_location": "L98"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -62059,66 +62293,12 @@
       "source_location": "L33"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -63744,51 +63924,6 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
       "norm_label": "pageheader.tsx",
@@ -63796,7 +63931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -63805,7 +63940,7 @@
       "source_location": "L30"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -63814,7 +63949,7 @@
       "source_location": "L8"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -63823,7 +63958,7 @@
       "source_location": "L50"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -63832,7 +63967,7 @@
       "source_location": "L67"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -63841,7 +63976,7 @@
       "source_location": "L20"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -63850,7 +63985,7 @@
       "source_location": "L50"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -63859,7 +63994,7 @@
       "source_location": "L342"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -63868,7 +64003,7 @@
       "source_location": "L322"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -63877,7 +64012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -63886,7 +64021,7 @@
       "source_location": "L61"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -63895,7 +64030,7 @@
       "source_location": "L57"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -63904,7 +64039,7 @@
       "source_location": "L98"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -63913,7 +64048,7 @@
       "source_location": "L134"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -63922,7 +64057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -63931,7 +64066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -63940,7 +64075,7 @@
       "source_location": "L38"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -63949,7 +64084,7 @@
       "source_location": "L64"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -63958,7 +64093,7 @@
       "source_location": "L135"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -63967,7 +64102,7 @@
       "source_location": "L43"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "operationsqueueview_getapprovalrequestcopy",
       "label": "getApprovalRequestCopy()",
@@ -63976,7 +64111,7 @@
       "source_location": "L60"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "operationsqueueview_getdefaultworkflow",
       "label": "getDefaultWorkflow()",
@@ -63985,7 +64120,7 @@
       "source_location": "L51"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "operationsqueueview_if",
       "label": "if()",
@@ -63994,7 +64129,7 @@
       "source_location": "L496"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "operationsqueueview_setdecisioningapprovalrequestid",
       "label": "setDecisioningApprovalRequestId()",
@@ -64003,7 +64138,7 @@
       "source_location": "L559"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -64012,7 +64147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -64021,7 +64156,7 @@
       "source_location": "L58"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -64030,7 +64165,7 @@
       "source_location": "L63"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -64039,7 +64174,7 @@
       "source_location": "L50"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -64048,7 +64183,7 @@
       "source_location": "L53"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -64057,7 +64192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -64066,7 +64201,7 @@
       "source_location": "L140"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -64075,7 +64210,7 @@
       "source_location": "L177"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -64084,7 +64219,7 @@
       "source_location": "L195"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -64093,7 +64228,7 @@
       "source_location": "L45"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -64102,7 +64237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -64111,7 +64246,7 @@
       "source_location": "L92"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -64120,7 +64255,7 @@
       "source_location": "L307"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -64129,7 +64264,7 @@
       "source_location": "L70"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -64138,12 +64273,57 @@
       "source_location": "L50"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -64194,299 +64374,326 @@
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectharnessonboardingerrors",
-      "label": "collectHarnessOnboardingErrors()",
-      "norm_label": "collectharnessonboardingerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L402"
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "label": "ProcurementView.tsx",
+      "norm_label": "procurementview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectmarkdownlinkerrors",
-      "label": "collectMarkdownLinkErrors()",
-      "norm_label": "collectmarkdownlinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L217"
+      "id": "procurementview_addrecommendationtodraft",
+      "label": "addRecommendationToDraft()",
+      "norm_label": "addrecommendationtodraft()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L788"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectmissingrequiredlinkerrors",
-      "label": "collectMissingRequiredLinkErrors()",
-      "norm_label": "collectmissingrequiredlinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L56"
+      "id": "procurementview_buildvendoroptions",
+      "label": "buildVendorOptions()",
+      "norm_label": "buildvendoroptions()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L496"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectpackageguidelinkerrors",
-      "label": "collectPackageGuideLinkErrors()",
-      "norm_label": "collectpackageguidelinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L646"
+      "id": "procurementview_canreceivepurchaseorder",
+      "label": "canReceivePurchaseOrder()",
+      "norm_label": "canreceivepurchaseorder()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L476"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectpackagesrouterlinkerrors",
-      "label": "collectPackagesRouterLinkErrors()",
-      "norm_label": "collectpackagesrouterlinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L622"
+      "id": "procurementview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1191"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectreadmelinkerrors",
-      "label": "collectReadmeLinkErrors()",
-      "norm_label": "collectreadmelinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L610"
+      "id": "procurementview_countrecommendationsformode",
+      "label": "countRecommendationsForMode()",
+      "norm_label": "countrecommendationsformode()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L395"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectreferencedpatherrors",
-      "label": "collectReferencedPathErrors()",
-      "norm_label": "collectreferencedpatherrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L316"
+      "id": "procurementview_formatlinecount",
+      "label": "formatLineCount()",
+      "norm_label": "formatlinecount()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L248"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectruntimescenariodocsyncerrors",
-      "label": "collectRuntimeScenarioDocSyncErrors()",
-      "norm_label": "collectruntimescenariodocsyncerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L158"
+      "id": "procurementview_formatoptionaldate",
+      "label": "formatOptionalDate()",
+      "norm_label": "formatoptionaldate()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_collectservicedocumentedsurfaces",
-      "label": "collectServiceDocumentedSurfaces()",
-      "norm_label": "collectservicedocumentedsurfaces()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L485"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_collecttestingdocerrors",
-      "label": "collectTestingDocErrors()",
-      "norm_label": "collecttestingdocerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L557"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_collecttestsurfaceroots",
-      "label": "collectTestSurfaceRoots()",
-      "norm_label": "collecttestsurfaceroots()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L510"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_extractinlinecode",
-      "label": "extractInlineCode()",
-      "norm_label": "extractinlinecode()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_extractruntimescenariosection",
-      "label": "extractRuntimeScenarioSection()",
-      "norm_label": "extractruntimescenariosection()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_extracttestscriptfromcommand",
-      "label": "extractTestScriptFromCommand()",
-      "norm_label": "extracttestscriptfromcommand()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L433"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_formatscenariolist",
-      "label": "formatScenarioList()",
-      "norm_label": "formatscenariolist()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L123"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_isenforcedharnessapp",
-      "label": "isEnforcedHarnessApp()",
-      "norm_label": "isenforcedharnessapp()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_islikelypathreference",
-      "label": "isLikelyPathReference()",
-      "norm_label": "islikelypathreference()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_isrelativelink",
-      "label": "isRelativeLink()",
-      "norm_label": "isrelativelink()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_isruntimescenarioname",
-      "label": "isRuntimeScenarioName()",
-      "norm_label": "isruntimescenarioname()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_listworkspacepackagedirs",
-      "label": "listWorkspacePackageDirs()",
-      "norm_label": "listworkspacepackagedirs()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "harness_check_normalizepathreference",
-      "label": "normalizePathReference()",
-      "norm_label": "normalizepathreference()",
-      "source_file": "scripts/harness-check.ts",
+      "id": "procurementview_formatpurchaseordercount",
+      "label": "formatPurchaseOrderCount()",
+      "norm_label": "formatpurchaseordercount()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
       "source_location": "L252"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L40"
+      "id": "procurementview_formatstatus",
+      "label": "formatStatus()",
+      "norm_label": "formatstatus()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L179"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_readpackageconfig",
-      "label": "readPackageConfig()",
-      "norm_label": "readpackageconfig()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L351"
+      "id": "procurementview_formatunitcount",
+      "label": "formatUnitCount()",
+      "norm_label": "formatunitcount()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L244"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_resolvepathreference",
-      "label": "resolvePathReference()",
-      "norm_label": "resolvepathreference()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L290"
+      "id": "procurementview_getcontinuitystatecopy",
+      "label": "getContinuityStateCopy()",
+      "norm_label": "getcontinuitystatecopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L185"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_runharnesscheck",
-      "label": "runHarnessCheck()",
-      "norm_label": "runharnesscheck()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L827"
+      "id": "procurementview_getmodeemptystatecopy",
+      "label": "getModeEmptyStateCopy()",
+      "norm_label": "getmodeemptystatecopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_sortuniqueentries",
-      "label": "sortUniqueEntries()",
-      "norm_label": "sortuniqueentries()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L117"
+      "id": "procurementview_getnextlifecycleactions",
+      "label": "getNextLifecycleActions()",
+      "norm_label": "getnextlifecycleactions()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L459"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_striplinkdecorations",
-      "label": "stripLinkDecorations()",
-      "norm_label": "striplinkdecorations()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L44"
+      "id": "procurementview_getpurchaseordermode",
+      "label": "getPurchaseOrderMode()",
+      "norm_label": "getpurchaseordermode()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L480"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_torelativelinktarget",
-      "label": "toRelativeLinkTarget()",
-      "norm_label": "torelativelinktarget()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L48"
+      "id": "procurementview_getrecommendationcountcopy",
+      "label": "getRecommendationCountCopy()",
+      "norm_label": "getrecommendationcountcopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L439"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_validateharnessdocs",
-      "label": "validateHarnessDocs()",
-      "norm_label": "validateharnessdocs()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L668"
+      "id": "procurementview_getrecommendationforpurchaseorder",
+      "label": "getRecommendationForPurchaseOrder()",
+      "norm_label": "getrecommendationforpurchaseorder()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L724"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "harness_check_walkfiles",
-      "label": "walkFiles()",
-      "norm_label": "walkfiles()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L465"
+      "id": "procurementview_getrecommendationstatenote",
+      "label": "getRecommendationStateNote()",
+      "norm_label": "getrecommendationstatenote()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L322"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "scripts_harness_check_ts",
-      "label": "harness-check.ts",
-      "norm_label": "harness-check.ts",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L1"
+      "id": "procurementview_getuniquepurchaseorderreferences",
+      "label": "getUniquePurchaseOrderReferences()",
+      "norm_label": "getuniquepurchaseorderreferences()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L256"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_getuniquevendorcount",
+      "label": "getUniqueVendorCount()",
+      "norm_label": "getuniquevendorcount()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L275"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handleadvancepurchaseordertoordered",
+      "label": "handleAdvancePurchaseOrderToOrdered()",
+      "norm_label": "handleadvancepurchaseordertoordered()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1002"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handlecreatedraftpurchaseorders",
+      "label": "handleCreateDraftPurchaseOrders()",
+      "norm_label": "handlecreatedraftpurchaseorders()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L883"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handlemodechange",
+      "label": "handleModeChange()",
+      "norm_label": "handlemodechange()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L593"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handlepurchaseordersummaryclick",
+      "label": "handlePurchaseOrderSummaryClick()",
+      "norm_label": "handlepurchaseordersummaryclick()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L734"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handlequickaddvendor",
+      "label": "handleQuickAddVendor()",
+      "norm_label": "handlequickaddvendor()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L831"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handlerecommendationpagechange",
+      "label": "handleRecommendationPageChange()",
+      "norm_label": "handlerecommendationpagechange()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L602"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_handleupdatepurchaseorderstatus",
+      "label": "handleUpdatePurchaseOrderStatus()",
+      "norm_label": "handleupdatepurchaseorderstatus()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L975"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_hasinboundpurchaseordercover",
+      "label": "hasInboundPurchaseOrderCover()",
+      "norm_label": "hasinboundpurchaseordercover()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L295"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_hasmixedpurchaseordercover",
+      "label": "hasMixedPurchaseOrderCover()",
+      "norm_label": "hasmixedpurchaseordercover()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_hasplannedpurchaseordercover",
+      "label": "hasPlannedPurchaseOrderCover()",
+      "norm_label": "hasplannedpurchaseordercover()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L283"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1220"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_isrecommendationvisible",
+      "label": "isRecommendationVisible()",
+      "norm_label": "isrecommendationvisible()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L353"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_parsedraftlinequantity",
+      "label": "parseDraftLineQuantity()",
+      "norm_label": "parsedraftlinequantity()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L521"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_removedraftline",
+      "label": "removeDraftLine()",
+      "norm_label": "removedraftline()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L825"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_sanitizedraftquantityinput",
+      "label": "sanitizeDraftQuantityInput()",
+      "norm_label": "sanitizedraftquantityinput()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L511"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "procurementview_updatedraftline",
+      "label": "updateDraftLine()",
+      "norm_label": "updatedraftline()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L814"
     },
     {
       "community": 20,
@@ -69562,7 +69769,7 @@
       "label": "handleDraftChange()",
       "norm_label": "handledraftchange()",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L984"
+      "source_location": "L1060"
     },
     {
       "community": 29,
@@ -69625,7 +69832,7 @@
       "label": "setDraftValue()",
       "norm_label": "setdraftvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L974"
+      "source_location": "L1050"
     },
     {
       "community": 29,
@@ -69999,289 +70206,298 @@
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_asregexp",
-      "label": "asRegExp()",
-      "norm_label": "asregexp()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L300"
+      "id": "harness_check_collectharnessonboardingerrors",
+      "label": "collectHarnessOnboardingErrors()",
+      "norm_label": "collectharnessonboardingerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L402"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_collectlatencydiagnostics",
-      "label": "collectLatencyDiagnostics()",
-      "norm_label": "collectlatencydiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L780"
+      "id": "harness_check_collectmarkdownlinkerrors",
+      "label": "collectMarkdownLinkErrors()",
+      "norm_label": "collectmarkdownlinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L217"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_collectruntimesignaldiagnostics",
-      "label": "collectRuntimeSignalDiagnostics()",
-      "norm_label": "collectruntimesignaldiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L747"
+      "id": "harness_check_collectmissingrequiredlinkerrors",
+      "label": "collectMissingRequiredLinkErrors()",
+      "norm_label": "collectmissingrequiredlinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L56"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_collectruntimesignalmatches",
-      "label": "collectRuntimeSignalMatches()",
-      "norm_label": "collectruntimesignalmatches()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L690"
+      "id": "harness_check_collectpackageguidelinkerrors",
+      "label": "collectPackageGuideLinkErrors()",
+      "norm_label": "collectpackageguidelinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L646"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_consumelines",
-      "label": "consumeLines()",
-      "norm_label": "consumelines()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L333"
+      "id": "harness_check_collectpackagesrouterlinkerrors",
+      "label": "collectPackagesRouterLinkErrors()",
+      "norm_label": "collectpackagesrouterlinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L622"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_escaperegexp",
-      "label": "escapeRegExp()",
-      "norm_label": "escaperegexp()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L308"
+      "id": "harness_check_collectreadmelinkerrors",
+      "label": "collectReadmeLinkErrors()",
+      "norm_label": "collectreadmelinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L610"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_formatassertiondiagnostics",
-      "label": "formatAssertionDiagnostics()",
-      "norm_label": "formatassertiondiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L828"
+      "id": "harness_check_collectreferencedpatherrors",
+      "label": "collectReferencedPathErrors()",
+      "norm_label": "collectreferencedpatherrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L316"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L312"
+      "id": "harness_check_collectruntimescenariodocsyncerrors",
+      "label": "collectRuntimeScenarioDocSyncErrors()",
+      "norm_label": "collectruntimescenariodocsyncerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L158"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_getlinesforsource",
-      "label": "getLinesForSource()",
-      "norm_label": "getlinesforsource()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L320"
+      "id": "harness_check_collectservicedocumentedsurfaces",
+      "label": "collectServiceDocumentedSurfaces()",
+      "norm_label": "collectservicedocumentedsurfaces()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L485"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_harnessbehaviorphaseerror",
-      "label": "HarnessBehaviorPhaseError",
-      "norm_label": "harnessbehaviorphaseerror",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L227"
+      "id": "harness_check_collecttestingdocerrors",
+      "label": "collectTestingDocErrors()",
+      "norm_label": "collecttestingdocerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L557"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L232"
+      "id": "harness_check_collecttestsurfaceroots",
+      "label": "collectTestSurfaceRoots()",
+      "norm_label": "collecttestsurfaceroots()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L510"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_installplaywrightchromium",
-      "label": "installPlaywrightChromium()",
-      "norm_label": "installplaywrightchromium()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L939"
+      "id": "harness_check_extractinlinecode",
+      "label": "extractInlineCode()",
+      "norm_label": "extractinlinecode()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L246"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_ismissingplaywrightchromiumerror",
-      "label": "isMissingPlaywrightChromiumError()",
-      "norm_label": "ismissingplaywrightchromiumerror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L917"
+      "id": "harness_check_extractruntimescenariosection",
+      "label": "extractRuntimeScenarioSection()",
+      "norm_label": "extractruntimescenariosection()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L136"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_launchplaywrightchromium",
-      "label": "launchPlaywrightChromium()",
-      "norm_label": "launchplaywrightchromium()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L943"
+      "id": "harness_check_extracttestscriptfromcommand",
+      "label": "extractTestScriptFromCommand()",
+      "norm_label": "extracttestscriptfromcommand()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L433"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_logphase",
-      "label": "logPhase()",
-      "norm_label": "logphase()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L286"
+      "id": "harness_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L81"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_missingplaywrightchromiumdiagnostic",
-      "label": "missingPlaywrightChromiumDiagnostic()",
-      "norm_label": "missingplaywrightchromiumdiagnostic()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L930"
+      "id": "harness_check_formatscenariolist",
+      "label": "formatScenarioList()",
+      "norm_label": "formatscenariolist()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L123"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_parseharnessbehaviorargs",
-      "label": "parseHarnessBehaviorArgs()",
-      "norm_label": "parseharnessbehaviorargs()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1341"
+      "id": "harness_check_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L90"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_printharnessbehaviorusage",
-      "label": "printHarnessBehaviorUsage()",
-      "norm_label": "printharnessbehaviorusage()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1413"
+      "id": "harness_check_isenforcedharnessapp",
+      "label": "isEnforcedHarnessApp()",
+      "norm_label": "isenforcedharnessapp()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L106"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_resolveharnessbehaviorshell",
-      "label": "resolveHarnessBehaviorShell()",
-      "norm_label": "resolveharnessbehaviorshell()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L631"
+      "id": "harness_check_islikelypathreference",
+      "label": "isLikelyPathReference()",
+      "norm_label": "islikelypathreference()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L265"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_runharnessbehaviorcli",
-      "label": "runHarnessBehaviorCli()",
-      "norm_label": "runharnessbehaviorcli()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1421"
+      "id": "harness_check_isrelativelink",
+      "label": "isRelativeLink()",
+      "norm_label": "isrelativelink()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L73"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1107"
+      "id": "harness_check_isruntimescenarioname",
+      "label": "isRuntimeScenarioName()",
+      "norm_label": "isruntimescenarioname()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L127"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_runhttpreadinesscheck",
-      "label": "runHttpReadinessCheck()",
-      "norm_label": "runhttpreadinesscheck()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L658"
+      "id": "harness_check_listworkspacepackagedirs",
+      "label": "listWorkspacePackageDirs()",
+      "norm_label": "listworkspacepackagedirs()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L379"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_runphasewithduration",
-      "label": "runPhaseWithDuration()",
-      "norm_label": "runphasewithduration()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1094"
+      "id": "harness_check_normalizepathreference",
+      "label": "normalizePathReference()",
+      "norm_label": "normalizepathreference()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L252"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_runplaywrightflow",
-      "label": "runPlaywrightFlow()",
-      "norm_label": "runplaywrightflow()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L980"
+      "id": "harness_check_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L40"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_runshellcommand",
-      "label": "runShellCommand()",
-      "norm_label": "runshellcommand()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L609"
+      "id": "harness_check_readpackageconfig",
+      "label": "readPackageConfig()",
+      "norm_label": "readpackageconfig()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L351"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_shouldautoinstallplaywrightchromium",
-      "label": "shouldAutoInstallPlaywrightChromium()",
-      "norm_label": "shouldautoinstallplaywrightchromium()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L926"
+      "id": "harness_check_resolvepathreference",
+      "label": "resolvePathReference()",
+      "norm_label": "resolvepathreference()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L290"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L294"
+      "id": "harness_check_runharnesscheck",
+      "label": "runHarnessCheck()",
+      "norm_label": "runharnesscheck()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L827"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_spawncommand",
-      "label": "spawnCommand()",
-      "norm_label": "spawncommand()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L555"
+      "id": "harness_check_sortuniqueentries",
+      "label": "sortUniqueEntries()",
+      "norm_label": "sortuniqueentries()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L117"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_startprocess",
-      "label": "startProcess()",
-      "norm_label": "startprocess()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L421"
+      "id": "harness_check_striplinkdecorations",
+      "label": "stripLinkDecorations()",
+      "norm_label": "striplinkdecorations()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L44"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_stopprocess",
-      "label": "stopProcess()",
-      "norm_label": "stopprocess()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L399"
+      "id": "harness_check_torelativelinktarget",
+      "label": "toRelativeLinkTarget()",
+      "norm_label": "torelativelinktarget()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L48"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "harness_behavior_wrapphaseerror",
-      "label": "wrapPhaseError()",
-      "norm_label": "wrapphaseerror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1083"
+      "id": "harness_check_validateharnessdocs",
+      "label": "validateHarnessDocs()",
+      "norm_label": "validateharnessdocs()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L668"
     },
     {
       "community": 3,
       "file_type": "code",
-      "id": "scripts_harness_behavior_ts",
-      "label": "harness-behavior.ts",
-      "norm_label": "harness-behavior.ts",
-      "source_file": "scripts/harness-behavior.ts",
+      "id": "harness_check_walkfiles",
+      "label": "walkFiles()",
+      "norm_label": "walkfiles()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L465"
+    },
+    {
+      "community": 3,
+      "file_type": "code",
+      "id": "scripts_harness_check_ts",
+      "label": "harness-check.ts",
+      "norm_label": "harness-check.ts",
+      "source_file": "scripts/harness-check.ts",
       "source_location": "L1"
     },
     {
@@ -72757,7 +72973,7 @@
       "label": "chooseDraftVendor()",
       "norm_label": "choosedraftvendor()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L283"
+      "source_location": "L313"
     },
     {
       "community": 355,
@@ -72766,7 +72982,7 @@
       "label": "installMutationMocks()",
       "norm_label": "installmutationmocks()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L249"
+      "source_location": "L279"
     },
     {
       "community": 356,
@@ -74526,280 +74742,289 @@
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_builddiscoveryindex",
-      "label": "buildDiscoveryIndex()",
-      "norm_label": "builddiscoveryindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L386"
+      "id": "harness_behavior_asregexp",
+      "label": "asRegExp()",
+      "norm_label": "asregexp()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L300"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_buildgenerateddoc",
-      "label": "buildGeneratedDoc()",
-      "norm_label": "buildgenerateddoc()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L376"
+      "id": "harness_behavior_collectlatencydiagnostics",
+      "label": "collectLatencyDiagnostics()",
+      "norm_label": "collectlatencydiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L780"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_buildkeyfolderindex",
-      "label": "buildKeyFolderIndex()",
-      "norm_label": "buildkeyfolderindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L478"
+      "id": "harness_behavior_collectruntimesignaldiagnostics",
+      "label": "collectRuntimeSignalDiagnostics()",
+      "norm_label": "collectruntimesignaldiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L747"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_buildtestindex",
-      "label": "buildTestIndex()",
-      "norm_label": "buildtestindex()",
-      "source_file": "scripts/harness-generate.ts",
+      "id": "harness_behavior_collectruntimesignalmatches",
+      "label": "collectRuntimeSignalMatches()",
+      "norm_label": "collectruntimesignalmatches()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L690"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_consumelines",
+      "label": "consumeLines()",
+      "norm_label": "consumelines()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L333"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_escaperegexp",
+      "label": "escapeRegExp()",
+      "norm_label": "escaperegexp()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_formatassertiondiagnostics",
+      "label": "formatAssertionDiagnostics()",
+      "norm_label": "formatassertiondiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L828"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_getlinesforsource",
+      "label": "getLinesForSource()",
+      "norm_label": "getlinesforsource()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L320"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_harnessbehaviorphaseerror",
+      "label": "HarnessBehaviorPhaseError",
+      "norm_label": "harnessbehaviorphaseerror",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L232"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_installplaywrightchromium",
+      "label": "installPlaywrightChromium()",
+      "norm_label": "installplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L939"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_ismissingplaywrightchromiumerror",
+      "label": "isMissingPlaywrightChromiumError()",
+      "norm_label": "ismissingplaywrightchromiumerror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L917"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_launchplaywrightchromium",
+      "label": "launchPlaywrightChromium()",
+      "norm_label": "launchplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L943"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_logphase",
+      "label": "logPhase()",
+      "norm_label": "logphase()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "label": "missingPlaywrightChromiumDiagnostic()",
+      "norm_label": "missingplaywrightchromiumdiagnostic()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L930"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_parseharnessbehaviorargs",
+      "label": "parseHarnessBehaviorArgs()",
+      "norm_label": "parseharnessbehaviorargs()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1341"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_printharnessbehaviorusage",
+      "label": "printHarnessBehaviorUsage()",
+      "norm_label": "printharnessbehaviorusage()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1413"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_resolveharnessbehaviorshell",
+      "label": "resolveHarnessBehaviorShell()",
+      "norm_label": "resolveharnessbehaviorshell()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L631"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_runharnessbehaviorcli",
+      "label": "runHarnessBehaviorCli()",
+      "norm_label": "runharnessbehaviorcli()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1421"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1107"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_runhttpreadinesscheck",
+      "label": "runHttpReadinessCheck()",
+      "norm_label": "runhttpreadinesscheck()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L658"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_runphasewithduration",
+      "label": "runPhaseWithDuration()",
+      "norm_label": "runphasewithduration()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1094"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_runplaywrightflow",
+      "label": "runPlaywrightFlow()",
+      "norm_label": "runplaywrightflow()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L980"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_runshellcommand",
+      "label": "runShellCommand()",
+      "norm_label": "runshellcommand()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L609"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_shouldautoinstallplaywrightchromium",
+      "label": "shouldAutoInstallPlaywrightChromium()",
+      "norm_label": "shouldautoinstallplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L926"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_spawncommand",
+      "label": "spawnCommand()",
+      "norm_label": "spawncommand()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L555"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "harness_behavior_startprocess",
+      "label": "startProcess()",
+      "norm_label": "startprocess()",
+      "source_file": "scripts/harness-behavior.ts",
       "source_location": "L421"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_buildvalidationguide",
-      "label": "buildValidationGuide()",
-      "norm_label": "buildvalidationguide()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L511"
+      "id": "harness_behavior_stopprocess",
+      "label": "stopProcess()",
+      "norm_label": "stopprocess()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L399"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_buildvalidationmap",
-      "label": "buildValidationMap()",
-      "norm_label": "buildvalidationmap()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L553"
+      "id": "harness_behavior_wrapphaseerror",
+      "label": "wrapPhaseError()",
+      "norm_label": "wrapphaseerror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1083"
     },
     {
       "community": 4,
       "file_type": "code",
-      "id": "harness_generate_collectfolderfacts",
-      "label": "collectFolderFacts()",
-      "norm_label": "collectfolderfacts()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L272"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_collectroutegroups",
-      "label": "collectRouteGroups()",
-      "norm_label": "collectroutegroups()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_collectservicedocumentedentries",
-      "label": "collectServiceDocumentedEntries()",
-      "norm_label": "collectservicedocumentedentries()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_collectserviceentrygroups",
-      "label": "collectServiceEntryGroups()",
-      "norm_label": "collectserviceentrygroups()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_collecttestfiles",
-      "label": "collectTestFiles()",
-      "norm_label": "collecttestfiles()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_collecttestsurfaceroots",
-      "label": "collectTestSurfaceRoots()",
-      "norm_label": "collecttestsurfaceroots()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_formatmarkdownlink",
-      "label": "formatMarkdownLink()",
-      "norm_label": "formatmarkdownlink()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_formatscriptcommand",
-      "label": "formatScriptCommand()",
-      "norm_label": "formatscriptcommand()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L316"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_formatvalidationcommandfordoc",
-      "label": "formatValidationCommandForDoc()",
-      "norm_label": "formatvalidationcommandfordoc()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_generateharnessdocs",
-      "label": "generateHarnessDocs()",
-      "norm_label": "generateharnessdocs()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L560"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_headingfromsegment",
-      "label": "headingFromSegment()",
-      "norm_label": "headingfromsegment()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_iswithinfolder",
-      "label": "isWithinFolder()",
-      "norm_label": "iswithinfolder()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_readpackageconfig",
-      "label": "readPackageConfig()",
-      "norm_label": "readpackageconfig()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_shouldskipgeneratedentry",
-      "label": "shouldSkipGeneratedEntry()",
-      "norm_label": "shouldskipgeneratedentry()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_slugifytitle",
-      "label": "slugifyTitle()",
-      "norm_label": "slugifytitle()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L331"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_summarizechildren",
-      "label": "summarizeChildren()",
-      "norm_label": "summarizechildren()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_todocpath",
-      "label": "toDocPath()",
-      "norm_label": "todocpath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_togeneratedvalidationmap",
-      "label": "toGeneratedValidationMap()",
-      "norm_label": "togeneratedvalidationmap()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_topackagerelativegenerateddocpaths",
-      "label": "toPackageRelativeGeneratedDocPaths()",
-      "norm_label": "topackagerelativegenerateddocpaths()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_torepovalidationpath",
-      "label": "toRepoValidationPath()",
-      "norm_label": "torepovalidationpath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_walkfiles",
-      "label": "walkFiles()",
-      "norm_label": "walkfiles()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "harness_generate_writegeneratedharnessdocs",
-      "label": "writeGeneratedHarnessDocs()",
-      "norm_label": "writegeneratedharnessdocs()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L590"
-    },
-    {
-      "community": 4,
-      "file_type": "code",
-      "id": "scripts_harness_generate_ts",
-      "label": "harness-generate.ts",
-      "norm_label": "harness-generate.ts",
-      "source_file": "scripts/harness-generate.ts",
+      "id": "scripts_harness_behavior_ts",
+      "label": "harness-behavior.ts",
+      "norm_label": "harness-behavior.ts",
+      "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1"
     },
     {
@@ -78351,254 +78576,281 @@
     {
       "community": 5,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
-      "label": "storeConfigV2.ts",
-      "norm_label": "storeconfigv2.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L1"
+      "id": "harness_generate_builddiscoveryindex",
+      "label": "buildDiscoveryIndex()",
+      "norm_label": "builddiscoveryindex()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L386"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_asarray",
-      "label": "asArray()",
-      "norm_label": "asarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L77"
+      "id": "harness_generate_buildgenerateddoc",
+      "label": "buildGeneratedDoc()",
+      "norm_label": "buildgenerateddoc()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L376"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_assignordelete",
-      "label": "assignOrDelete()",
-      "norm_label": "assignordelete()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L507"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 5,
-      "file_type": "code",
-      "id": "storeconfigv2_deepmerge",
-      "label": "deepMerge()",
-      "norm_label": "deepmerge()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "id": "harness_generate_buildkeyfolderindex",
+      "label": "buildKeyFolderIndex()",
+      "norm_label": "buildkeyfolderindex()",
+      "source_file": "scripts/harness-generate.ts",
       "source_location": "L478"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L101"
+      "id": "harness_generate_buildtestindex",
+      "label": "buildTestIndex()",
+      "norm_label": "buildtestindex()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L421"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "label": "getUnknownStoreConfigRootKeys()",
-      "norm_label": "getunknownstoreconfigrootkeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L591"
+      "id": "harness_generate_buildvalidationguide",
+      "label": "buildValidationGuide()",
+      "norm_label": "buildvalidationguide()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L511"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L178"
+      "id": "harness_generate_buildvalidationmap",
+      "label": "buildValidationMap()",
+      "norm_label": "buildvalidationmap()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L553"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_islegacyrootkey",
-      "label": "isLegacyRootKey()",
-      "norm_label": "islegacyrootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L623"
+      "id": "harness_generate_collectfolderfacts",
+      "label": "collectFolderFacts()",
+      "norm_label": "collectfolderfacts()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L272"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_isplainobject",
-      "label": "isPlainObject()",
-      "norm_label": "isplainobject()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L53"
+      "id": "harness_generate_collectroutegroups",
+      "label": "collectRouteGroups()",
+      "norm_label": "collectroutegroups()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L126"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_isstorecheckoutdisabled",
-      "label": "isStoreCheckoutDisabled()",
-      "norm_label": "isstorecheckoutdisabled()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L597"
+      "id": "harness_generate_collectservicedocumentedentries",
+      "label": "collectServiceDocumentedEntries()",
+      "norm_label": "collectservicedocumentedentries()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L152"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_isv2rootkey",
-      "label": "isV2RootKey()",
-      "norm_label": "isv2rootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L627"
+      "id": "harness_generate_collectserviceentrygroups",
+      "label": "collectServiceEntryGroups()",
+      "norm_label": "collectserviceentrygroups()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L177"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L191"
+      "id": "harness_generate_collecttestfiles",
+      "label": "collectTestFiles()",
+      "norm_label": "collecttestfiles()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L196"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L111"
+      "id": "harness_generate_collecttestsurfaceroots",
+      "label": "collectTestSurfaceRoots()",
+      "norm_label": "collecttestsurfaceroots()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L226"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L115"
+      "id": "harness_generate_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L32"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_mirrorlegacykeys",
-      "label": "mirrorLegacyKeys()",
-      "norm_label": "mirrorlegacykeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L520"
+      "id": "harness_generate_formatmarkdownlink",
+      "label": "formatMarkdownLink()",
+      "norm_label": "formatmarkdownlink()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L85"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L214"
+      "id": "harness_generate_formatscriptcommand",
+      "label": "formatScriptCommand()",
+      "norm_label": "formatscriptcommand()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L316"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_normalizestoreconfig",
-      "label": "normalizeStoreConfig()",
-      "norm_label": "normalizestoreconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L474"
+      "id": "harness_generate_formatvalidationcommandfordoc",
+      "label": "formatValidationCommandForDoc()",
+      "norm_label": "formatvalidationcommandfordoc()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L338"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L135"
+      "id": "harness_generate_generateharnessdocs",
+      "label": "generateHarnessDocs()",
+      "norm_label": "generateharnessdocs()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L560"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_patchv2config",
-      "label": "patchV2Config()",
-      "norm_label": "patchv2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L498"
+      "id": "harness_generate_headingfromsegment",
+      "label": "headingFromSegment()",
+      "norm_label": "headingfromsegment()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L89"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "label": "removeLegacyRootKeysFromConfig()",
-      "norm_label": "removelegacyrootkeysfromconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L606"
+      "id": "harness_generate_iswithinfolder",
+      "label": "isWithinFolder()",
+      "norm_label": "iswithinfolder()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L105"
     },
     {
       "community": 5,
       "file_type": "code",
-      "id": "storeconfigv2_tov2config",
-      "label": "toV2Config()",
-      "norm_label": "tov2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L231"
+      "id": "harness_generate_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_readpackageconfig",
+      "label": "readPackageConfig()",
+      "norm_label": "readpackageconfig()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_shouldskipgeneratedentry",
+      "label": "shouldSkipGeneratedEntry()",
+      "norm_label": "shouldskipgeneratedentry()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_slugifytitle",
+      "label": "slugifyTitle()",
+      "norm_label": "slugifytitle()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L331"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_summarizechildren",
+      "label": "summarizeChildren()",
+      "norm_label": "summarizechildren()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_todocpath",
+      "label": "toDocPath()",
+      "norm_label": "todocpath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_togeneratedvalidationmap",
+      "label": "toGeneratedValidationMap()",
+      "norm_label": "togeneratedvalidationmap()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_topackagerelativegenerateddocpaths",
+      "label": "toPackageRelativeGeneratedDocPaths()",
+      "norm_label": "topackagerelativegenerateddocpaths()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_torepovalidationpath",
+      "label": "toRepoValidationPath()",
+      "norm_label": "torepovalidationpath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_walkfiles",
+      "label": "walkFiles()",
+      "norm_label": "walkfiles()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "harness_generate_writegeneratedharnessdocs",
+      "label": "writeGeneratedHarnessDocs()",
+      "norm_label": "writegeneratedharnessdocs()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L590"
+    },
+    {
+      "community": 5,
+      "file_type": "code",
+      "id": "scripts_harness_generate_ts",
+      "label": "harness-generate.ts",
+      "norm_label": "harness-generate.ts",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L1"
     },
     {
       "community": 50,
@@ -81555,353 +81807,353 @@
     {
       "community": 6,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
+      "label": "storeConfigV2.ts",
+      "norm_label": "storeconfigv2.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_applycloseoutcommandresult",
-      "label": "applyCloseoutCommandResult()",
-      "norm_label": "applycloseoutcommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L521"
+      "id": "storeconfigv2_asarray",
+      "label": "asArray()",
+      "norm_label": "asarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L77"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L511"
+      "id": "storeconfigv2_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L69"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_builddepositsubmissionkey",
-      "label": "buildDepositSubmissionKey()",
-      "norm_label": "builddepositsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L276"
+      "id": "storeconfigv2_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L165"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2140"
+      "id": "storeconfigv2_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L61"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L280"
+      "id": "storeconfigv2_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L90"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L329"
+      "id": "storeconfigv2_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L57"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatregisterheadername",
-      "label": "formatRegisterHeaderName()",
-      "norm_label": "formatregisterheadername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L342"
+      "id": "storeconfigv2_assignordelete",
+      "label": "assignOrDelete()",
+      "norm_label": "assignordelete()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L507"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L337"
+      "id": "storeconfigv2_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L65"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatsessioncode",
-      "label": "formatSessionCode()",
-      "norm_label": "formatsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L356"
+      "id": "storeconfigv2_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L153"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L299"
+      "id": "storeconfigv2_deepmerge",
+      "label": "deepMerge()",
+      "norm_label": "deepmerge()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L478"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formatstoredamountforinput",
-      "label": "formatStoredAmountForInput()",
-      "norm_label": "formatstoredamountforinput()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L288"
+      "id": "storeconfigv2_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L101"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L292"
+      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
+      "label": "getUnknownStoreConfigRootKeys()",
+      "norm_label": "getunknownstoreconfigrootkeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L591"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_getnumericeventmetadata",
-      "label": "getNumericEventMetadata()",
-      "norm_label": "getnumericeventmetadata()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L314"
+      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L178"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L368"
+      "id": "storeconfigv2_islegacyrootkey",
+      "label": "isLegacyRootKey()",
+      "norm_label": "islegacyrootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L623"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L360"
+      "id": "storeconfigv2_isplainobject",
+      "label": "isPlainObject()",
+      "norm_label": "isplainobject()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L53"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handleauthenticatedcloseoutstaff",
-      "label": "handleAuthenticatedCloseoutStaff()",
-      "norm_label": "handleauthenticatedcloseoutstaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L691"
+      "id": "storeconfigv2_isstorecheckoutdisabled",
+      "label": "isStoreCheckoutDisabled()",
+      "norm_label": "isstorecheckoutdisabled()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L597"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handleopeningfloatapprovalapproved",
-      "label": "handleOpeningFloatApprovalApproved()",
-      "norm_label": "handleopeningfloatapprovalapproved()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L805"
+      "id": "storeconfigv2_isv2rootkey",
+      "label": "isV2RootKey()",
+      "norm_label": "isv2rootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L627"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlerecorddeposit",
-      "label": "handleRecordDeposit()",
-      "norm_label": "handlerecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L538"
+      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L191"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlereviewcloseout",
-      "label": "handleReviewCloseout()",
-      "norm_label": "handlereviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L618"
+      "id": "storeconfigv2_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L111"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlesubmitcloseout",
-      "label": "handleSubmitCloseout()",
-      "norm_label": "handlesubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L581"
+      "id": "storeconfigv2_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L115"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_handlesubmitopeningfloatcorrection",
-      "label": "handleSubmitOpeningFloatCorrection()",
-      "norm_label": "handlesubmitopeningfloatcorrection()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L635"
+      "id": "storeconfigv2_mirrorlegacykeys",
+      "label": "mirrorLegacyKeys()",
+      "norm_label": "mirrorlegacykeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L520"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_iscloseoutrejectionevent",
-      "label": "isCloseoutRejectionEvent()",
-      "norm_label": "iscloseoutrejectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L303"
+      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L214"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_ismanagerstaff",
-      "label": "isManagerStaff()",
-      "norm_label": "ismanagerstaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L272"
+      "id": "storeconfigv2_normalizestoreconfig",
+      "label": "normalizeStoreConfig()",
+      "norm_label": "normalizestoreconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L474"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_isopeningfloatcorrectionevent",
-      "label": "isOpeningFloatCorrectionEvent()",
-      "norm_label": "isopeningfloatcorrectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L307"
+      "id": "storeconfigv2_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L135"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_isregistersessioncorrectionevent",
-      "label": "isRegisterSessionCorrectionEvent()",
-      "norm_label": "isregistersessioncorrectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L323"
+      "id": "storeconfigv2_patchv2config",
+      "label": "patchV2Config()",
+      "norm_label": "patchv2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L498"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_runopeningfloatcorrection",
-      "label": "runOpeningFloatCorrection()",
-      "norm_label": "runopeningfloatcorrection()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L759"
+      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
+      "label": "removeLegacyRootKeysFromConfig()",
+      "norm_label": "removelegacyrootkeysfromconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L606"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L267"
+      "id": "storeconfigv2_tov2config",
+      "label": "toV2Config()",
+      "norm_label": "tov2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L231"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L116"
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L283"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L318"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "gettransactions_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L55"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L46"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L16"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 600,
@@ -82086,100 +82338,100 @@
     {
       "community": 61,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L116"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L46"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L16"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
     },
     {
@@ -82365,101 +82617,101 @@
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 620,
@@ -82644,101 +82896,101 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 630,
@@ -82923,101 +83175,101 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 640,
@@ -84534,6 +84786,24 @@
     {
       "community": 698,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 698,
+      "file_type": "code",
+      "id": "procurement_index_procurementroute",
+      "label": "ProcurementRoute()",
+      "norm_label": "procurementroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
       "norm_label": "published.index.tsx",
@@ -84541,7 +84811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -84550,274 +84820,256 @@
       "source_location": "L9"
     },
     {
-      "community": 699,
+      "community": 7,
       "file_type": "code",
-      "id": "index_index",
-      "label": "Index()",
-      "norm_label": "index()",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
       "source_location": "L1"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_builddocumentationstatus",
-      "label": "buildDocumentationStatus()",
-      "norm_label": "builddocumentationstatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L275"
+      "id": "registersessionview_applycloseoutcommandresult",
+      "label": "applyCloseoutCommandResult()",
+      "norm_label": "applycloseoutcommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_buildemptyhistorymetric",
-      "label": "buildEmptyHistoryMetric()",
-      "norm_label": "buildemptyhistorymetric()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L569"
+      "id": "registersessionview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L511"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_buildgraphifystatus",
-      "label": "buildGraphifyStatus()",
-      "norm_label": "buildgraphifystatus()",
-      "source_file": "scripts/harness-scorecard.ts",
+      "id": "registersessionview_builddepositsubmissionkey",
+      "label": "buildDepositSubmissionKey()",
+      "norm_label": "builddepositsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L276"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L2140"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L280"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L329"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_formatregisterheadername",
+      "label": "formatRegisterHeaderName()",
+      "norm_label": "formatregisterheadername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L337"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_formatsessioncode",
+      "label": "formatSessionCode()",
+      "norm_label": "formatsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L356"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
       "source_location": "L299"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_buildinferentialsummarynote",
-      "label": "buildInferentialSummaryNote()",
-      "norm_label": "buildinferentialsummarynote()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L315"
+      "id": "registersessionview_formatstoredamountforinput",
+      "label": "formatStoredAmountForInput()",
+      "norm_label": "formatstoredamountforinput()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L288"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L327"
+      "id": "registersessionview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L292"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_collectharnessscorecard",
-      "label": "collectHarnessScorecard()",
-      "norm_label": "collectharnessscorecard()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L752"
+      "id": "registersessionview_getnumericeventmetadata",
+      "label": "getNumericEventMetadata()",
+      "norm_label": "getnumericeventmetadata()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L314"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_countmissingsnippets",
-      "label": "countMissingSnippets()",
-      "norm_label": "countmissingsnippets()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L268"
+      "id": "registersessionview_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L368"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_createfilesystem",
-      "label": "createFileSystem()",
-      "norm_label": "createfilesystem()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L224"
+      "id": "registersessionview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L360"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_extractscenarionames",
-      "label": "extractScenarioNames()",
-      "norm_label": "extractscenarionames()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L255"
+      "id": "registersessionview_handleauthenticatedcloseoutstaff",
+      "label": "handleAuthenticatedCloseoutStaff()",
+      "norm_label": "handleauthenticatedcloseoutstaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L691"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_extractscenariosection",
-      "label": "extractScenarioSection()",
-      "norm_label": "extractscenariosection()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L233"
+      "id": "registersessionview_handleopeningfloatapprovalapproved",
+      "label": "handleOpeningFloatApprovalApproved()",
+      "norm_label": "handleopeningfloatapprovalapproved()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L805"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L203"
+      "id": "registersessionview_handlerecorddeposit",
+      "label": "handleRecordDeposit()",
+      "norm_label": "handlerecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L538"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_getdocumentedscenarioexpectations",
-      "label": "getDocumentedScenarioExpectations()",
-      "norm_label": "getdocumentedscenarioexpectations()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L470"
+      "id": "registersessionview_handlereviewcloseout",
+      "label": "handleReviewCloseout()",
+      "norm_label": "handlereviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L618"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L389"
+      "id": "registersessionview_handlesubmitcloseout",
+      "label": "handleSubmitCloseout()",
+      "norm_label": "handlesubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L581"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_inspectappdocumentation",
-      "label": "inspectAppDocumentation()",
-      "norm_label": "inspectappdocumentation()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L406"
+      "id": "registersessionview_handlesubmitopeningfloatcorrection",
+      "label": "handleSubmitOpeningFloatCorrection()",
+      "norm_label": "handlesubmitopeningfloatcorrection()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L635"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_inspectgraphifyartifacts",
-      "label": "inspectGraphifyArtifacts()",
-      "norm_label": "inspectgraphifyartifacts()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L724"
+      "id": "registersessionview_iscloseoutrejectionevent",
+      "label": "isCloseoutRejectionEvent()",
+      "norm_label": "iscloseoutrejectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L303"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_inspectinferentialartifact",
-      "label": "inspectInferentialArtifact()",
-      "norm_label": "inspectinferentialartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L483"
+      "id": "registersessionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L272"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_inspectinferentialhistory",
-      "label": "inspectInferentialHistory()",
-      "norm_label": "inspectinferentialhistory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L579"
+      "id": "registersessionview_isopeningfloatcorrectionevent",
+      "label": "isOpeningFloatCorrectionEvent()",
+      "norm_label": "isopeningfloatcorrectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L307"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_inspectruntimetrendartifact",
-      "label": "inspectRuntimeTrendArtifact()",
-      "norm_label": "inspectruntimetrendartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L631"
+      "id": "registersessionview_isregistersessioncorrectionevent",
+      "label": "isRegisterSessionCorrectionEvent()",
+      "norm_label": "isregistersessioncorrectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L323"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_inspectruntimetrendhistory",
-      "label": "inspectRuntimeTrendHistory()",
-      "norm_label": "inspectruntimetrendhistory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L674"
+      "id": "registersessionview_runopeningfloatcorrection",
+      "label": "runOpeningFloatCorrection()",
+      "norm_label": "runopeningfloatcorrection()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L759"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_scorecard_ishealthyinferentialstatus",
-      "label": "isHealthyInferentialStatus()",
-      "norm_label": "ishealthyinferentialstatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_isruntimescenarioname",
-      "label": "isRuntimeScenarioName()",
-      "norm_label": "isruntimescenarioname()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_listdirectory",
-      "label": "listDirectory()",
-      "norm_label": "listdirectory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_readtextfile",
-      "label": "readTextFile()",
-      "norm_label": "readtextfile()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L220"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_runharnessscorecard",
-      "label": "runHarnessScorecard()",
-      "norm_label": "runharnessscorecard()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L842"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_scorecard_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "scripts_harness_scorecard_ts",
-      "label": "harness-scorecard.ts",
-      "norm_label": "harness-scorecard.ts",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L1"
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L267"
     },
     {
       "community": 70,
@@ -84912,6 +85164,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "index_index",
+      "label": "Index()",
+      "norm_label": "index()",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
       "norm_label": "athenaloginreadyview()",
@@ -84919,7 +85189,7 @@
       "source_location": "L4"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -84928,7 +85198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -84937,7 +85207,7 @@
       "source_location": "L13"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -84946,7 +85216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -84955,7 +85225,7 @@
       "source_location": "L5"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -84964,7 +85234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
       "label": "view-patterns.tsx",
@@ -84973,7 +85243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "view_patterns_cn",
       "label": "cn()",
@@ -84982,7 +85252,7 @@
       "source_location": "L142"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -84991,7 +85261,7 @@
       "source_location": "L17"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -85000,7 +85270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -85009,7 +85279,7 @@
       "source_location": "L15"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -85018,7 +85288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -85027,7 +85297,7 @@
       "source_location": "L12"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -85036,7 +85306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -85045,7 +85315,7 @@
       "source_location": "L5"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -85054,7 +85324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -85063,31 +85333,13 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
       "norm_label": "popovershowcase()",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
-      "label": "Sheet.stories.tsx",
-      "norm_label": "sheet.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "sheet_stories_sheetshowcase",
-      "label": "SheetShowcase()",
-      "norm_label": "sheetshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L14"
     },
     {
       "community": 71,
@@ -85182,6 +85434,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
+      "label": "Sheet.stories.tsx",
+      "norm_label": "sheet.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "sheet_stories_sheetshowcase",
+      "label": "SheetShowcase()",
+      "norm_label": "sheetshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
       "norm_label": "tooltip.stories.tsx",
@@ -85189,7 +85459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -85198,7 +85468,7 @@
       "source_location": "L13"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -85207,7 +85477,7 @@
       "source_location": "L5"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -85216,7 +85486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -85225,7 +85495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -85234,7 +85504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -85243,7 +85513,7 @@
       "source_location": "L4"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -85252,7 +85522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -85261,7 +85531,7 @@
       "source_location": "L27"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -85270,7 +85540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -85279,7 +85549,7 @@
       "source_location": "L4"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -85288,7 +85558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -85297,7 +85567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -85306,7 +85576,7 @@
       "source_location": "L5"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -85315,7 +85585,7 @@
       "source_location": "L10"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -85324,7 +85594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -85333,31 +85603,13 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
       "norm_label": "productcardloadingskeleton()",
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "auth_authcomponent",
-      "label": "AuthComponent()",
-      "norm_label": "authcomponent()",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
     },
     {
       "community": 72,
@@ -85452,6 +85704,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "auth_authcomponent",
+      "label": "AuthComponent()",
+      "norm_label": "authcomponent()",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
       "norm_label": "tobagsummaryitems()",
@@ -85459,7 +85729,7 @@
       "source_location": "L39"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -85468,7 +85738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -85477,7 +85747,7 @@
       "source_location": "L18"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -85486,7 +85756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -85495,7 +85765,7 @@
       "source_location": "L71"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -85504,7 +85774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -85513,7 +85783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -85522,7 +85792,7 @@
       "source_location": "L12"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -85531,7 +85801,7 @@
       "source_location": "L6"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -85540,7 +85810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -85549,7 +85819,7 @@
       "source_location": "L18"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -85558,7 +85828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -85567,7 +85837,7 @@
       "source_location": "L10"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -85576,7 +85846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -85585,7 +85855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -85594,7 +85864,7 @@
       "source_location": "L8"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -85603,31 +85873,13 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
       "norm_label": "paymentsection()",
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
     },
     {
       "community": 73,
@@ -85722,6 +85974,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
       "norm_label": "derivecheckoutstate()",
@@ -85729,7 +85999,7 @@
       "source_location": "L3"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -85738,7 +86008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -85747,7 +86017,7 @@
       "source_location": "L8"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -85756,7 +86026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -85765,7 +86035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -85774,7 +86044,7 @@
       "source_location": "L12"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -85783,7 +86053,7 @@
       "source_location": "L77"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -85792,7 +86062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -85801,7 +86071,7 @@
       "source_location": "L161"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -85810,7 +86080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -85819,7 +86089,7 @@
       "source_location": "L3"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -85828,7 +86098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -85837,7 +86107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -85846,7 +86116,7 @@
       "source_location": "L4"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -85855,7 +86125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -85864,7 +86134,7 @@
       "source_location": "L14"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -85873,30 +86143,12 @@
       "source_location": "L27"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
       "norm_label": "filter.tsx",
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L1"
     },
     {
@@ -85992,6 +86244,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
       "norm_label": "resolvehomepagecontent()",
@@ -85999,7 +86269,7 @@
       "source_location": "L13"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -86008,7 +86278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -86017,7 +86287,7 @@
       "source_location": "L47"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -86026,7 +86296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -86035,7 +86305,7 @@
       "source_location": "L7"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -86044,7 +86314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -86053,7 +86323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -86062,7 +86332,7 @@
       "source_location": "L17"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -86071,7 +86341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -86080,7 +86350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -86089,7 +86359,7 @@
       "source_location": "L12"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -86098,7 +86368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -86107,7 +86377,7 @@
       "source_location": "L7"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -86116,7 +86386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -86125,7 +86395,7 @@
       "source_location": "L45"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -86134,7 +86404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -86143,31 +86413,13 @@
       "source_location": "L5"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
       "norm_label": "onsaleproduct.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
     },
     {
       "community": 75,
@@ -86262,6 +86514,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
       "norm_label": "productattributes.tsx",
@@ -86269,7 +86539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -86278,7 +86548,7 @@
       "source_location": "L3"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -86287,7 +86557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -86296,7 +86566,7 @@
       "source_location": "L37"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -86305,7 +86575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -86314,7 +86584,7 @@
       "source_location": "L79"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -86323,7 +86593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -86332,7 +86602,7 @@
       "source_location": "L87"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -86341,7 +86611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -86350,7 +86620,7 @@
       "source_location": "L8"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -86359,7 +86629,7 @@
       "source_location": "L12"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -86368,7 +86638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -86377,7 +86647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -86386,7 +86656,7 @@
       "source_location": "L18"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -86395,7 +86665,7 @@
       "source_location": "L10"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -86404,7 +86674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -86413,31 +86683,13 @@
       "source_location": "L11"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
       "norm_label": "orderpointsdisplay.tsx",
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "label": "PastOrdersRewards.tsx",
-      "norm_label": "pastordersrewards.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "pastordersrewards_handleclaimpoints",
-      "label": "handleClaimPoints()",
-      "norm_label": "handleclaimpoints()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L59"
     },
     {
       "community": 76,
@@ -86523,6 +86775,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
+      "label": "PastOrdersRewards.tsx",
+      "norm_label": "pastordersrewards.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "pastordersrewards_handleclaimpoints",
+      "label": "handleClaimPoints()",
+      "norm_label": "handleclaimpoints()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
       "norm_label": "rewardspanel.tsx",
@@ -86530,7 +86800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -86539,7 +86809,7 @@
       "source_location": "L33"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -86548,7 +86818,7 @@
       "source_location": "L19"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -86557,7 +86827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -86566,7 +86836,7 @@
       "source_location": "L4"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -86575,7 +86845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -86584,7 +86854,7 @@
       "source_location": "L22"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -86593,7 +86863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -86602,7 +86872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -86611,7 +86881,7 @@
       "source_location": "L11"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -86620,7 +86890,7 @@
       "source_location": "L3"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -86629,7 +86899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -86638,7 +86908,7 @@
       "source_location": "L3"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -86647,7 +86917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -86656,7 +86926,7 @@
       "source_location": "L9"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -86665,7 +86935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -86674,31 +86944,13 @@
       "source_location": "L66"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
       "norm_label": "leaveareviewmodal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "label": "UpsellModalSuccess.tsx",
-      "norm_label": "upsellmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "label": "UpsellModalSuccess()",
-      "norm_label": "upsellmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L19"
     },
     {
       "community": 77,
@@ -86784,6 +87036,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
+      "label": "UpsellModalSuccess.tsx",
+      "norm_label": "upsellmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
+      "file_type": "code",
+      "id": "upsellmodalsuccess_upsellmodalsuccess",
+      "label": "UpsellModalSuccess()",
+      "norm_label": "upsellmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
       "norm_label": "welcomebackmodalsuccess.tsx",
@@ -86791,7 +87061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -86800,7 +87070,7 @@
       "source_location": "L13"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -86809,7 +87079,7 @@
       "source_location": "L46"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -86818,7 +87088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -86827,7 +87097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -86836,7 +87106,7 @@
       "source_location": "L46"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -86845,7 +87115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -86854,7 +87124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -86863,7 +87133,7 @@
       "source_location": "L15"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -86872,7 +87142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -86881,7 +87151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -86890,7 +87160,7 @@
       "source_location": "L5"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -86899,7 +87169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -86908,7 +87178,7 @@
       "source_location": "L14"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -86917,7 +87187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -86926,7 +87196,7 @@
       "source_location": "L29"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -86935,30 +87205,12 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
       "norm_label": "usegetactivecheckoutsession()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "label": "useGetProduct.tsx",
-      "norm_label": "usegetproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "usegetproduct_usegetproductquery",
-      "label": "useGetProductQuery()",
-      "norm_label": "usegetproductquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5"
     },
     {
@@ -87045,6 +87297,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
+      "label": "useGetProduct.tsx",
+      "norm_label": "usegetproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
+      "file_type": "code",
+      "id": "usegetproduct_usegetproductquery",
+      "label": "useGetProductQuery()",
+      "norm_label": "usegetproductquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
       "norm_label": "usegetproductfilters.ts",
@@ -87052,7 +87322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -87061,7 +87331,7 @@
       "source_location": "L3"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -87070,7 +87340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -87079,7 +87349,7 @@
       "source_location": "L4"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -87088,7 +87358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -87097,7 +87367,7 @@
       "source_location": "L4"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -87106,7 +87376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -87115,7 +87385,7 @@
       "source_location": "L9"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -87124,7 +87394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -87133,7 +87403,7 @@
       "source_location": "L17"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -87142,7 +87412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -87151,7 +87421,7 @@
       "source_location": "L5"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -87160,7 +87430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -87169,7 +87439,7 @@
       "source_location": "L15"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -87178,7 +87448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -87187,7 +87457,7 @@
       "source_location": "L18"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -87196,31 +87466,13 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
       "norm_label": "useproductreminder()",
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "label": "usePromoAlert.tsx",
-      "norm_label": "usepromoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "usepromoalert_usepromoalert",
-      "label": "usePromoAlert()",
-      "norm_label": "usepromoalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L16"
     },
     {
       "community": 79,
@@ -87306,6 +87558,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
+      "label": "usePromoAlert.tsx",
+      "norm_label": "usepromoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
+      "file_type": "code",
+      "id": "usepromoalert_usepromoalert",
+      "label": "usePromoAlert()",
+      "norm_label": "usepromoalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
       "norm_label": "usequeryenabled.ts",
@@ -87313,7 +87583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -87322,7 +87592,7 @@
       "source_location": "L3"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -87331,7 +87601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -87340,7 +87610,7 @@
       "source_location": "L11"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -87349,7 +87619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -87358,7 +87628,7 @@
       "source_location": "L3"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -87367,7 +87637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -87376,7 +87646,7 @@
       "source_location": "L7"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -87385,7 +87655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -87394,7 +87664,7 @@
       "source_location": "L4"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -87403,7 +87673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -87412,7 +87682,7 @@
       "source_location": "L14"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -87421,7 +87691,7 @@
       "source_location": "L4"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -87430,7 +87700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -87439,7 +87709,7 @@
       "source_location": "L7"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -87448,7 +87718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -87457,7 +87727,7 @@
       "source_location": "L6"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -87466,265 +87736,256 @@
       "source_location": "L1"
     },
     {
-      "community": 799,
+      "community": 8,
       "file_type": "code",
-      "id": "checkout_usecheckoutsessionqueries",
-      "label": "useCheckoutSessionQueries()",
-      "norm_label": "usecheckoutsessionqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L10"
+      "id": "harness_scorecard_builddocumentationstatus",
+      "label": "buildDocumentationStatus()",
+      "norm_label": "builddocumentationstatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L275"
     },
     {
-      "community": 799,
+      "community": 8,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "id": "harness_scorecard_buildemptyhistorymetric",
+      "label": "buildEmptyHistoryMetric()",
+      "norm_label": "buildemptyhistorymetric()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_buildgraphifystatus",
+      "label": "buildGraphifyStatus()",
+      "norm_label": "buildgraphifystatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_buildinferentialsummarynote",
+      "label": "buildInferentialSummaryNote()",
+      "norm_label": "buildinferentialsummarynote()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L315"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L327"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_collectharnessscorecard",
+      "label": "collectHarnessScorecard()",
+      "norm_label": "collectharnessscorecard()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L752"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_countmissingsnippets",
+      "label": "countMissingSnippets()",
+      "norm_label": "countmissingsnippets()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_createfilesystem",
+      "label": "createFileSystem()",
+      "norm_label": "createfilesystem()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_extractscenarionames",
+      "label": "extractScenarioNames()",
+      "norm_label": "extractscenarionames()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_extractscenariosection",
+      "label": "extractScenarioSection()",
+      "norm_label": "extractscenariosection()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L203"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_getdocumentedscenarioexpectations",
+      "label": "getDocumentedScenarioExpectations()",
+      "norm_label": "getdocumentedscenarioexpectations()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L470"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L389"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectappdocumentation",
+      "label": "inspectAppDocumentation()",
+      "norm_label": "inspectappdocumentation()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L406"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectgraphifyartifacts",
+      "label": "inspectGraphifyArtifacts()",
+      "norm_label": "inspectgraphifyartifacts()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectinferentialartifact",
+      "label": "inspectInferentialArtifact()",
+      "norm_label": "inspectinferentialartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L483"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectinferentialhistory",
+      "label": "inspectInferentialHistory()",
+      "norm_label": "inspectinferentialhistory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L579"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectruntimetrendartifact",
+      "label": "inspectRuntimeTrendArtifact()",
+      "norm_label": "inspectruntimetrendartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L631"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectruntimetrendhistory",
+      "label": "inspectRuntimeTrendHistory()",
+      "norm_label": "inspectruntimetrendhistory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L674"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_ishealthyinferentialstatus",
+      "label": "isHealthyInferentialStatus()",
+      "norm_label": "ishealthyinferentialstatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_isruntimescenarioname",
+      "label": "isRuntimeScenarioName()",
+      "norm_label": "isruntimescenarioname()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_listdirectory",
+      "label": "listDirectory()",
+      "norm_label": "listdirectory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_readtextfile",
+      "label": "readTextFile()",
+      "norm_label": "readtextfile()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_runharnessscorecard",
+      "label": "runHarnessScorecard()",
+      "norm_label": "runharnessscorecard()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L842"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_scorecard_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "scripts_harness_scorecard_ts",
+      "label": "harness-scorecard.ts",
+      "norm_label": "harness-scorecard.ts",
+      "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
-      "label": "ProcurementView.tsx",
-      "norm_label": "procurementview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_addrecommendationtodraft",
-      "label": "addRecommendationToDraft()",
-      "norm_label": "addrecommendationtodraft()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L606"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_buildvendoroptions",
-      "label": "buildVendorOptions()",
-      "norm_label": "buildvendoroptions()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L476"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_canreceivepurchaseorder",
-      "label": "canReceivePurchaseOrder()",
-      "norm_label": "canreceivepurchaseorder()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L472"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_countrecommendationsformode",
-      "label": "countRecommendationsForMode()",
-      "norm_label": "countrecommendationsformode()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L391"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_formatlinecount",
-      "label": "formatLineCount()",
-      "norm_label": "formatlinecount()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L239"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_formatoptionaldate",
-      "label": "formatOptionalDate()",
-      "norm_label": "formatoptionaldate()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_formatpurchaseordercount",
-      "label": "formatPurchaseOrderCount()",
-      "norm_label": "formatpurchaseordercount()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_formatstatus",
-      "label": "formatStatus()",
-      "norm_label": "formatstatus()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L170"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_formatunitcount",
-      "label": "formatUnitCount()",
-      "norm_label": "formatunitcount()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L235"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getcontinuitystatecopy",
-      "label": "getContinuityStateCopy()",
-      "norm_label": "getcontinuitystatecopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L176"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getmodeemptystatecopy",
-      "label": "getModeEmptyStateCopy()",
-      "norm_label": "getmodeemptystatecopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L400"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getnextlifecycleactions",
-      "label": "getNextLifecycleActions()",
-      "norm_label": "getnextlifecycleactions()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L455"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getrecommendationcountcopy",
-      "label": "getRecommendationCountCopy()",
-      "norm_label": "getrecommendationcountcopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L435"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getrecommendationstatenote",
-      "label": "getRecommendationStateNote()",
-      "norm_label": "getrecommendationstatenote()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L313"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getuniquepurchaseorderreferences",
-      "label": "getUniquePurchaseOrderReferences()",
-      "norm_label": "getuniquepurchaseorderreferences()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L247"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_getuniquevendorcount",
-      "label": "getUniqueVendorCount()",
-      "norm_label": "getuniquevendorcount()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L266"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_handleadvancepurchaseordertoordered",
-      "label": "handleAdvancePurchaseOrderToOrdered()",
-      "norm_label": "handleadvancepurchaseordertoordered()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L814"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_handlecreatedraftpurchaseorders",
-      "label": "handleCreateDraftPurchaseOrders()",
-      "norm_label": "handlecreatedraftpurchaseorders()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L699"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_handlequickaddvendor",
-      "label": "handleQuickAddVendor()",
-      "norm_label": "handlequickaddvendor()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L647"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_handleupdatepurchaseorderstatus",
-      "label": "handleUpdatePurchaseOrderStatus()",
-      "norm_label": "handleupdatepurchaseorderstatus()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L787"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_hasinboundpurchaseordercover",
-      "label": "hasInboundPurchaseOrderCover()",
-      "norm_label": "hasinboundpurchaseordercover()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L286"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_hasmixedpurchaseordercover",
-      "label": "hasMixedPurchaseOrderCover()",
-      "norm_label": "hasmixedpurchaseordercover()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L298"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_hasplannedpurchaseordercover",
-      "label": "hasPlannedPurchaseOrderCover()",
-      "norm_label": "hasplannedpurchaseordercover()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L274"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_isrecommendationvisible",
-      "label": "isRecommendationVisible()",
-      "norm_label": "isrecommendationvisible()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L349"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_removedraftline",
-      "label": "removeDraftLine()",
-      "norm_label": "removedraftline()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L641"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "procurementview_updatedraftline",
-      "label": "updateDraftLine()",
-      "norm_label": "updatedraftline()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L630"
     },
     {
       "community": 80,
@@ -87810,6 +88071,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "checkout_usecheckoutsessionqueries",
+      "label": "useCheckoutSessionQueries()",
+      "norm_label": "usecheckoutsessionqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 800,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
       "norm_label": "useinventoryqueries()",
@@ -87817,7 +88096,7 @@
       "source_location": "L6"
     },
     {
-      "community": 800,
+      "community": 801,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -87826,7 +88105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -87835,7 +88114,7 @@
       "source_location": "L5"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -87844,7 +88123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -87853,7 +88132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -87862,7 +88141,7 @@
       "source_location": "L5"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -87871,7 +88150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -87880,7 +88159,7 @@
       "source_location": "L14"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -87889,7 +88168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -87898,7 +88177,7 @@
       "source_location": "L9"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -87907,7 +88186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -87916,7 +88195,7 @@
       "source_location": "L10"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -87925,7 +88204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -87934,7 +88213,7 @@
       "source_location": "L11"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -87943,7 +88222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -87952,7 +88231,7 @@
       "source_location": "L6"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -87961,31 +88240,13 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
       "norm_label": "useuserqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "useroffers_useuseroffersqueries",
-      "label": "useUserOffersQueries()",
-      "norm_label": "useuseroffersqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L6"
     },
     {
       "community": 81,
@@ -88071,6 +88332,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
+      "file_type": "code",
+      "id": "useroffers_useuseroffersqueries",
+      "label": "useUserOffersQueries()",
+      "norm_label": "useuseroffersqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
@@ -88078,7 +88357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 810,
+      "community": 811,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -88087,7 +88366,7 @@
       "source_location": "L10"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -88096,7 +88375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -88105,7 +88384,7 @@
       "source_location": "L15"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -88114,7 +88393,7 @@
       "source_location": "L14"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -88123,7 +88402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -88132,7 +88411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -88141,7 +88420,7 @@
       "source_location": "L6"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -88150,7 +88429,7 @@
       "source_location": "L14"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -88159,7 +88438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -88168,7 +88447,7 @@
       "source_location": "L8"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -88177,7 +88456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -88186,7 +88465,7 @@
       "source_location": "L14"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -88195,7 +88474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -88204,7 +88483,7 @@
       "source_location": "L13"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -88213,7 +88492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -88222,31 +88501,13 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
       "norm_label": "privacypolicy()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
     },
     {
       "community": 82,
@@ -88332,6 +88593,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
       "norm_label": "shop.product.$productslug.tsx",
@@ -88339,7 +88618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 820,
+      "community": 821,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -88348,7 +88627,7 @@
       "source_location": "L16"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -88357,7 +88636,7 @@
       "source_location": "L6"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -88366,7 +88645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -88375,7 +88654,7 @@
       "source_location": "L10"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -88384,7 +88663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -88393,7 +88672,7 @@
       "source_location": "L21"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -88402,7 +88681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -88411,7 +88690,7 @@
       "source_location": "L33"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -88420,7 +88699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -88429,7 +88708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -88438,7 +88717,7 @@
       "source_location": "L193"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -88447,7 +88726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -88456,7 +88735,7 @@
       "source_location": "L7"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -88465,7 +88744,7 @@
       "source_location": "L10"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -88474,7 +88753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -88483,30 +88762,12 @@
       "source_location": "L32"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
       "norm_label": "architecture-boundary-check.ts",
       "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "deploy_qa_vps_test_readrepofile",
-      "label": "readRepoFile()",
-      "norm_label": "readrepofile()",
-      "source_file": "scripts/deploy-qa-vps.test.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "scripts_deploy_qa_vps_test_ts",
-      "label": "deploy-qa-vps.test.ts",
-      "norm_label": "deploy-qa-vps.test.ts",
-      "source_file": "scripts/deploy-qa-vps.test.ts",
       "source_location": "L1"
     },
     {
@@ -88593,6 +88854,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "deploy_qa_vps_test_readrepofile",
+      "label": "readRepoFile()",
+      "norm_label": "readrepofile()",
+      "source_file": "scripts/deploy-qa-vps.test.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 830,
+      "file_type": "code",
+      "id": "scripts_deploy_qa_vps_test_ts",
+      "label": "deploy-qa-vps.test.ts",
+      "norm_label": "deploy-qa-vps.test.ts",
+      "source_file": "scripts/deploy-qa-vps.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
       "norm_label": "runcommand()",
@@ -88600,7 +88879,7 @@
       "source_location": "L16"
     },
     {
-      "community": 830,
+      "community": 831,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
@@ -88609,7 +88888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -88618,7 +88897,7 @@
       "source_location": "L211"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -88627,7 +88906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -88636,7 +88915,7 @@
       "source_location": "L85"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -88645,7 +88924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -88654,7 +88933,7 @@
       "source_location": "L15"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -88663,7 +88942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -88672,7 +88951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -88681,7 +88960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -88690,7 +88969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -88699,21 +88978,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_app_ts",
-      "label": "app.ts",
-      "norm_label": "app.ts",
-      "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1"
     },
     {
@@ -88800,6 +89070,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_app_ts",
+      "label": "app.ts",
+      "norm_label": "app.ts",
+      "source_file": "packages/athena-webapp/convex/app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
       "norm_label": "auth.config.js",
@@ -88807,7 +89086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -88816,7 +89095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -88825,7 +89104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -88834,7 +89113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -88843,7 +89122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -88852,7 +89131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -88861,7 +89140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -88870,21 +89149,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
       "norm_label": "crons.ts",
       "source_file": "packages/athena-webapp/convex/crons.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
-      "label": "FeedbackRequest.tsx",
-      "norm_label": "feedbackrequest.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1"
     },
     {
@@ -88971,6 +89241,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
+      "label": "FeedbackRequest.tsx",
+      "norm_label": "feedbackrequest.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
       "norm_label": "neworderadmin.tsx",
@@ -88978,7 +89257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -88987,7 +89266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -88996,7 +89275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -89005,7 +89284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -89014,7 +89293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -89023,7 +89302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -89032,7 +89311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
@@ -89041,21 +89320,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/organizations.ts",
       "source_location": "L1"
     },
     {
@@ -89133,6 +89403,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
@@ -89140,7 +89419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -89149,7 +89428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -89158,7 +89437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
@@ -89167,7 +89446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
@@ -89176,7 +89455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
@@ -89185,7 +89464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
@@ -89194,7 +89473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
@@ -89203,21 +89482,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
-      "label": "paystack.ts",
-      "norm_label": "paystack.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/paystack.ts",
       "source_location": "L1"
     },
     {
@@ -89295,6 +89565,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
+      "label": "paystack.ts",
+      "norm_label": "paystack.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/paystack.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -89302,7 +89581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -89311,7 +89590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
@@ -89320,7 +89599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -89329,7 +89608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
@@ -89338,7 +89617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
@@ -89347,7 +89626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
@@ -89356,7 +89635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
@@ -89365,21 +89644,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/moneyMovement/routes/index.ts",
       "source_location": "L1"
     },
     {
@@ -89457,6 +89727,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/moneyMovement/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
       "norm_label": "health.test.ts",
@@ -89464,7 +89743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -89473,7 +89752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -89482,7 +89761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -89491,7 +89770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -89500,7 +89779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -89509,7 +89788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -89518,7 +89797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -89527,21 +89806,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
       "norm_label": "expensetransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
       "source_location": "L1"
     },
     {
@@ -89619,6 +89889,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
@@ -89626,7 +89905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -89635,7 +89914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -89644,7 +89923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -89653,7 +89932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -89662,7 +89941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -89671,7 +89950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -89680,7 +89959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
@@ -89689,21 +89968,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
       "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1"
     },
     {
@@ -90006,6 +90276,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
@@ -90013,7 +90292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -90022,7 +90301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -90031,7 +90310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -90040,7 +90319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -90049,7 +90328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -90058,7 +90337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -90067,7 +90346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -90076,21 +90355,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "label": "normalize.test.ts",
-      "norm_label": "normalize.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1"
     },
     {
@@ -90168,6 +90438,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
+      "label": "normalize.test.ts",
+      "norm_label": "normalize.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -90175,7 +90454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -90184,7 +90463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -90193,7 +90472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -90202,7 +90481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -90211,7 +90490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -90220,7 +90499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
@@ -90229,7 +90508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
@@ -90238,21 +90517,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
-      "label": "getRegisterState.test.ts",
-      "norm_label": "getregisterstate.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
       "source_location": "L1"
     },
     {
@@ -90330,6 +90600,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
+      "label": "getRegisterState.test.ts",
+      "norm_label": "getregisterstate.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
       "norm_label": "possessiontracing.test.ts",
@@ -90337,7 +90616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -90346,7 +90625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -90355,7 +90634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -90364,7 +90643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -90373,7 +90652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -90382,7 +90661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -90391,7 +90670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -90400,21 +90679,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
       "source_file": "packages/athena-webapp/convex/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
-      "label": "appVerificationCode.ts",
-      "norm_label": "appverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
       "source_location": "L1"
     },
     {
@@ -90492,6 +90762,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
+      "label": "appVerificationCode.ts",
+      "norm_label": "appverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
       "norm_label": "athenauser.ts",
@@ -90499,7 +90778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -90508,7 +90787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -90517,7 +90796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -90526,7 +90805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -90535,7 +90814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -90544,7 +90823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -90553,7 +90832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -90562,21 +90841,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
       "norm_label": "inventoryhold.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/inventoryHold.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -90654,6 +90924,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
@@ -90661,7 +90940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -90670,7 +90949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -90679,7 +90958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -90688,7 +90967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -90697,7 +90976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -90706,7 +90985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -90715,7 +90994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -90724,21 +91003,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
       "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
-      "label": "workflowTraceEvent.ts",
-      "norm_label": "workflowtraceevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
       "source_location": "L1"
     },
     {
@@ -90816,6 +91086,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
+      "label": "workflowTraceEvent.ts",
+      "norm_label": "workflowtraceevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
       "norm_label": "workflowtracelookup.ts",
@@ -90823,7 +91102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -90832,7 +91111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -90841,7 +91120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -90850,7 +91129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -90859,7 +91138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -90868,7 +91147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -90877,7 +91156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -90886,21 +91165,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
       "norm_label": "registersession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
-      "label": "staffCredential.ts",
-      "norm_label": "staffcredential.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
       "source_location": "L1"
     },
     {
@@ -90978,6 +91248,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
+      "label": "staffCredential.ts",
+      "norm_label": "staffcredential.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
       "norm_label": "staffprofile.ts",
@@ -90985,7 +91264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -90994,7 +91273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -91003,7 +91282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -91012,7 +91291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -91021,7 +91300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -91030,7 +91309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -91039,7 +91318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -91048,21 +91327,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1"
     },
     {
@@ -91140,6 +91410,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
       "norm_label": "possessionitem.ts",
@@ -91147,7 +91426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -91156,7 +91435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -91165,7 +91444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -91174,7 +91453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -91183,7 +91462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -91192,7 +91471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -91201,7 +91480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -91210,21 +91489,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
       "norm_label": "servicecatalog.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
-      "label": "serviceInventoryUsage.ts",
-      "norm_label": "serviceinventoryusage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
       "source_location": "L1"
     },
     {
@@ -91302,6 +91572,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
+      "label": "serviceInventoryUsage.ts",
+      "norm_label": "serviceinventoryusage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
       "norm_label": "cyclecountdraft.ts",
@@ -91309,7 +91588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -91318,7 +91597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -91327,7 +91606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -91336,7 +91615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -91345,7 +91624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -91354,7 +91633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -91363,7 +91642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -91372,21 +91651,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -91464,6 +91734,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
       "norm_label": "checkoutsession.ts",
@@ -91471,7 +91750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -91480,7 +91759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -91489,7 +91768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -91498,7 +91777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -91507,7 +91786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -91516,7 +91795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -91525,7 +91804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -91534,21 +91813,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,19 +8,19 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1594
-- Graph nodes: 4477
-- Graph edges: 4271
+- Graph nodes: 4487
+- Graph edges: 4286
 - Communities: 1522
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `harness-check.ts` (32 edges, Community 2) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
-- `harness-behavior.ts` (30 edges, Community 3) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
-- `harness-generate.ts` (30 edges, Community 4) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
-- `harness-scorecard.ts` (27 edges, Community 7) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
-- `RegisterSessionView.tsx` (27 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `ProcurementView.tsx` (35 edges, Community 2) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
+- `harness-check.ts` (32 edges, Community 3) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
+- `harness-behavior.ts` (30 edges, Community 4) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
+- `harness-generate.ts` (30 edges, Community 5) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
+- `harness-scorecard.ts` (27 edges, Community 8) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,9 +17,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `RegisterSessionView.tsx` (27 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
-- `storeConfigV2.ts` (27 edges, Community 5) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `ProcurementView.tsx` (26 edges, Community 8) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
+- `ProcurementView.tsx` (35 edges, Community 2) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
+- `RegisterSessionView.tsx` (27 edges, Community 7) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `storeConfigV2.ts` (27 edges, Community 6) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `posSessions.ts` (23 edges, Community 10) - [`packages/athena-webapp/convex/inventory/posSessions.ts`](../../../packages/athena-webapp/convex/inventory/posSessions.ts)
 - `cycleCountDrafts.ts` (21 edges, Community 11) - [`packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts`](../../../packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts)
 

--- a/packages/athena-webapp/src/components/app-sidebar.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.tsx
@@ -12,7 +12,7 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import type { ComponentType, ReactNode } from "react";
+import type { ComponentType, MouseEventHandler, ReactNode } from "react";
 import {
   BadgePercent,
   ChartNoAxesCombined,
@@ -43,7 +43,7 @@ import {
   Banknote,
   ChevronRight,
 } from "lucide-react";
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import useGetActiveStore from "../hooks/useGetActiveStore";
 import { useGetActiveOrganization } from "../hooks/useGetOrganizations";
 import { useNewOrderNotification } from "../hooks/useNewOrderNotification";
@@ -61,6 +61,7 @@ function SidebarMenuCollapsible({
   disabled,
   defaultOpen = false,
   isActive = false,
+  onClick,
   children,
 }: {
   icon: ComponentType<{ className?: string }>;
@@ -68,6 +69,7 @@ function SidebarMenuCollapsible({
   disabled?: boolean;
   defaultOpen?: boolean;
   isActive?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   children: ReactNode;
 }) {
   return (
@@ -81,6 +83,7 @@ function SidebarMenuCollapsible({
             disabled={disabled}
             className="w-full"
             isActive={isActive}
+            onClick={onClick}
           >
             <Icon className="w-4 h-4" />
             <p className="font-medium">{label}</p>
@@ -97,6 +100,7 @@ export function AppSidebar() {
   const { activeStore } = useGetActiveStore();
   const { activeOrganization } = useGetActiveOrganization();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const productsWithNoImages = useGetUnresolvedProducts();
 
@@ -140,6 +144,8 @@ export function AppSidebar() {
 
   const { canAccessOperations, hasFullAdminAccess } = usePermissions();
   const isOperationsRoute = location.pathname.includes("/operations");
+  const isOrdersRoute = location.pathname.includes("/orders");
+  const isProductsRoute = location.pathname.includes("/products");
 
   if (!activeStore || !activeOrganization) {
     return null;
@@ -194,7 +200,17 @@ export function AppSidebar() {
                 defaultOpen={isOperationsRoute}
                 disabled={!canAccessOperations()}
                 icon={Layers}
+                isActive={isOperationsRoute}
                 label="Operations"
+                onClick={() => {
+                  void navigate({
+                    to: "/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments",
+                    params: {
+                      orgUrlSlug: activeOrganization.slug,
+                      storeUrlSlug: activeStore.slug,
+                    },
+                  });
+                }}
               >
                 <SidebarMenuSub>
                   <SidebarMenuSubItem>
@@ -315,9 +331,20 @@ export function AppSidebar() {
 
               {/* Orders section */}
               <SidebarMenuCollapsible
+                defaultOpen={isOrdersRoute}
                 icon={ShoppingBag}
+                isActive={isOrdersRoute}
                 label="Orders"
                 disabled={!hasFullAdminAccess}
+                onClick={() => {
+                  void navigate({
+                    to: "/$orgUrlSlug/store/$storeUrlSlug/orders",
+                    params: {
+                      orgUrlSlug: activeOrganization.slug,
+                      storeUrlSlug: activeStore.slug,
+                    },
+                  });
+                }}
               >
                 <SidebarMenuSub>
                   <SidebarMenuSubItem>
@@ -477,7 +504,21 @@ export function AppSidebar() {
               </SidebarMenuCollapsible>
 
               {/* Products section */}
-              <SidebarMenuCollapsible icon={Tag} label="Products">
+              <SidebarMenuCollapsible
+                defaultOpen={isProductsRoute}
+                icon={Tag}
+                isActive={isProductsRoute}
+                label="Products"
+                onClick={() => {
+                  void navigate({
+                    to: "/$orgUrlSlug/store/$storeUrlSlug/products",
+                    params: {
+                      orgUrlSlug: activeOrganization.slug,
+                      storeUrlSlug: activeStore.slug,
+                    },
+                  });
+                }}
+              >
                 {categories?.map((category) => (
                   <SidebarMenuSub key={category._id}>
                     <SidebarMenuSubItem>

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -329,6 +329,85 @@ function rowMatchesAvailabilityFilter(
   return availability === "all_available" ? isAllAvailable : !isAllAvailable;
 }
 
+export function SkuDetailPanel({
+  activeInventoryItem,
+}: {
+  activeInventoryItem: InventorySnapshotItem | null;
+}) {
+  const activeInventoryItemDetails = activeInventoryItem
+    ? getSkuDetailEntries(activeInventoryItem)
+    : [];
+
+  return (
+    <div className="space-y-layout-sm">
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        SKU detail
+      </p>
+      <div className="overflow-hidden rounded-md bg-muted/30">
+        {activeInventoryItem?.imageUrl ? (
+          <img
+            alt={getInventoryItemDisplayName(activeInventoryItem)}
+            className="aspect-square w-full object-cover"
+            src={activeInventoryItem.imageUrl}
+          />
+        ) : (
+          <div className="flex aspect-square w-full items-center justify-center bg-muted">
+            <Package
+              aria-label="SKU image unavailable"
+              className="h-8 w-8 text-muted-foreground"
+            />
+          </div>
+        )}
+      </div>
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          {activeInventoryItem ? (
+            <p className="line-clamp-2 text-sm font-medium text-foreground">
+              {getInventoryItemDisplayName(activeInventoryItem)}
+            </p>
+          ) : null}
+          {activeInventoryItem?.productId ? (
+            <Link
+              aria-label={`View product detail for ${getInventoryItemDisplayName(
+                activeInventoryItem,
+              )}`}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              params={(prev) => ({
+                ...prev,
+                orgUrlSlug: prev.orgUrlSlug!,
+                productSlug: activeInventoryItem.productId!,
+                storeUrlSlug: prev.storeUrlSlug!,
+              })}
+              search={{
+                o: getOrigin(),
+                variant: activeInventoryItem?.sku || undefined,
+              }}
+              to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug"
+            >
+              View
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          ) : null}
+        </div>
+        {activeInventoryItemDetails.length > 0 ? (
+          <dl className="grid grid-cols-2 gap-x-layout-md gap-y-layout-md pt-layout-xs text-xs">
+            {activeInventoryItemDetails.map((entry) => (
+              <div className="min-w-0" key={entry.label}>
+                <dt className="font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                  {entry.label}
+                </dt>
+                <dd className="mt-0.5 truncate text-foreground capitalize">
+                  {entry.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function StockAdjustmentWorkspaceContent({
   cycleCountDraft,
   cycleCountDraftSummary,
@@ -682,9 +761,6 @@ export function StockAdjustmentWorkspaceContent({
     inventoryItems.find((item) => item._id === activeInventoryItemId) ??
     inventoryItems[0] ??
     null;
-  const activeInventoryItemDetails = activeInventoryItem
-    ? getSkuDetailEntries(activeInventoryItem)
-    : [];
   const inventoryState = useMemo(() => {
     const totals = inventoryItems.reduce(
       (current, item) => {
@@ -1810,72 +1886,7 @@ export function StockAdjustmentWorkspaceContent({
         </section>
 
         <section className="space-y-layout-xl rounded-lg border border-border bg-surface-raised px-layout-md py-layout-md shadow-surface">
-          <div className="space-y-layout-sm">
-            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              SKU detail
-            </p>
-            <div className="overflow-hidden rounded-md bg-muted/30">
-              {activeInventoryItem?.imageUrl ? (
-                <img
-                  alt={getInventoryItemDisplayName(activeInventoryItem)}
-                  className="aspect-square w-full object-cover"
-                  src={activeInventoryItem.imageUrl}
-                />
-              ) : (
-                <div className="flex aspect-square w-full items-center justify-center bg-muted">
-                  <Package
-                    aria-label="SKU image unavailable"
-                    className="h-8 w-8 text-muted-foreground"
-                  />
-                </div>
-              )}
-            </div>
-            <div className="space-y-4">
-              <div className="flex items-start justify-between gap-3">
-                {activeInventoryItem ? (
-                  <p className="line-clamp-2 text-sm font-medium text-foreground">
-                    {getInventoryItemDisplayName(activeInventoryItem)}
-                  </p>
-                ) : null}
-                {activeInventoryItem?.productId ? (
-                  <Link
-                    aria-label={`View product detail for ${getInventoryItemDisplayName(
-                      activeInventoryItem,
-                    )}`}
-                    className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                    params={(prev) => ({
-                      ...prev,
-                      orgUrlSlug: prev.orgUrlSlug!,
-                      productSlug: activeInventoryItem.productId!,
-                      storeUrlSlug: prev.storeUrlSlug!,
-                    })}
-                    search={{
-                      o: getOrigin(),
-                      variant: activeInventoryItem?.sku || undefined,
-                    }}
-                    to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug"
-                  >
-                    View
-                    <ExternalLink className="h-3 w-3" />
-                  </Link>
-                ) : null}
-              </div>
-              {activeInventoryItemDetails.length > 0 ? (
-                <dl className="grid grid-cols-2 gap-x-layout-md gap-y-layout-md pt-layout-xs text-xs">
-                  {activeInventoryItemDetails.map((entry) => (
-                    <div className="min-w-0" key={entry.label}>
-                      <dt className="font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                        {entry.label}
-                      </dt>
-                      <dd className="mt-0.5 truncate text-foreground capitalize">
-                        {entry.value}
-                      </dd>
-                    </div>
-                  ))}
-                </dl>
-              ) : null}
-            </div>
-          </div>
+          <SkuDetailPanel activeInventoryItem={activeInventoryItem} />
 
           <div className="space-y-2">
             <Label htmlFor="reason-code">Reason code</Label>

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "~/convex/_generated/dataModel";
 import { ProcurementView, ProcurementViewContent } from "./ProcurementView";
@@ -106,6 +106,13 @@ const plannedRecommendation = {
   suggestedOrderQuantity: 0,
 };
 
+const singlePlannedRecommendation = {
+  ...plannedRecommendation,
+  plannedPurchaseOrderCount: 1,
+  plannedPurchaseOrderQuantity: 4,
+  plannedPurchaseOrders: [plannedRecommendation.plannedPurchaseOrders[0]],
+};
+
 const inboundRecommendation = {
   _id: "sku-3" as Id<"productSku">,
   guidance: "Ordered purchase-order work is covering this SKU.",
@@ -211,9 +218,32 @@ const resolvedWithInboundRecommendation = {
   status: "resolved" as const,
 };
 
+const inventoryItems = [
+  {
+    _id: "sku-1" as Id<"productSku">,
+    barcode: "BAR-CW-18",
+    colorName: "Natural black",
+    imageUrl: "https://cdn.example.com/closure-wig.jpg",
+    inventoryCount: 0,
+    productCategory: "Hair",
+    productName: "Closure Wig",
+    quantityAvailable: 0,
+    sku: "CW-18",
+  },
+  {
+    _id: "sku-4" as Id<"productSku">,
+    inventoryCount: 0,
+    productName: "Lace Adhesive",
+    quantityAvailable: 0,
+    reservedQuantity: 2,
+    sku: "LA-01",
+  },
+];
+
 const baseProps: React.ComponentProps<typeof ProcurementViewContent> = {
   hasActiveStore: true,
   hasFullAdminAccess: true,
+  inventoryItems,
   isLoadingPermissions: false,
   isLoadingProcurement: false,
   purchaseOrders: [
@@ -292,6 +322,11 @@ async function chooseDraftVendor(
 describe("ProcurementViewContent", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+    HTMLElement.prototype.scrollIntoView = vi.fn();
     vi.clearAllMocks();
     mockedHooks.useAuth.mockReturnValue({
       isLoading: false,
@@ -382,8 +417,10 @@ describe("ProcurementViewContent", () => {
       ),
     ).toHaveClass("bg-muted/50", "text-muted-foreground");
     expect(
-      screen.getByText("Next action: order this purchase order."),
-    ).toBeInTheDocument();
+      screen.queryByText(
+        "Draft purchase-order work exists but is not inbound cover yet.",
+      ),
+    ).not.toBeInTheDocument();
     expect(
       within(screen.getByText("Frontal Wig").closest("article")!).getAllByRole(
         "button",
@@ -447,6 +484,106 @@ describe("ProcurementViewContent", () => {
     );
   });
 
+  it("moves a completed single planned action to inbound", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onModeChange = vi.fn();
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        mode="planned"
+        onModeChange={onModeChange}
+        recommendations={[singlePlannedRecommendation]}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByText("Frontal Wig").closest("article")!).getByRole(
+        "button",
+        { name: /mark ordered/i },
+      ),
+    );
+
+    expect(mockedHooks.advancePurchaseOrderToOrdered).toHaveBeenCalledWith({
+      purchaseOrderId: "po-draft",
+    });
+    expect(onModeChange).toHaveBeenCalledWith("inbound");
+  });
+
+  it("lets planned rows add another purchase order through the reorder draft", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        mode="planned"
+        recommendations={[singlePlannedRecommendation]}
+      />,
+    );
+
+    const plannedRow = screen.getByText("Frontal Wig").closest("article")!;
+    const addPurchaseOrderButton = within(plannedRow).getByRole("button", {
+      name: /add purchase order/i,
+    });
+
+    expect(addPurchaseOrderButton).toHaveClass("w-[160px]");
+    expect(addPurchaseOrderButton).toHaveClass("text-action-neutral");
+    expect(addPurchaseOrderButton).not.toHaveClass("text-action-workflow");
+
+    await user.click(addPurchaseOrderButton);
+
+    const draftPanel = screen
+      .getByText("Vendor-backed purchase order draft")
+      .closest("section")!;
+    const openPurchaseOrdersSection = screen
+      .getByText("Open purchase orders")
+      .closest("section")!;
+    expect(within(draftPanel).getByText("Frontal Wig")).toBeInTheDocument();
+    expect(within(draftPanel).getByLabelText("Quantity")).toHaveValue("1");
+    expect(draftPanel).toHaveClass("order-2");
+    expect(openPurchaseOrdersSection).toHaveClass("order-3");
+    expect(
+      within(plannedRow).getByRole("button", { name: /in draft/i }),
+    ).toHaveClass("w-[160px]");
+    expect(
+      within(plannedRow).getByRole("button", { name: /in draft/i }),
+    ).toBeDisabled();
+  });
+
+  it("lets inbound rows add another purchase order through the reorder draft", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        mode="inbound"
+        recommendations={[inboundRecommendation]}
+      />,
+    );
+
+    const inboundRow = screen.getByText("Silk Press Kit").closest("article")!;
+
+    await user.click(
+      within(inboundRow).getByRole("button", {
+        name: /add purchase order/i,
+      }),
+    );
+
+    const draftPanel = screen
+      .getByText("Vendor-backed purchase order draft")
+      .closest("section")!;
+
+    expect(within(draftPanel).getByText("Silk Press Kit")).toBeInTheDocument();
+    expect(within(draftPanel).getByLabelText("Quantity")).toHaveValue("1");
+    expect(draftPanel).toHaveClass("order-2");
+    expect(
+      within(inboundRow).getByRole("button", { name: /in draft/i }),
+    ).toBeDisabled();
+  });
+
   it("keeps mixed planned and inbound purchase orders actionable in both modes", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
@@ -466,9 +603,7 @@ describe("ProcurementViewContent", () => {
       "text-foreground",
     );
     expect(
-      within(plannedRow).getByText(
-        "Next action: order the remaining purchase order. 5 units already inbound.",
-      ),
+      within(plannedRow).getByText("5 units already inbound."),
     ).toBeInTheDocument();
     expect(within(plannedRow).getByText("PO-DRAFT-2")).toBeInTheDocument();
     expect(within(plannedRow).getByText("PO-ORDERED")).toBeInTheDocument();
@@ -506,11 +641,49 @@ describe("ProcurementViewContent", () => {
     const resolvedRow = screen.getByText("Logitech Mouse").closest("article")!;
     expect(within(resolvedRow).getByText("Handled")).toBeInTheDocument();
     expect(
-      within(resolvedRow).getByText(
-        "Stock pressure is handled. 1 unit still inbound.",
-      ),
+      within(resolvedRow).getByText("1 unit still inbound."),
     ).toBeInTheDocument();
     expect(resolvedRow).toHaveTextContent(/0\s*planned,\s*1\s*inbound/i);
+  });
+
+  it("paginates stock pressure rows ten at a time", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const resolvedRecommendations = Array.from({ length: 12 }, (_, index) => ({
+      ...resolvedWithInboundRecommendation,
+      _id: `sku-resolved-${index + 1}` as Id<"productSku">,
+      productName: `Handled SKU ${index + 1}`,
+      sku: `HS-${index + 1}`,
+    }));
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        mode="resolved"
+        recommendations={resolvedRecommendations}
+      />,
+    );
+
+    expect(screen.getByText("Showing 1-10 of 12")).toBeInTheDocument();
+    expect(screen.getByText("Handled SKU 1")).toBeInTheDocument();
+    expect(screen.getByText("Handled SKU 10")).toBeInTheDocument();
+    expect(screen.queryByText("Handled SKU 11")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(screen.getByText("Showing 11-12 of 12")).toBeInTheDocument();
+    expect(screen.queryByText("Handled SKU 1")).not.toBeInTheDocument();
+    expect(screen.getByText("Handled SKU 11")).toBeInTheDocument();
+    expect(screen.getByText("Handled SKU 12")).toBeInTheDocument();
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+
+    expect(screen.getByText("Showing 1-10 of 12")).toBeInTheDocument();
+    expect(screen.getByText("Handled SKU 1")).toBeInTheDocument();
   });
 
   it("requires vendors before creating grouped draft purchase orders", async () => {
@@ -547,6 +720,111 @@ describe("ProcurementViewContent", () => {
       storeId: "store-1",
       vendorId: "vendor-1",
     });
+  });
+
+  it("moves a single needs-action draft to planned after purchase-order creation", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onModeChange = vi.fn();
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        onModeChange={onModeChange}
+        recommendations={[exposedRecommendation]}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByText("Closure Wig").closest("article")!).getByRole(
+        "button",
+        { name: /add to draft/i },
+      ),
+    );
+    await chooseDraftVendor(user, "Closure Wig", "Main Vendor");
+    await user.click(
+      screen.getByRole("button", { name: /create draft purchase orders/i }),
+    );
+
+    expect(mockedHooks.createPurchaseOrder).toHaveBeenCalledWith({
+      lineItems: [
+        {
+          description: "Closure Wig (CW-18)",
+          orderedQuantity: 6,
+          productSkuId: "sku-1",
+          unitCost: 0,
+        },
+      ],
+      storeId: "store-1",
+      vendorId: "vendor-1",
+    });
+    expect(onModeChange).toHaveBeenCalledWith("planned");
+  });
+
+  it("shows the stock-adjustment SKU detail panel when a pressure row is selected", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(<ProcurementViewContent {...baseProps} />);
+
+    expect(screen.queryByText("SKU detail")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Closure Wig").closest("article")!);
+
+    const skuDetailPanel = screen.getByText("SKU detail").closest("section")!;
+    expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(
+      within(skuDetailPanel).getByText("Natural Black Closure Wig"),
+    ).toBeInTheDocument();
+    expect(within(skuDetailPanel).getByText("CW-18")).toBeInTheDocument();
+    expect(within(skuDetailPanel).getByText("BAR-CW-18")).toBeInTheDocument();
+    expect(within(skuDetailPanel).getByText("Hair")).toBeInTheDocument();
+    await user.click(
+      within(screen.getByText("Lace Adhesive").closest("article")!).getByRole(
+        "button",
+        { name: /add purchase order/i },
+      ),
+    );
+
+    expect(
+      within(skuDetailPanel).getByText("Natural Black Closure Wig"),
+    ).toBeInTheDocument();
+    const draftPanel = screen
+      .getByText("Vendor-backed purchase order draft")
+      .closest("section")!;
+    const openPurchaseOrdersSection = screen
+      .getByText("Open purchase orders")
+      .closest("section")!;
+    expect(skuDetailPanel).toHaveClass("order-1");
+    expect(draftPanel).toHaveClass("order-2");
+    expect(openPurchaseOrdersSection).toHaveClass("order-3");
+  });
+
+  it("keeps draft quantity entry editable without forcing zero or leading zeroes", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(<ProcurementViewContent {...baseProps} />);
+
+    await user.click(
+      within(screen.getByText("Closure Wig").closest("article")!).getByRole(
+        "button",
+        { name: /add to draft/i },
+      ),
+    );
+
+    const quantityInput = screen.getByLabelText("Quantity");
+
+    await user.clear(quantityInput);
+
+    expect(quantityInput).toHaveValue("");
+    expect(
+      screen.getByRole("button", { name: /create draft purchase orders/i }),
+    ).toBeDisabled();
+
+    await user.type(quantityInput, "04");
+
+    expect(quantityInput).toHaveValue("4");
   });
 
   it("quick-adds a vendor and assigns it to the first draft line missing one", async () => {
@@ -600,7 +878,7 @@ describe("ProcurementViewContent", () => {
     await user.click(
       within(screen.getByText("Lace Adhesive").closest("article")!).getByRole(
         "button",
-        { name: /add to draft/i },
+        { name: /add purchase order/i },
       ),
     );
     await chooseDraftVendor(user, "Closure Wig", "Main Vendor");
@@ -657,6 +935,67 @@ describe("ProcurementViewContent", () => {
     expect(mockedHooks.updatePurchaseOrderStatus).not.toHaveBeenCalled();
   });
 
+  it("navigates from a purchase-order summary to the owning row and tab", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(<ProcurementViewContent {...baseProps} />);
+
+    expect(screen.queryByText("Frontal Wig")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /po-draft/i }));
+
+    const plannedRow = screen.getByText("Frontal Wig").closest("article")!;
+    expect(screen.getByRole("tab", { name: /planned/i })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(plannedRow).toHaveClass("bg-muted/30");
+    await waitFor(() =>
+      expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center",
+      }),
+    );
+  });
+
+  it("opens the owning page when a purchase-order summary targets a paginated row", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const fillerRecommendations = Array.from({ length: 10 }, (_, index) => ({
+      ...plannedRecommendation,
+      _id: `sku-planned-filler-${index + 1}` as Id<"productSku">,
+      plannedPurchaseOrders: [
+        {
+          ...plannedRecommendation.plannedPurchaseOrders[0],
+          poNumber: `PO-FILLER-${index + 1}`,
+          purchaseOrderId: `po-filler-${index + 1}` as Id<"purchaseOrder">,
+        },
+      ],
+      productName: `Planned SKU ${index + 1}`,
+      sku: `PS-${index + 1}`,
+    }));
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        recommendations={[...fillerRecommendations, singlePlannedRecommendation]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /po-draft/i }));
+
+    expect(screen.getByText("Showing 11-11 of 11")).toBeInTheDocument();
+    expect(screen.queryByText("Planned SKU 1")).not.toBeInTheDocument();
+    expect(screen.getByText("Frontal Wig")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center",
+      }),
+    );
+  });
+
   it("opens receiving from ordered purchase orders", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
@@ -665,11 +1004,19 @@ describe("ProcurementViewContent", () => {
 
     await user.click(screen.getByRole("tab", { name: /inbound/i }));
     const silkPressRow = screen.getByText("Silk Press Kit").closest("article")!;
+    const receiveButton = within(silkPressRow).getByRole("button", {
+      name: /receive/i,
+    });
+
+    expect(receiveButton).toHaveClass("w-[92px]");
     await user.click(
-      within(silkPressRow).getByRole("button", { name: /receive/i }),
+      receiveButton,
     );
 
     expect(screen.getByText("Receiving form for po-1")).toBeInTheDocument();
+    expect(
+      within(silkPressRow).getByRole("button", { name: /receiving/i }),
+    ).toHaveClass("w-[92px]");
     expect(
       within(silkPressRow).getByRole("button", { name: /receiving/i }),
     ).toBeDisabled();
@@ -753,6 +1100,7 @@ describe("ProcurementViewContent", () => {
       "skip",
       "skip",
       "skip",
+      "skip",
     ]);
   });
 
@@ -778,6 +1126,7 @@ describe("ProcurementViewContent", () => {
       "skip",
       "skip",
       "skip",
+      "skip",
     ]);
   });
 
@@ -785,11 +1134,13 @@ describe("ProcurementViewContent", () => {
     mockedHooks.useQuery
       .mockReturnValueOnce([])
       .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
       .mockReturnValueOnce([]);
 
     render(<ProcurementView />);
 
     expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
+      { storeId: "store-1" },
       { storeId: "store-1" },
       { storeId: "store-1" },
       { status: "active", storeId: "store-1" },

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 
@@ -19,6 +19,10 @@ import {
 } from "../ui/select";
 import { Skeleton } from "../ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
+import {
+  SkuDetailPanel,
+  type InventorySnapshotItem,
+} from "../operations/StockAdjustmentWorkspace";
 import { ReceivingView } from "./ReceivingView";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
@@ -110,7 +114,7 @@ type PurchaseOrderDetail = ProcurementOrderSummary & {
 type ReorderDraftLine = {
   productName: string;
   productSkuId: Id<"productSku">;
-  quantity: number;
+  quantityInput: string;
   sku?: string | null;
   vendorId?: Id<"vendor">;
 };
@@ -120,6 +124,9 @@ type ProcurementViewContentProps = {
   hasFullAdminAccess: boolean;
   isLoadingPermissions: boolean;
   isLoadingProcurement: boolean;
+  inventoryItems: InventorySnapshotItem[];
+  mode?: ProcurementMode;
+  onModeChange?: (mode: ProcurementMode) => void;
   purchaseOrders: ProcurementOrderSummary[];
   recommendations: ReplenishmentRecommendation[];
   storeId?: Id<"store">;
@@ -136,6 +143,8 @@ const MODE_OPTIONS = [
 ] as const;
 
 type ProcurementMode = (typeof MODE_OPTIONS)[number]["value"];
+
+const RECOMMENDATIONS_PER_PAGE = 10;
 
 const UNASSIGNED_VENDOR_VALUE = "unassigned-vendor";
 
@@ -319,16 +328,11 @@ function getRecommendationStateNote(
   const plannedPurchaseOrderCount = recommendation.plannedPurchaseOrderCount;
 
   if (hasMixedPurchaseOrderCover(recommendation)) {
-    const remainingAction =
-      plannedPurchaseOrderCount === 1
-        ? "order the remaining purchase order"
-        : `order ${plannedPurchaseOrderCount} remaining purchase orders`;
-
-    return `Next action: ${remainingAction}. ${formatUnitCount(inboundUnits)} already inbound.`;
+    return `${formatUnitCount(inboundUnits)} already inbound.`;
   }
 
   if (PLANNED_STATES.includes(recommendation.status)) {
-    return "Next action: order this purchase order.";
+    return null;
   }
 
   if (INBOUND_STATES.includes(recommendation.status)) {
@@ -337,10 +341,10 @@ function getRecommendationStateNote(
 
   if (recommendation.status === "resolved") {
     if (inboundUnits > 0) {
-      return `Stock pressure is handled. ${formatUnitCount(inboundUnits)} still inbound.`;
+      return `${formatUnitCount(inboundUnits)} still inbound.`;
     }
 
-    return "Stock pressure is handled.";
+    return null;
   }
 
   return null;
@@ -473,6 +477,22 @@ function canReceivePurchaseOrder(status: PurchaseOrderStatus) {
   return status === "ordered" || status === "partially_received";
 }
 
+function getPurchaseOrderMode(status: PurchaseOrderStatus): ProcurementMode {
+  switch (status) {
+    case "draft":
+    case "submitted":
+    case "approved":
+      return "planned";
+    case "ordered":
+    case "partially_received":
+      return "inbound";
+    case "received":
+      return "resolved";
+    case "cancelled":
+      return "exceptions";
+  }
+}
+
 function buildVendorOptions(
   vendors: VendorSummary[],
   createdVendors: VendorSummary[],
@@ -488,17 +508,40 @@ function buildVendorOptions(
   );
 }
 
+function sanitizeDraftQuantityInput(value: string) {
+  const digits = value.replace(/\D/g, "");
+
+  if (digits === "") {
+    return "";
+  }
+
+  return digits.replace(/^0+(?=\d)/, "");
+}
+
+function parseDraftLineQuantity(line: ReorderDraftLine) {
+  if (line.quantityInput.trim() === "") {
+    return null;
+  }
+
+  const quantity = Number(line.quantityInput);
+
+  return Number.isInteger(quantity) && quantity > 0 ? quantity : null;
+}
+
 export function ProcurementViewContent({
   hasActiveStore,
   hasFullAdminAccess,
   isLoadingPermissions,
   isLoadingProcurement,
+  inventoryItems,
+  mode: controlledMode,
+  onModeChange,
   purchaseOrders,
   recommendations,
   storeId,
   vendors,
 }: ProcurementViewContentProps) {
-  const [mode, setMode] = useState<ProcurementMode>("needs_action");
+  const [localMode, setLocalMode] = useState<ProcurementMode>("needs_action");
   const [draftLines, setDraftLines] = useState<ReorderDraftLine[]>([]);
   const [quickAddVendorName, setQuickAddVendorName] = useState("");
   const [createdVendors, setCreatedVendors] = useState<VendorSummary[]>([]);
@@ -509,6 +552,17 @@ export function ProcurementViewContent({
     useState<Id<"purchaseOrder"> | null>(null);
   const [selectedReceivingOrderId, setSelectedReceivingOrderId] =
     useState<Id<"purchaseOrder"> | null>(null);
+  const [selectedProductSkuId, setSelectedProductSkuId] =
+    useState<Id<"productSku"> | null>(null);
+  const [selectedPurchaseOrderId, setSelectedPurchaseOrderId] =
+    useState<Id<"purchaseOrder"> | null>(null);
+  const [recommendationPage, setRecommendationPage] = useState(1);
+  const [scrollTargetProductSkuId, setScrollTargetProductSkuId] =
+    useState<Id<"productSku"> | null>(null);
+  const stockPressureSectionRef = useRef<HTMLElement | null>(null);
+  const recommendationRowRefs = useRef(
+    new Map<Id<"productSku">, HTMLElement>(),
+  );
 
   const createVendor = useMutation(api.stockOps.vendors.createVendorCommand);
   const createPurchaseOrder = useMutation(
@@ -531,6 +585,180 @@ export function ProcurementViewContent({
     () => buildVendorOptions(vendors, createdVendors),
     [createdVendors, vendors],
   );
+  const inventoryItemsById = useMemo(
+    () => new Map(inventoryItems.map((item) => [item._id, item])),
+    [inventoryItems],
+  );
+  const mode = controlledMode ?? localMode;
+  const handleModeChange = (nextMode: ProcurementMode) => {
+    setRecommendationPage(1);
+
+    if (!controlledMode) {
+      setLocalMode(nextMode);
+    }
+
+    onModeChange?.(nextMode);
+  };
+  const handleRecommendationPageChange = (nextPage: number) => {
+    setRecommendationPage(nextPage);
+    window.requestAnimationFrame(() => {
+      stockPressureSectionRef.current?.scrollIntoView({
+        block: "start",
+        behavior: "smooth",
+      });
+    });
+  };
+
+  const visibleRecommendations = useMemo(
+    () =>
+      recommendations.filter((recommendation) =>
+        isRecommendationVisible(recommendation, mode),
+      ),
+    [mode, recommendations],
+  );
+  const recommendationPageCount = Math.max(
+    Math.ceil(visibleRecommendations.length / RECOMMENDATIONS_PER_PAGE),
+    1,
+  );
+  const clampedRecommendationPage = Math.min(
+    recommendationPage,
+    recommendationPageCount,
+  );
+  const paginatedRecommendations = visibleRecommendations.slice(
+    (clampedRecommendationPage - 1) * RECOMMENDATIONS_PER_PAGE,
+    clampedRecommendationPage * RECOMMENDATIONS_PER_PAGE,
+  );
+  const paginationStart =
+    visibleRecommendations.length === 0
+      ? 0
+      : (clampedRecommendationPage - 1) * RECOMMENDATIONS_PER_PAGE + 1;
+  const paginationEnd = Math.min(
+    clampedRecommendationPage * RECOMMENDATIONS_PER_PAGE,
+    visibleRecommendations.length,
+  );
+  const activePurchaseOrders = purchaseOrders
+    .filter((order) =>
+      ACTIVE_PROCUREMENT_STATUSES.includes(
+        order.status as (typeof ACTIVE_PROCUREMENT_STATUSES)[number],
+      ),
+    )
+    .sort((left, right) => {
+      const leftExpectedAt = left.expectedAt ?? Number.MAX_SAFE_INTEGER;
+      const rightExpectedAt = right.expectedAt ?? Number.MAX_SAFE_INTEGER;
+
+      if (leftExpectedAt !== rightExpectedAt) {
+        return leftExpectedAt - rightExpectedAt;
+      }
+
+      return left.poNumber.localeCompare(right.poNumber);
+    });
+  const selectedReceivingPurchaseOrder = activePurchaseOrders.find(
+    (purchaseOrder) => purchaseOrder._id === selectedReceivingOrderId,
+  );
+  const selectedInventoryItem = selectedProductSkuId
+    ? (inventoryItemsById.get(selectedProductSkuId) ?? null)
+    : null;
+  const visiblePurchaseOrders = activePurchaseOrders.slice(0, 6);
+  const hiddenPurchaseOrderCount = Math.max(
+    activePurchaseOrders.length - visiblePurchaseOrders.length,
+    0,
+  );
+  const draftHasMissingVendor = draftLines.some((line) => !line.vendorId);
+  const draftHasInvalidQuantity = draftLines.some(
+    (line) => parseDraftLineQuantity(line) === null,
+  );
+  const recommendationCounts: Record<ProcurementMode, number> = {
+    all: countRecommendationsForMode(recommendations, "all"),
+    exceptions: countRecommendationsForMode(recommendations, "exceptions"),
+    inbound: countRecommendationsForMode(recommendations, "inbound"),
+    needs_action: countRecommendationsForMode(recommendations, "needs_action"),
+    planned: countRecommendationsForMode(recommendations, "planned"),
+    resolved: countRecommendationsForMode(recommendations, "resolved"),
+  };
+  const summary = {
+    activePurchaseOrders: activePurchaseOrders.length,
+    exceptions: recommendationCounts.exceptions,
+    inbound: recommendationCounts.inbound,
+    needsAction: recommendationCounts.needs_action,
+    planned: recommendationCounts.planned,
+    resolved: recommendationCounts.resolved,
+  };
+  const shouldPrioritizeReorderDraft = draftLines.length > 0;
+  const plannedPurchaseOrderActionCount = visibleRecommendations.reduce(
+    (count, recommendation) =>
+      count +
+      getUniquePurchaseOrderReferences(recommendation).filter(
+        (purchaseOrder) =>
+          getPurchaseOrderMode(purchaseOrder.status) === "planned",
+      ).length,
+    0,
+  );
+
+  useEffect(() => {
+    if (recommendationPage > recommendationPageCount) {
+      setRecommendationPage(recommendationPageCount);
+    }
+  }, [recommendationPage, recommendationPageCount]);
+
+  useEffect(() => {
+    if (!scrollTargetProductSkuId) return;
+    if (
+      !visibleRecommendations.some(
+        (recommendation) => recommendation._id === scrollTargetProductSkuId,
+      )
+    ) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      recommendationRowRefs.current
+        .get(scrollTargetProductSkuId)
+        ?.scrollIntoView({
+          block: "center",
+          behavior: "smooth",
+        });
+      setScrollTargetProductSkuId(null);
+    });
+  }, [scrollTargetProductSkuId, visibleRecommendations]);
+
+  function getRecommendationForPurchaseOrder(
+    purchaseOrderId: Id<"purchaseOrder">,
+  ) {
+    return recommendations.find((recommendation) =>
+      getUniquePurchaseOrderReferences(recommendation).some(
+        (purchaseOrder) => purchaseOrder.purchaseOrderId === purchaseOrderId,
+      ),
+    );
+  }
+
+  function handlePurchaseOrderSummaryClick(
+    purchaseOrder: ProcurementOrderSummary,
+  ) {
+    const recommendation = getRecommendationForPurchaseOrder(purchaseOrder._id);
+    const nextMode = getPurchaseOrderMode(purchaseOrder.status);
+
+    setSelectedPurchaseOrderId(purchaseOrder._id);
+    if (recommendation) {
+      setSelectedProductSkuId(recommendation._id);
+      setScrollTargetProductSkuId(recommendation._id);
+    }
+    handleModeChange(nextMode);
+    if (recommendation) {
+      const nextVisibleRecommendations = recommendations.filter(
+        (nextRecommendation) =>
+          isRecommendationVisible(nextRecommendation, nextMode),
+      );
+      const recommendationIndex = nextVisibleRecommendations.findIndex(
+        (nextRecommendation) => nextRecommendation._id === recommendation._id,
+      );
+
+      if (recommendationIndex >= 0) {
+        setRecommendationPage(
+          Math.floor(recommendationIndex / RECOMMENDATIONS_PER_PAGE) + 1,
+        );
+      }
+    }
+  }
 
   if (isLoadingPermissions) {
     return null;
@@ -557,52 +785,6 @@ export function ProcurementViewContent({
     return null;
   }
 
-  const visibleRecommendations = recommendations.filter((recommendation) =>
-    isRecommendationVisible(recommendation, mode),
-  );
-  const activePurchaseOrders = purchaseOrders
-    .filter((order) =>
-      ACTIVE_PROCUREMENT_STATUSES.includes(
-        order.status as (typeof ACTIVE_PROCUREMENT_STATUSES)[number],
-      ),
-    )
-    .sort((left, right) => {
-      const leftExpectedAt = left.expectedAt ?? Number.MAX_SAFE_INTEGER;
-      const rightExpectedAt = right.expectedAt ?? Number.MAX_SAFE_INTEGER;
-
-      if (leftExpectedAt !== rightExpectedAt) {
-        return leftExpectedAt - rightExpectedAt;
-      }
-
-      return left.poNumber.localeCompare(right.poNumber);
-    });
-  const selectedReceivingPurchaseOrder = activePurchaseOrders.find(
-    (purchaseOrder) => purchaseOrder._id === selectedReceivingOrderId,
-  );
-  const visiblePurchaseOrders = activePurchaseOrders.slice(0, 6);
-  const hiddenPurchaseOrderCount = Math.max(
-    activePurchaseOrders.length - visiblePurchaseOrders.length,
-    0,
-  );
-  const draftHasMissingVendor = draftLines.some((line) => !line.vendorId);
-  const draftHasInvalidQuantity = draftLines.some((line) => line.quantity <= 0);
-  const recommendationCounts: Record<ProcurementMode, number> = {
-    all: countRecommendationsForMode(recommendations, "all"),
-    exceptions: countRecommendationsForMode(recommendations, "exceptions"),
-    inbound: countRecommendationsForMode(recommendations, "inbound"),
-    needs_action: countRecommendationsForMode(recommendations, "needs_action"),
-    planned: countRecommendationsForMode(recommendations, "planned"),
-    resolved: countRecommendationsForMode(recommendations, "resolved"),
-  };
-  const summary = {
-    activePurchaseOrders: activePurchaseOrders.length,
-    exceptions: recommendationCounts.exceptions,
-    inbound: recommendationCounts.inbound,
-    needsAction: recommendationCounts.needs_action,
-    planned: recommendationCounts.planned,
-    resolved: recommendationCounts.resolved,
-  };
-
   function addRecommendationToDraft(
     recommendation: ReplenishmentRecommendation,
   ) {
@@ -620,7 +802,9 @@ export function ProcurementViewContent({
         {
           productName: recommendation.productName,
           productSkuId: recommendation._id,
-          quantity: Math.max(1, recommendation.suggestedOrderQuantity),
+          quantityInput: String(
+            Math.max(1, recommendation.suggestedOrderQuantity),
+          ),
           sku: recommendation.sku,
         },
       ];
@@ -629,7 +813,7 @@ export function ProcurementViewContent({
 
   function updateDraftLine(
     productSkuId: Id<"productSku">,
-    updates: Partial<Pick<ReorderDraftLine, "quantity" | "vendorId">>,
+    updates: Partial<Pick<ReorderDraftLine, "quantityInput" | "vendorId">>,
   ) {
     setDraftLines((currentDraftLines) =>
       currentDraftLines.map((line) =>
@@ -744,7 +928,7 @@ export function ProcurementViewContent({
               description: line.sku
                 ? `${line.productName} (${line.sku})`
                 : line.productName,
-              orderedQuantity: line.quantity,
+              orderedQuantity: parseDraftLineQuantity(line)!,
               productSkuId: line.productSkuId,
               unitCost: 0,
             })),
@@ -779,6 +963,10 @@ export function ProcurementViewContent({
           linesByVendor.size === 1 ? "" : "s"
         } created`,
       );
+
+      if (mode === "needs_action" && summary.needsAction === 1) {
+        handleModeChange("planned");
+      }
     } finally {
       setIsCreatingPurchaseOrders(false);
     }
@@ -829,6 +1017,10 @@ export function ProcurementViewContent({
       }
 
       toast.success(`${purchaseOrder.poNumber} marked ordered`);
+
+      if (mode === "planned" && plannedPurchaseOrderActionCount === 1) {
+        handleModeChange("inbound");
+      }
     } finally {
       setUpdatingPurchaseOrderId(null);
     }
@@ -846,12 +1038,11 @@ export function ProcurementViewContent({
                 </p>
                 <div className="space-y-1">
                   <h2 className="font-display text-2xl font-semibold tracking-tight text-foreground">
-                    Procurement workspace
+                    Procurement
                   </h2>
                   <p className="text-sm text-muted-foreground">
-                    Turn low-stock items into vendor-backed purchase orders,
-                    inbound cover, and receiving work without losing the stock
-                    continuity context.
+                    Review stock pressure, create vendor-backed orders, and
+                    track receiving in one workspace.
                   </p>
                 </div>
                 <div className="grid max-w-2xl grid-cols-2 gap-2 sm:grid-cols-4">
@@ -891,7 +1082,9 @@ export function ProcurementViewContent({
               </div>
 
               <Tabs
-                onValueChange={(value) => setMode(value as ProcurementMode)}
+                onValueChange={(value) =>
+                  handleModeChange(value as ProcurementMode)
+                }
                 value={mode}
               >
                 <TabsList>
@@ -904,7 +1097,10 @@ export function ProcurementViewContent({
               </Tabs>
             </div>
 
-            <section className="overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface">
+            <section
+              className="overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface"
+              ref={stockPressureSectionRef}
+            >
               <div className="border-b border-border/70 px-layout-md py-layout-md">
                 <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-end lg:justify-between">
                   <div>
@@ -934,7 +1130,7 @@ export function ProcurementViewContent({
                     />
                   </div>
                 ) : (
-                  visibleRecommendations.map((recommendation) => {
+                  paginatedRecommendations.map((recommendation) => {
                     const statusCopy = getContinuityStateCopy(
                       recommendation.status,
                     );
@@ -953,12 +1149,27 @@ export function ProcurementViewContent({
                     );
                     const stateNote =
                       getRecommendationStateNote(recommendation);
+                    const rowNote =
+                      stateNote ??
+                      (PLANNED_STATES.includes(recommendation.status)
+                        ? null
+                        : recommendation.guidance);
                     const hasSuggestedOrder =
                       recommendation.suggestedOrderQuantity > 0;
-                    const showDraftAction = isInDraft || hasSuggestedOrder;
+                    const canAddAnotherPurchaseOrder =
+                      PLANNED_STATES.includes(recommendation.status) ||
+                      INBOUND_STATES.includes(recommendation.status) ||
+                      hasPlannedPurchaseOrderCover(recommendation) ||
+                      hasInboundPurchaseOrderCover(recommendation);
+                    const showDraftAction =
+                      isInDraft ||
+                      hasSuggestedOrder ||
+                      canAddAnotherPurchaseOrder;
                     const draftActionLabel = isInDraft
                       ? "In draft"
-                      : "Add to draft";
+                      : canAddAnotherPurchaseOrder
+                        ? "Add purchase order"
+                        : "Add to draft";
                     const plannedUnits =
                       recommendation.plannedPurchaseOrderQuantity ?? 0;
                     const linkedPurchaseOrders =
@@ -974,8 +1185,47 @@ export function ProcurementViewContent({
 
                     return (
                       <article
-                        className="bg-background px-layout-md py-layout-lg transition-colors hover:bg-muted/30"
+                        aria-pressed={
+                          selectedProductSkuId === recommendation._id
+                        }
+                        className={cn(
+                          "bg-background px-layout-md py-layout-lg text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          selectedProductSkuId === recommendation._id ||
+                            linkedPurchaseOrders.some(
+                              (purchaseOrder) =>
+                                purchaseOrder.purchaseOrderId ===
+                                selectedPurchaseOrderId,
+                            )
+                            ? "bg-muted/30 hover:bg-muted/40"
+                            : undefined,
+                        )}
                         key={recommendation._id}
+                        onClick={() =>
+                          setSelectedProductSkuId(recommendation._id)
+                        }
+                        ref={(element) => {
+                          if (element) {
+                            recommendationRowRefs.current.set(
+                              recommendation._id,
+                              element,
+                            );
+                            return;
+                          }
+
+                          recommendationRowRefs.current.delete(
+                            recommendation._id,
+                          );
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key !== "Enter" && event.key !== " ") {
+                            return;
+                          }
+
+                          event.preventDefault();
+                          setSelectedProductSkuId(recommendation._id);
+                        }}
+                        role="button"
+                        tabIndex={0}
                       >
                         <div className="flex flex-col gap-layout-lg lg:flex-row lg:items-start lg:justify-between">
                           <div className="min-w-0 flex-1 space-y-layout-lg">
@@ -1008,9 +1258,11 @@ export function ProcurementViewContent({
                                     </span>
                                   ) : null}
                                 </div>
-                                <p className="max-w-3xl text-sm text-muted-foreground">
-                                  {stateNote ?? recommendation.guidance}
-                                </p>
+                                {rowNote ? (
+                                  <p className="max-w-3xl text-sm text-muted-foreground">
+                                    {rowNote}
+                                  </p>
+                                ) : null}
                               </div>
                             </div>
 
@@ -1086,7 +1338,10 @@ export function ProcurementViewContent({
                                           "flex flex-col gap-layout-sm rounded-md border bg-surface px-3 py-2 transition-colors sm:flex-row sm:items-center sm:justify-between",
                                           isReceivingActive
                                             ? "border-action-workflow-border bg-action-workflow-soft/40"
-                                            : "border-border",
+                                            : selectedPurchaseOrderId ===
+                                                purchaseOrder.purchaseOrderId
+                                              ? "border-action-workflow-border bg-action-workflow-soft/30"
+                                              : "border-border",
                                         )}
                                         key={purchaseOrder.purchaseOrderId}
                                       >
@@ -1113,24 +1368,25 @@ export function ProcurementViewContent({
                                             <Button
                                               disabled={isUpdatingPurchaseOrder}
                                               key={action.nextStatus}
-                                              onClick={() =>
+                                              onClick={(event) => {
+                                                event.stopPropagation();
                                                 action.nextStatus === "ordered"
-                                                  ? handleAdvancePurchaseOrderToOrdered(
+                                                  ? void handleAdvancePurchaseOrderToOrdered(
                                                       {
                                                         _id: purchaseOrder.purchaseOrderId,
                                                         poNumber:
                                                           purchaseOrder.poNumber,
                                                       },
                                                     )
-                                                  : handleUpdatePurchaseOrderStatus(
+                                                  : void handleUpdatePurchaseOrderStatus(
                                                       {
                                                         _id: purchaseOrder.purchaseOrderId,
                                                         poNumber:
                                                           purchaseOrder.poNumber,
                                                       },
                                                       action.nextStatus,
-                                                    )
-                                              }
+                                                    );
+                                              }}
                                               size="sm"
                                               variant={
                                                 action.nextStatus ===
@@ -1151,12 +1407,14 @@ export function ProcurementViewContent({
                                                   ? "true"
                                                   : undefined
                                               }
+                                              className="w-[92px]"
                                               disabled={isReceivingActive}
-                                              onClick={() =>
+                                              onClick={(event) => {
+                                                event.stopPropagation();
                                                 setSelectedReceivingOrderId(
                                                   purchaseOrder.purchaseOrderId,
-                                                )
-                                              }
+                                                );
+                                              }}
                                               size="sm"
                                               variant={
                                                 isReceivingActive
@@ -1181,13 +1439,18 @@ export function ProcurementViewContent({
                           {showDraftAction ? (
                             <div className="flex shrink-0 flex-wrap gap-2 lg:justify-end">
                               <Button
-                                className="self-start"
+                                className="w-[160px] self-start"
                                 disabled={isInDraft}
-                                onClick={() =>
-                                  addRecommendationToDraft(recommendation)
-                                }
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  addRecommendationToDraft(recommendation);
+                                }}
                                 size="sm"
-                                variant="workflow-soft"
+                                variant={
+                                  canAddAnotherPurchaseOrder
+                                    ? "utility"
+                                    : "workflow-soft"
+                                }
                               >
                                 {draftActionLabel}
                               </Button>
@@ -1199,12 +1462,67 @@ export function ProcurementViewContent({
                   })
                 )}
               </div>
+              {visibleRecommendations.length > RECOMMENDATIONS_PER_PAGE ? (
+                <div className="flex flex-col gap-layout-sm border-t border-border/70 px-layout-md py-layout-sm text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                  <p>
+                    Showing {paginationStart}-{paginationEnd} of{" "}
+                    {visibleRecommendations.length}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      disabled={clampedRecommendationPage === 1}
+                      onClick={() =>
+                        handleRecommendationPageChange(
+                          Math.max(1, clampedRecommendationPage - 1),
+                        )
+                      }
+                      size="sm"
+                      variant="utility"
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      disabled={
+                        clampedRecommendationPage === recommendationPageCount
+                      }
+                      onClick={() =>
+                        handleRecommendationPageChange(
+                          Math.min(
+                            recommendationPageCount,
+                            clampedRecommendationPage + 1,
+                          ),
+                        )
+                      }
+                      size="sm"
+                      variant="utility"
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
             </section>
           </section>
 
           <aside className="flex min-h-0 flex-col gap-layout-md overflow-y-auto overscroll-contain pr-1 scrollbar-hide">
+            {selectedInventoryItem ? (
+              <section
+                className={cn(
+                  "space-y-layout-xl rounded-lg border border-border bg-surface-raised px-layout-md py-layout-md shadow-surface",
+                  shouldPrioritizeReorderDraft ? "order-1" : undefined,
+                )}
+              >
+                <SkuDetailPanel activeInventoryItem={selectedInventoryItem} />
+              </section>
+            ) : null}
+
             {selectedReceivingOrderId ? (
-              <section className="space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
+              <section
+                className={cn(
+                  "space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface",
+                  shouldPrioritizeReorderDraft ? "order-4" : undefined,
+                )}
+              >
                 <div className="flex items-start justify-between gap-layout-md">
                   <PanelHeader
                     description={
@@ -1267,7 +1585,12 @@ export function ProcurementViewContent({
             ) : null}
 
             {activePurchaseOrders.length > 0 ? (
-              <section className="space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
+              <section
+                className={cn(
+                  "space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface",
+                  shouldPrioritizeReorderDraft ? "order-3" : undefined,
+                )}
+              >
                 <PanelHeader
                   description="Purchase orders that may not be visible in the current stock list."
                   eyebrow="Purchase Orders"
@@ -1278,8 +1601,29 @@ export function ProcurementViewContent({
                   {visiblePurchaseOrders.map((purchaseOrder) => {
                     return (
                       <article
-                        className="rounded-lg border border-border bg-background p-layout-md"
+                        aria-pressed={
+                          selectedPurchaseOrderId === purchaseOrder._id
+                        }
+                        className={cn(
+                          "rounded-lg border bg-background p-layout-md text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          selectedPurchaseOrderId === purchaseOrder._id
+                            ? "border-action-workflow-border bg-action-workflow-soft/30"
+                            : "border-border",
+                        )}
                         key={purchaseOrder._id}
+                        onClick={() =>
+                          handlePurchaseOrderSummaryClick(purchaseOrder)
+                        }
+                        onKeyDown={(event) => {
+                          if (event.key !== "Enter" && event.key !== " ") {
+                            return;
+                          }
+
+                          event.preventDefault();
+                          handlePurchaseOrderSummaryClick(purchaseOrder);
+                        }}
+                        role="button"
+                        tabIndex={0}
                       >
                         <div className="flex items-start justify-between gap-layout-md">
                           <div className="min-w-0 space-y-1.5">
@@ -1321,7 +1665,12 @@ export function ProcurementViewContent({
               </section>
             ) : null}
 
-            <section className="space-y-layout-lg rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
+            <section
+              className={cn(
+                "space-y-layout-lg rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface",
+                shouldPrioritizeReorderDraft ? "order-2" : undefined,
+              )}
+            >
               <PanelHeader
                 description="Select low-stock items, confirm quantities, and assign a vendor before creating draft purchase orders."
                 eyebrow="Reorder Draft"
@@ -1362,14 +1711,18 @@ export function ProcurementViewContent({
                       <label className="block space-y-1 text-xs font-medium text-muted-foreground">
                         <span>Quantity</span>
                         <Input
+                          inputMode="numeric"
                           min={1}
                           onChange={(event) =>
                             updateDraftLine(line.productSkuId, {
-                              quantity: Number(event.target.value),
+                              quantityInput: sanitizeDraftQuantityInput(
+                                event.target.value,
+                              ),
                             })
                           }
-                          type="number"
-                          value={line.quantity}
+                          pattern="[0-9]*"
+                          type="text"
+                          value={line.quantityInput}
                         />
                       </label>
                       <label className="block space-y-1 text-xs font-medium text-muted-foreground">
@@ -1453,7 +1806,12 @@ export function ProcurementViewContent({
               </Button>
             </section>
 
-            <section className="space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
+            <section
+              className={cn(
+                "space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface",
+                shouldPrioritizeReorderDraft ? "order-5" : undefined,
+              )}
+            >
               <PanelHeader
                 description="Use the current stock-continuity mix to decide whether to order, advance planned work, receive, or resolve an exception."
                 eyebrow="Snapshot"
@@ -1489,7 +1847,13 @@ export function ProcurementViewContent({
   );
 }
 
-export function ProcurementView() {
+export function ProcurementView({
+  mode,
+  onModeChange,
+}: {
+  mode?: ProcurementMode;
+  onModeChange?: (mode: ProcurementMode) => void;
+} = {}) {
   const {
     activeStore,
     canQueryProtectedData,
@@ -1508,6 +1872,10 @@ export function ProcurementView() {
     api.stockOps.purchaseOrders.listPurchaseOrders,
     procurementQueryArgs,
   ) as ProcurementOrderSummary[] | undefined;
+  const inventoryItems = useQuery(
+    api.stockOps.adjustments.listInventorySnapshot,
+    procurementQueryArgs,
+  ) as InventorySnapshotItem[] | undefined;
   const vendors = useQuery(
     api.stockOps.vendors.listVendors,
     canQueryProtectedData
@@ -1533,9 +1901,13 @@ export function ProcurementView() {
       isLoadingProcurement={Boolean(
         canQueryProtectedData &&
         (recommendations === undefined ||
+          inventoryItems === undefined ||
           purchaseOrders === undefined ||
           vendors === undefined),
       )}
+      inventoryItems={inventoryItems ?? []}
+      mode={mode}
+      onModeChange={onModeChange}
       purchaseOrders={purchaseOrders ?? []}
       recommendations={recommendations ?? []}
       storeId={activeStore?._id}

--- a/packages/athena-webapp/src/routes/__root.tsx
+++ b/packages/athena-webapp/src/routes/__root.tsx
@@ -20,6 +20,9 @@ const rootPageSchema = z.object({
   registerSessionId: z.string().optional(),
   mode: z.enum(["cycle_count", "manual"]).optional(),
   page: z.coerce.number().int().positive().optional(),
+  procurementMode: z
+    .enum(["needs_action", "planned", "inbound", "exceptions", "resolved", "all"])
+    .optional(),
   scope: z.string().optional(),
   sku: z.string().optional(),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx
@@ -1,8 +1,44 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { ProcurementView } from "~/src/components/procurement/ProcurementView";
 
-export const Route = createFileRoute(
-  "/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement/"
-)({
-  component: ProcurementView,
+const procurementSearchSchema = z.object({
+  procurementMode: z
+    .enum(["needs_action", "planned", "inbound", "exceptions", "resolved", "all"])
+    .optional(),
 });
+
+export const Route = createFileRoute(
+  "/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement/",
+)({
+  component: ProcurementRoute,
+  validateSearch: procurementSearchSchema,
+});
+
+function ProcurementRoute() {
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+
+  return (
+    <ProcurementView
+      mode={search.procurementMode}
+      onModeChange={(mode) => {
+        void navigate({
+          replace: true,
+          search: ((current: Record<string, unknown>) => {
+            const next: Record<string, unknown> = {
+              ...current,
+              procurementMode: mode,
+            };
+
+            if (next.procurementMode === "needs_action") {
+              delete next.procurementMode;
+            }
+
+            return next;
+          }) as never,
+        });
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Refines the stock-ops procurement workspace so navigation, tab state, row selection, and purchase-order actions stay aligned with the operator's stock-pressure flow.

- Makes sidebar parent items navigate to their canonical workspaces and keeps procurement tab state in `procurementMode` instead of the legacy shared `mode` key.
- Reuses the stock-adjustment SKU detail rail in procurement, supports row selection without disruptive auto-scroll, and lets right-rail purchase-order cards jump to the owning tab/page/row.
- Adds reorder-draft flow polish: editable quantity strings, additional purchase-order actions from planned/inbound rows, card ordering, next-tab progression, fixed-width lifecycle buttons, pagination with table-top scroll, and tighter header copy.
- Updates the procurement stock-continuity solution note and regenerates graphify artifacts.

## Validation

- `bun run pr:athena`
- `git push -u origin HEAD` pre-push hook, including graphify check, architecture check, harness review, selected behavior scenarios, and inferential review

## Notes

Visual validation was intentionally left to the browser review flow requested during iteration.
