### PR TITLE
Refine compound solution sensor

### DIFF
--- a/docs/harness.md
+++ b/docs/harness.md
@@ -128,6 +128,14 @@ test-only changes, generated artifacts, and docs-only changes can pass without a
 new solution note. Large behavior-bearing changes need durable compounding while
 the context is still fresh.
 
+The sensor also treats workflow-critical files as compound-sensitive even when
+the line count is small. Changes to repo harness scripts, PR validation wiring,
+GitHub workflows, Husky hooks, package-level command wiring, or the core
+delivery skills need a solution note because those paths affect how future
+agents deliver work. A changed solution note must include the expected
+frontmatter and the `Problem`, `Solution`, and `Prevention` sections; placeholder
+notes do not satisfy the gate.
+
 ### Coverage Sensors
 
 `bun run test:coverage` is the repo coverage gate. It first repairs missing or

--- a/docs/solutions/harness/compound-solution-gate-2026-05-05.md
+++ b/docs/solutions/harness/compound-solution-gate-2026-05-05.md
@@ -8,6 +8,7 @@ component: pr-validation
 symptoms:
   - "A large feature PR could land even when its planned docs/solutions note was missing"
   - "Fresh delivery context was lost before the reusable lesson was captured"
+  - "Parallel subagent execution could satisfy implementation tickets while missing the final compounding deliverable"
 root_cause: missing_validation
 resolution_type: guardrail
 severity: medium
@@ -37,10 +38,21 @@ repo-local invariants:
   an existing file.
 - Substantial behavior-bearing source changes must include a changed
   `docs/solutions/**/*.md` note.
+- Compound-sensitive workflow changes must include a changed
+  `docs/solutions/**/*.md` note even when the line count is small.
+- Changed solution notes must include the expected frontmatter and the
+  `Problem`, `Solution`, and `Prevention` sections.
 
 The source threshold intentionally ignores generated files, test files, and
 docs-only changes. The goal is to catch meaningful implementation deliveries,
 not to require a learning document for every small edit.
+
+The workflow-sensitive path list covers repo delivery and validation surfaces:
+compound checks, pre-push/pre-commit repair scripts, harness scripts, coverage
+and architecture gates, GitHub workflow files, Husky hooks, package command
+wiring, and the core delivery skills. These files change how future agents
+deliver work, so small edits there can be more reusable than a larger ordinary
+component change.
 
 ## Why This Works
 
@@ -54,6 +66,11 @@ names a solution document, that path has to exist before the branch can pass.
 The line-threshold check covers large work that never added an explicit
 reference.
 
+The quality check keeps the gate from becoming a checkbox. A changed
+`docs/solutions/` file needs enough structure for a future agent to understand
+the problem, the fix, and the prevention rule. Placeholder notes fail in the
+same command that would otherwise accept them.
+
 ## Prevention
 
 - Keep `bun run compound:check` in `pr:athena`.
@@ -62,5 +79,8 @@ reference.
 - Do not satisfy the gate with empty documentation. The note should capture the
   reusable boundary, failure mode, command, or workflow decision future agents
   need.
+- Treat the final integration branch as the unit of compounding. Parallel
+  subagent work is evaluated in aggregate, so the final branch needs the durable
+  learning artifact even if no single worker owned the note.
 - If a large change truly has no reusable learning, split the work smaller or
   adjust the sensor with a focused test case that explains the exception.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4487 nodes · 4286 edges · 1522 communities detected
+- 4492 nodes · 4296 edges · 1522 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1596,32 +1596,32 @@ Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
 ### Community 9 - "Community 9"
+Cohesion: 0.19
+Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.16
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.23
-Nodes (19): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractSolutionReferences() (+11 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.18
@@ -1800,24 +1800,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 60 - "Community 60"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 61 - "Community 61"
 Cohesion: 0.25
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 62 - "Community 62"
+### Community 61 - "Community 61"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 63 - "Community 63"
+### Community 62 - "Community 62"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 64 - "Community 64"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 65 - "Community 65"
 Cohesion: 0.18
@@ -2076,72 +2076,72 @@ Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
 ### Community 129 - "Community 129"
+Cohesion: 0.43
+Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+
+### Community 130 - "Community 130"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.53
 Nodes (4): listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 145 - "Community 145"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 146 - "Community 146"
 Cohesion: 0.33
@@ -2156,8 +2156,8 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 149 - "Community 149"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 150 - "Community 150"
 Cohesion: 0.33
@@ -2228,16 +2228,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 167 - "Community 167"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 168 - "Community 168"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
-
-### Community 169 - "Community 169"
-Cohesion: 0.53
-Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.53
@@ -2321,7 +2321,7 @@ Nodes (0):
 
 ### Community 190 - "Community 190"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.4
@@ -2332,16 +2332,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 194 - "Community 194"
 Cohesion: 0.5
-Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 195 - "Community 195"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getApprovalRequestCopy(), setDecisioningApprovalRequestId()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.4
@@ -2353,7 +2353,7 @@ Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.5
@@ -2500,84 +2500,84 @@ Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 236 - "Community 236"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 241 - "Community 241"
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 241 - "Community 241"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 243 - "Community 243"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 244 - "Community 244"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 245 - "Community 245"
+### Community 244 - "Community 244"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 246 - "Community 246"
+### Community 245 - "Community 245"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 247 - "Community 247"
+### Community 246 - "Community 246"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 248 - "Community 248"
+### Community 247 - "Community 247"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 248 - "Community 248"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 251 - "Community 251"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 254 - "Community 254"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.5
@@ -2592,12 +2592,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 259 - "Community 259"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 259 - "Community 259"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.5
@@ -2612,12 +2612,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 264 - "Community 264"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 264 - "Community 264"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 265 - "Community 265"
 Cohesion: 0.5
@@ -2640,72 +2640,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 270 - "Community 270"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 271 - "Community 271"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 271 - "Community 271"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 274 - "Community 274"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 275 - "Community 275"
+### Community 274 - "Community 274"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 276 - "Community 276"
+### Community 275 - "Community 275"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 277 - "Community 277"
+### Community 276 - "Community 276"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
+
+### Community 277 - "Community 277"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 278 - "Community 278"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 279 - "Community 279"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 281 - "Community 281"
+### Community 280 - "Community 280"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 281 - "Community 281"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 283 - "Community 283"
+### Community 282 - "Community 282"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 284 - "Community 284"
+### Community 283 - "Community 283"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 285 - "Community 285"
+### Community 284 - "Community 284"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 286 - "Community 286"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.5
@@ -2732,12 +2732,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 293 - "Community 293"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
@@ -9806,5 +9806,5 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 7` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
-- **Should `Community 10` be split into smaller, more focused modules?**
+- **Should `Community 11` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1559,7 +1559,7 @@
       "relation": "calls",
       "source": "compound_solution_check_collectchangedfiles",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L303",
+      "source_location": "L397",
       "target": "compound_solution_check_assertcompoundsolutioncheck",
       "weight": 1
     },
@@ -1571,7 +1571,7 @@
       "relation": "calls",
       "source": "compound_solution_check_collectcompoundsolutionfindings",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L304",
+      "source_location": "L398",
       "target": "compound_solution_check_assertcompoundsolutioncheck",
       "weight": 1
     },
@@ -1583,7 +1583,7 @@
       "relation": "calls",
       "source": "compound_solution_check_collectexistingfiles",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L306",
+      "source_location": "L400",
       "target": "compound_solution_check_assertcompoundsolutioncheck",
       "weight": 1
     },
@@ -1595,7 +1595,7 @@
       "relation": "calls",
       "source": "compound_solution_check_collectmarkdowncontents",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L307",
+      "source_location": "L401",
       "target": "compound_solution_check_assertcompoundsolutioncheck",
       "weight": 1
     },
@@ -1607,7 +1607,7 @@
       "relation": "calls",
       "source": "compound_solution_check_collectsourcelinechanges",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L308",
+      "source_location": "L402",
       "target": "compound_solution_check_assertcompoundsolutioncheck",
       "weight": 1
     },
@@ -1619,7 +1619,7 @@
       "relation": "calls",
       "source": "compound_solution_check_parsechangedfiles",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L196",
+      "source_location": "L290",
       "target": "compound_solution_check_collectchangedfiles",
       "weight": 1
     },
@@ -1631,7 +1631,7 @@
       "relation": "calls",
       "source": "compound_solution_check_rungit",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L196",
+      "source_location": "L290",
       "target": "compound_solution_check_collectchangedfiles",
       "weight": 1
     },
@@ -1643,7 +1643,7 @@
       "relation": "calls",
       "source": "compound_solution_check_sortuniquepaths",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L195",
+      "source_location": "L289",
       "target": "compound_solution_check_collectchangedfiles",
       "weight": 1
     },
@@ -1655,7 +1655,31 @@
       "relation": "calls",
       "source": "compound_solution_check_extractsolutionreferences",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L103",
+      "source_location": "L167",
+      "target": "compound_solution_check_collectcompoundsolutionfindings",
+      "weight": 1
+    },
+    {
+      "_src": "compound_solution_check_collectcompoundsolutionfindings",
+      "_tgt": "compound_solution_check_missingsolutionfrontmatterfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "compound_solution_check_missingsolutionfrontmatterfields",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L182",
+      "target": "compound_solution_check_collectcompoundsolutionfindings",
+      "weight": 1
+    },
+    {
+      "_src": "compound_solution_check_collectcompoundsolutionfindings",
+      "_tgt": "compound_solution_check_missingsolutionsections",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "compound_solution_check_missingsolutionsections",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L183",
       "target": "compound_solution_check_collectcompoundsolutionfindings",
       "weight": 1
     },
@@ -1667,7 +1691,7 @@
       "relation": "calls",
       "source": "compound_solution_check_normalizerepopath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L108",
+      "source_location": "L172",
       "target": "compound_solution_check_collectcompoundsolutionfindings",
       "weight": 1
     },
@@ -1679,7 +1703,7 @@
       "relation": "calls",
       "source": "compound_solution_check_sortuniquepaths",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L97",
+      "source_location": "L158",
       "target": "compound_solution_check_collectcompoundsolutionfindings",
       "weight": 1
     },
@@ -1691,7 +1715,7 @@
       "relation": "calls",
       "source": "compound_solution_check_totalconsiderablesourcelinechanges",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L116",
+      "source_location": "L202",
       "target": "compound_solution_check_collectcompoundsolutionfindings",
       "weight": 1
     },
@@ -1703,7 +1727,7 @@
       "relation": "calls",
       "source": "compound_solution_check_parsechangedfiles",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L258",
+      "source_location": "L352",
       "target": "compound_solution_check_collectexistingfiles",
       "weight": 1
     },
@@ -1715,7 +1739,7 @@
       "relation": "calls",
       "source": "compound_solution_check_rungit",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L258",
+      "source_location": "L352",
       "target": "compound_solution_check_collectexistingfiles",
       "weight": 1
     },
@@ -1727,7 +1751,7 @@
       "relation": "calls",
       "source": "compound_solution_check_ismarkdowndocpath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L243",
+      "source_location": "L337",
       "target": "compound_solution_check_collectmarkdowncontents",
       "weight": 1
     },
@@ -1739,7 +1763,7 @@
       "relation": "calls",
       "source": "compound_solution_check_countfilelines",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L224",
+      "source_location": "L318",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1751,7 +1775,7 @@
       "relation": "calls",
       "source": "compound_solution_check_isconsiderablesourcepath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L219",
+      "source_location": "L313",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1763,7 +1787,7 @@
       "relation": "calls",
       "source": "compound_solution_check_mergelinechanges",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L206",
+      "source_location": "L300",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1775,7 +1799,7 @@
       "relation": "calls",
       "source": "compound_solution_check_normalizerepopath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L218",
+      "source_location": "L312",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1787,7 +1811,7 @@
       "relation": "calls",
       "source": "compound_solution_check_parsechangedfiles",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L213",
+      "source_location": "L307",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1799,7 +1823,7 @@
       "relation": "calls",
       "source": "compound_solution_check_parsenumstat",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L208",
+      "source_location": "L302",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1811,7 +1835,7 @@
       "relation": "calls",
       "source": "compound_solution_check_rungit",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L208",
+      "source_location": "L302",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -1823,8 +1847,32 @@
       "relation": "calls",
       "source": "compound_solution_check_sortuniquepaths",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L68",
+      "source_location": "L102",
       "target": "compound_solution_check_extractsolutionreferences",
+      "weight": 1
+    },
+    {
+      "_src": "compound_solution_check_iscompoundsensitiveworkflowpath",
+      "_tgt": "compound_solution_check_issolutiondocpath",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "compound_solution_check_issolutiondocpath",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L90",
+      "target": "compound_solution_check_iscompoundsensitiveworkflowpath",
+      "weight": 1
+    },
+    {
+      "_src": "compound_solution_check_iscompoundsensitiveworkflowpath",
+      "_tgt": "compound_solution_check_normalizerepopath",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "compound_solution_check_normalizerepopath",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L87",
+      "target": "compound_solution_check_iscompoundsensitiveworkflowpath",
       "weight": 1
     },
     {
@@ -1835,7 +1883,7 @@
       "relation": "calls",
       "source": "compound_solution_check_normalizerepopath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L53",
+      "source_location": "L72",
       "target": "compound_solution_check_isconsiderablesourcepath",
       "weight": 1
     },
@@ -1847,7 +1895,7 @@
       "relation": "calls",
       "source": "compound_solution_check_normalizerepopath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L49",
+      "source_location": "L68",
       "target": "compound_solution_check_ismarkdowndocpath",
       "weight": 1
     },
@@ -1859,8 +1907,20 @@
       "relation": "calls",
       "source": "compound_solution_check_normalizerepopath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L45",
+      "source_location": "L64",
       "target": "compound_solution_check_issolutiondocpath",
+      "weight": 1
+    },
+    {
+      "_src": "compound_solution_check_missingsolutionfrontmatterfields",
+      "_tgt": "compound_solution_check_extractfrontmatter",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "compound_solution_check_extractfrontmatter",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L121",
+      "target": "compound_solution_check_missingsolutionfrontmatterfields",
       "weight": 1
     },
     {
@@ -1871,7 +1931,7 @@
       "relation": "calls",
       "source": "compound_solution_check_normalizerepopath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L164",
+      "source_location": "L258",
       "target": "compound_solution_check_parsenumstat",
       "weight": 1
     },
@@ -1883,7 +1943,7 @@
       "relation": "calls",
       "source": "compound_solution_check_rungit",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L130",
+      "source_location": "L224",
       "target": "compound_solution_check_gitenv",
       "weight": 1
     },
@@ -1931,7 +1991,7 @@
       "relation": "calls",
       "source": "compound_solution_check_isconsiderablesourcepath",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L79",
+      "source_location": "L140",
       "target": "compound_solution_check_totalconsiderablesourcelinechanges",
       "weight": 1
     },
@@ -42341,6 +42401,18 @@
     },
     {
       "_src": "scripts_compound_solution_check_test_ts",
+      "_tgt": "compound_solution_check_test_solutionnote",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_compound_solution_check_test_ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L75",
+      "target": "compound_solution_check_test_solutionnote",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_compound_solution_check_test_ts",
       "_tgt": "compound_solution_check_test_write",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -42359,7 +42431,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L297",
+      "source_location": "L391",
       "target": "compound_solution_check_assertcompoundsolutioncheck",
       "weight": 1
     },
@@ -42371,7 +42443,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L194",
+      "source_location": "L288",
       "target": "compound_solution_check_collectchangedfiles",
       "weight": 1
     },
@@ -42383,7 +42455,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L89",
+      "source_location": "L150",
       "target": "compound_solution_check_collectcompoundsolutionfindings",
       "weight": 1
     },
@@ -42395,7 +42467,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L256",
+      "source_location": "L350",
       "target": "compound_solution_check_collectexistingfiles",
       "weight": 1
     },
@@ -42407,7 +42479,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L239",
+      "source_location": "L333",
       "target": "compound_solution_check_collectmarkdowncontents",
       "weight": 1
     },
@@ -42419,7 +42491,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L203",
+      "source_location": "L297",
       "target": "compound_solution_check_collectsourcelinechanges",
       "weight": 1
     },
@@ -42431,8 +42503,20 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L190",
+      "source_location": "L284",
       "target": "compound_solution_check_countfilelines",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_compound_solution_check_ts",
+      "_tgt": "compound_solution_check_extractfrontmatter",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_compound_solution_check_ts",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L107",
+      "target": "compound_solution_check_extractfrontmatter",
       "weight": 1
     },
     {
@@ -42443,7 +42527,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L67",
+      "source_location": "L101",
       "target": "compound_solution_check_extractsolutionreferences",
       "weight": 1
     },
@@ -42455,8 +42539,20 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L144",
+      "source_location": "L238",
       "target": "compound_solution_check_gitenv",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_compound_solution_check_ts",
+      "_tgt": "compound_solution_check_iscompoundsensitiveworkflowpath",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_compound_solution_check_ts",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L86",
+      "target": "compound_solution_check_iscompoundsensitiveworkflowpath",
       "weight": 1
     },
     {
@@ -42467,7 +42563,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L52",
+      "source_location": "L71",
       "target": "compound_solution_check_isconsiderablesourcepath",
       "weight": 1
     },
@@ -42479,7 +42575,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L48",
+      "source_location": "L67",
       "target": "compound_solution_check_ismarkdowndocpath",
       "weight": 1
     },
@@ -42491,7 +42587,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L44",
+      "source_location": "L63",
       "target": "compound_solution_check_issolutiondocpath",
       "weight": 1
     },
@@ -42503,8 +42599,32 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L180",
+      "source_location": "L274",
       "target": "compound_solution_check_mergelinechanges",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_compound_solution_check_ts",
+      "_tgt": "compound_solution_check_missingsolutionfrontmatterfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_compound_solution_check_ts",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L120",
+      "target": "compound_solution_check_missingsolutionfrontmatterfields",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_compound_solution_check_ts",
+      "_tgt": "compound_solution_check_missingsolutionsections",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_compound_solution_check_ts",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L128",
+      "target": "compound_solution_check_missingsolutionsections",
       "weight": 1
     },
     {
@@ -42515,7 +42635,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L34",
+      "source_location": "L53",
       "target": "compound_solution_check_normalizerepopath",
       "weight": 1
     },
@@ -42527,7 +42647,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L264",
+      "source_location": "L358",
       "target": "compound_solution_check_parseargs",
       "weight": 1
     },
@@ -42539,7 +42659,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L152",
+      "source_location": "L246",
       "target": "compound_solution_check_parsechangedfiles",
       "weight": 1
     },
@@ -42551,7 +42671,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L159",
+      "source_location": "L253",
       "target": "compound_solution_check_parsenumstat",
       "weight": 1
     },
@@ -42563,7 +42683,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L127",
+      "source_location": "L221",
       "target": "compound_solution_check_rungit",
       "weight": 1
     },
@@ -42575,7 +42695,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L38",
+      "source_location": "L57",
       "target": "compound_solution_check_sortuniquepaths",
       "weight": 1
     },
@@ -42587,7 +42707,7 @@
       "relation": "contains",
       "source": "scripts_compound_solution_check_ts",
       "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L73",
+      "source_location": "L134",
       "target": "compound_solution_check_totalconsiderablesourcelinechanges",
       "weight": 1
     },
@@ -52278,218 +52398,227 @@
     {
       "community": 10,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
+      "id": "harness_self_review_appendlistsection",
+      "label": "appendListSection()",
+      "norm_label": "appendlistsection()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L609"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_buildcartsummary",
-      "label": "buildCartSummary()",
-      "norm_label": "buildcartsummary()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L543"
+      "id": "harness_self_review_buildmarkdownbundle",
+      "label": "buildMarkdownBundle()",
+      "norm_label": "buildmarkdownbundle()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L628"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_buildsessionoperationsrow",
-      "label": "buildSessionOperationsRow()",
-      "norm_label": "buildsessionoperationsrow()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L586"
+      "id": "harness_self_review_collectcoverage",
+      "label": "collectCoverage()",
+      "norm_label": "collectcoverage()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L398"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_expirepossessionnow",
-      "label": "expirePosSessionNow()",
-      "norm_label": "expirepossessionnow()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L250"
+      "id": "harness_self_review_evaluategraphifyfreshness",
+      "label": "evaluateGraphifyFreshness()",
+      "norm_label": "evaluategraphifyfreshness()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L532"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L385"
+      "id": "harness_self_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L144"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L114"
+      "id": "harness_self_review_formatvalidationcommand",
+      "label": "formatValidationCommand()",
+      "norm_label": "formatvalidationcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L132"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L202"
+      "id": "harness_self_review_getchangedfilesfromgit",
+      "label": "getChangedFilesFromGit()",
+      "norm_label": "getchangedfilesfromgit()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L177"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L224"
+      "id": "harness_self_review_islikelycodeorconfig",
+      "label": "isLikelyCodeOrConfig()",
+      "norm_label": "islikelycodeorconfig()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L493"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_liststoresessionsforoperationsstatus",
-      "label": "listStoreSessionsForOperationsStatus()",
-      "norm_label": "liststoresessionsforoperationsstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L567"
+      "id": "harness_self_review_islocalgeneratedartifactpath",
+      "label": "isLocalGeneratedArtifactPath()",
+      "norm_label": "islocalgeneratedartifactpath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L523"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L180"
+      "id": "harness_self_review_isworktreemetadatapath",
+      "label": "isWorktreeMetadataPath()",
+      "norm_label": "isworktreemetadatapath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L514"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_loadsessioncustomer",
-      "label": "loadSessionCustomer()",
-      "norm_label": "loadsessioncustomer()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L439"
+      "id": "harness_self_review_loadselfreviewtarget",
+      "label": "loadSelfReviewTarget()",
+      "norm_label": "loadselfreviewtarget()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L247"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_loadsessionoperator",
-      "label": "loadSessionOperator()",
-      "norm_label": "loadsessionoperator()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L471"
+      "id": "harness_self_review_loadselfreviewtargets",
+      "label": "loadSelfReviewTargets()",
+      "norm_label": "loadselfreviewtargets()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L379"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_loadsessionregister",
-      "label": "loadSessionRegister()",
-      "norm_label": "loadsessionregister()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L517"
+      "id": "harness_self_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L106"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_loadsessionterminal",
-      "label": "loadSessionTerminal()",
-      "norm_label": "loadsessionterminal()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L495"
+      "id": "harness_self_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L128"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L370"
+      "id": "harness_self_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L96"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L306"
+      "id": "harness_self_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L120"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L327"
+      "id": "harness_self_review_parsecliarguments",
+      "label": "parseCliArguments()",
+      "norm_label": "parsecliarguments()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L801"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L118"
+      "id": "harness_self_review_parseruntimescenarios",
+      "label": "parseRuntimeScenarios()",
+      "norm_label": "parseruntimescenarios()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L241"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L396"
+      "id": "harness_self_review_quotecode",
+      "label": "quoteCode()",
+      "norm_label": "quotecode()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L140"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_usererrorfromsessioncommandfailure",
-      "label": "userErrorFromSessionCommandFailure()",
-      "norm_label": "usererrorfromsessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L72"
+      "id": "harness_self_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L153"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_usererrorfromvalidationmessage",
-      "label": "userErrorFromValidationMessage()",
-      "norm_label": "usererrorfromvalidationmessage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "id": "harness_self_review_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "harness_self_review_runharnessselfreview",
+      "label": "runHarnessSelfReview()",
+      "norm_label": "runharnessselfreview()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L850"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "harness_self_review_runquietharnesscheck",
+      "label": "runQuietHarnessCheck()",
+      "norm_label": "runquietharnesscheck()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L600"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "harness_self_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-self-review.ts",
       "source_location": "L100"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "possessions_validateoperationsactor",
-      "label": "validateOperationsActor()",
-      "norm_label": "validateoperationsactor()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "possessions_validateoperationsmanager",
-      "label": "validateOperationsManager()",
-      "norm_label": "validateoperationsmanager()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L646"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "possessions_validatesessiondrawerbinding",
-      "label": "validateSessionDrawerBinding()",
-      "norm_label": "validatesessiondrawerbinding()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L144"
+      "id": "scripts_harness_self_review_ts",
+      "label": "harness-self-review.ts",
+      "norm_label": "harness-self-review.ts",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L1"
     },
     {
       "community": 100,
@@ -54078,200 +54207,218 @@
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
-      "label": "buildActiveCycleCountDraftsSubmissionKey()",
-      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L90"
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
-      "label": "buildCycleCountDraftSubmissionKey()",
-      "norm_label": "buildcyclecountdraftsubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L75"
+      "id": "possessions_buildcartsummary",
+      "label": "buildCartSummary()",
+      "norm_label": "buildcartsummary()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L543"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
-      "label": "createCycleCountDraftWithCtx()",
-      "norm_label": "createcyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L190"
+      "id": "possessions_buildsessionoperationsrow",
+      "label": "buildSessionOperationsRow()",
+      "norm_label": "buildsessionoperationsrow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L586"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
-      "label": "discardCycleCountDraftCommandWithCtx()",
-      "norm_label": "discardcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L481"
+      "id": "possessions_expirepossessionnow",
+      "label": "expirePosSessionNow()",
+      "norm_label": "expirepossessionnow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L250"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
-      "label": "ensureCycleCountDraftCommandWithCtx()",
-      "norm_label": "ensurecyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L347"
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L385"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
-      "label": "ensureCycleCountDraftWithCtx()",
-      "norm_label": "ensurecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L235"
+      "id": "possessions_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L114"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
-      "label": "findOpenCycleCountDraftWithCtx()",
-      "norm_label": "findopencyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L103"
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L202"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
-      "label": "getActiveCycleCountDraftSummaryWithCtx()",
-      "norm_label": "getactivecyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L289"
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L224"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
-      "label": "getActiveCycleCountDraftWithCtx()",
-      "norm_label": "getactivecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L264"
+      "id": "possessions_liststoresessionsforoperationsstatus",
+      "label": "listStoreSessionsForOperationsStatus()",
+      "norm_label": "liststoresessionsforoperationsstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L567"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
-      "label": "getCycleCountDraftLineWithCtx()",
-      "norm_label": "getcyclecountdraftlinewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L155"
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L180"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
-      "label": "listCycleCountDraftLinesWithCtx()",
-      "norm_label": "listcyclecountdraftlineswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L144"
+      "id": "possessions_loadsessioncustomer",
+      "label": "loadSessionCustomer()",
+      "norm_label": "loadsessioncustomer()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L439"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
-      "label": "listOpenCycleCountDraftsWithCtx()",
-      "norm_label": "listopencyclecountdraftswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L123"
+      "id": "possessions_loadsessionoperator",
+      "label": "loadSessionOperator()",
+      "norm_label": "loadsessionoperator()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L471"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
-      "label": "listStaleCycleCountDraftLines()",
-      "norm_label": "liststalecyclecountdraftlines()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L612"
+      "id": "possessions_loadsessionregister",
+      "label": "loadSessionRegister()",
+      "norm_label": "loadsessionregister()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L517"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_mapcyclecountdrafterror",
-      "label": "mapCycleCountDraftError()",
-      "norm_label": "mapcyclecountdrafterror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L904"
+      "id": "possessions_loadsessionterminal",
+      "label": "loadSessionTerminal()",
+      "norm_label": "loadsessionterminal()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L495"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
-      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
-      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L530"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
-      "label": "refreshCycleCountDraftSummaryWithCtx()",
-      "norm_label": "refreshcyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
-      "label": "requireCycleCountDraftAccess()",
-      "norm_label": "requirecyclecountdraftaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
-      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
-      "label": "saveCycleCountDraftLineCommandWithCtx()",
-      "norm_label": "savecyclecountdraftlinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L370"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
-      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
-      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L776"
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L306"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
-      "label": "submitCycleCountDraftCommandWithCtx()",
-      "norm_label": "submitcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L645"
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L327"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "cyclecountdrafts_trimrequiredscopekey",
-      "label": "trimRequiredScopeKey()",
-      "norm_label": "trimrequiredscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L65"
+      "id": "possessions_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L118"
     },
     {
       "community": 11,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
-      "label": "cycleCountDrafts.ts",
-      "norm_label": "cyclecountdrafts.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L1"
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L396"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "possessions_validateoperationsactor",
+      "label": "validateOperationsActor()",
+      "norm_label": "validateoperationsactor()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "possessions_validateoperationsmanager",
+      "label": "validateOperationsManager()",
+      "norm_label": "validateoperationsmanager()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L646"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "possessions_validatesessiondrawerbinding",
+      "label": "validateSessionDrawerBinding()",
+      "norm_label": "validatesessiondrawerbinding()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L144"
     },
     {
       "community": 110,
@@ -55806,200 +55953,200 @@
     {
       "community": 12,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "label": "buildActiveCycleCountDraftsSubmissionKey()",
+      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L90"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
+      "label": "buildCycleCountDraftSubmissionKey()",
+      "norm_label": "buildcyclecountdraftsubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L75"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L117"
+      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
+      "label": "createCycleCountDraftWithCtx()",
+      "norm_label": "createcyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L190"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L80"
+      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
+      "label": "discardCycleCountDraftCommandWithCtx()",
+      "norm_label": "discardcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L481"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L114"
+      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
+      "label": "ensureCycleCountDraftCommandWithCtx()",
+      "norm_label": "ensurecyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L347"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L132"
+      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
+      "label": "ensureCycleCountDraftWithCtx()",
+      "norm_label": "ensurecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L235"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
+      "label": "findOpenCycleCountDraftWithCtx()",
+      "norm_label": "findopencyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L103"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L111"
+      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "label": "getActiveCycleCountDraftSummaryWithCtx()",
+      "norm_label": "getactivecyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L289"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L143"
+      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
+      "label": "getActiveCycleCountDraftWithCtx()",
+      "norm_label": "getactivecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L264"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_getrawconfig",
-      "label": "getRawConfig()",
-      "norm_label": "getrawconfig()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_getstoreconfigv2",
-      "label": "getStoreConfigV2()",
-      "norm_label": "getstoreconfigv2()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_getstorefallbackimageurl",
-      "label": "getStoreFallbackImageUrl()",
-      "norm_label": "getstorefallbackimageurl()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L479"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_isstoremaintenancemode",
-      "label": "isStoreMaintenanceMode()",
-      "norm_label": "isstoremaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_isstorereadonlymode",
-      "label": "isStoreReadOnlyMode()",
-      "norm_label": "isstorereadonlymode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L461"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_mappromo",
-      "label": "mapPromo()",
-      "norm_label": "mappromo()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "storeconfig_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
+      "label": "getCycleCountDraftLineWithCtx()",
+      "norm_label": "getcyclecountdraftlinewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L155"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L126"
+      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
+      "label": "listCycleCountDraftLinesWithCtx()",
+      "norm_label": "listcyclecountdraftlineswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L144"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "storeconfig_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L177"
+      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "label": "listOpenCycleCountDraftsWithCtx()",
+      "norm_label": "listopencyclecountdraftswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
+      "label": "listStaleCycleCountDraftLines()",
+      "norm_label": "liststalecyclecountdraftlines()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_mapcyclecountdrafterror",
+      "label": "mapCycleCountDraftError()",
+      "norm_label": "mapcyclecountdrafterror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L904"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
+      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L530"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
+      "label": "refreshCycleCountDraftSummaryWithCtx()",
+      "norm_label": "refreshcyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "label": "requireCycleCountDraftAccess()",
+      "norm_label": "requirecyclecountdraftaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
+      "label": "saveCycleCountDraftLineCommandWithCtx()",
+      "norm_label": "savecyclecountdraftlinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
+      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L776"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
+      "label": "submitCycleCountDraftCommandWithCtx()",
+      "norm_label": "submitcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "cyclecountdrafts_trimrequiredscopekey",
+      "label": "trimRequiredScopeKey()",
+      "norm_label": "trimrequiredscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "label": "cycleCountDrafts.ts",
+      "norm_label": "cyclecountdrafts.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L1"
     },
     {
       "community": 120,
@@ -57381,65 +57528,65 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "compound_solution_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "compound_solution_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "compound_solution_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "compound_solution_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "compound_solution_check_test_solutionnote",
+      "label": "solutionNote()",
+      "norm_label": "solutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "compound_solution_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "scripts_compound_solution_check_test_ts",
+      "label": "compound-solution-check.test.ts",
+      "norm_label": "compound-solution-check.test.ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
     },
     {
       "community": 1290,
@@ -57534,263 +57681,263 @@
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_buildgitprocessenv",
-      "label": "buildGitProcessEnv()",
-      "norm_label": "buildgitprocessenv()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L419"
+      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_collectcommandsforchangedfiles",
-      "label": "collectCommandsForChangedFiles()",
-      "norm_label": "collectcommandsforchangedfiles()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L302"
+      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L93"
+      "id": "storeconfig_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L117"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_formatmissingpathprefixerror",
-      "label": "formatMissingPathPrefixError()",
-      "norm_label": "formatmissingpathprefixerror()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L83"
+      "id": "storeconfig_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L80"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_getchangedfilesforharnessreview",
-      "label": "getChangedFilesForHarnessReview()",
-      "norm_label": "getchangedfilesforharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L425"
+      "id": "storeconfig_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L114"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtarget",
-      "label": "loadReviewTarget()",
-      "norm_label": "loadreviewtarget()",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_loadreviewtargets",
-      "label": "loadReviewTargets()",
-      "norm_label": "loadreviewtargets()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L269"
+      "id": "storeconfig_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L103"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L57"
+      "id": "storeconfig_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L111"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L79"
+      "id": "storeconfig_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L143"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L53"
+      "id": "storeconfig_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L120"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L71"
+      "id": "storeconfig_getrawconfig",
+      "label": "getRawConfig()",
+      "norm_label": "getrawconfig()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L196"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_parseharnessreviewargs",
-      "label": "parseHarnessReviewArgs()",
-      "norm_label": "parseharnessreviewargs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L666"
+      "id": "storeconfig_getstoreconfigv2",
+      "label": "getStoreConfigV2()",
+      "norm_label": "getstoreconfigv2()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L208"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L122"
+      "id": "storeconfig_getstorefallbackimageurl",
+      "label": "getStoreFallbackImageUrl()",
+      "norm_label": "getstorefallbackimageurl()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L479"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_resolveharnessreviewshell",
-      "label": "resolveHarnessReviewShell()",
-      "norm_label": "resolveharnessreviewshell()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L533"
+      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L93"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_rungitcommand",
-      "label": "runGitCommand()",
-      "norm_label": "rungitcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L398"
+      "id": "storeconfig_isstoremaintenancemode",
+      "label": "isStoreMaintenanceMode()",
+      "norm_label": "isstoremaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L465"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L568"
+      "id": "storeconfig_isstorereadonlymode",
+      "label": "isStoreReadOnlyMode()",
+      "norm_label": "isstorereadonlymode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L461"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_runharnessreview",
-      "label": "runHarnessReview()",
-      "norm_label": "runharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L582"
+      "id": "storeconfig_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L106"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_runpackagescript",
-      "label": "runPackageScript()",
-      "norm_label": "runpackagescript()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L519"
+      "id": "storeconfig_mappromo",
+      "label": "mapPromo()",
+      "norm_label": "mappromo()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_runrawcommand",
-      "label": "runRawCommand()",
-      "norm_label": "runrawcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L554"
+      "id": "storeconfig_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_review_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "scripts_harness_review_ts",
-      "label": "harness-review.ts",
-      "norm_label": "harness-review.ts",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L1"
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1300,
@@ -57885,64 +58032,64 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -58038,55 +58185,64 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -58182,56 +58338,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1330,
@@ -58326,56 +58482,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "listregistercatalog_listregistercatalog",
-      "label": "listRegisterCatalog()",
-      "norm_label": "listregistercatalog()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "listregistercatalog_listregistercatalogavailability",
-      "label": "listRegisterCatalogAvailability()",
-      "norm_label": "listregistercatalogavailability()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "listregistercatalog_mapskutoregistercatalogrow",
-      "label": "mapSkuToRegisterCatalogRow()",
-      "norm_label": "mapskutoregistercatalogrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "listregistercatalog_readcategoryname",
-      "label": "readCategoryName()",
-      "norm_label": "readcategoryname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "listregistercatalog_readcolorname",
-      "label": "readColorName()",
-      "norm_label": "readcolorname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
-      "label": "listRegisterCatalog.ts",
-      "norm_label": "listregistercatalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1340,
@@ -58470,55 +58626,55 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "listregistercatalog_listregistercatalog",
+      "label": "listRegisterCatalog()",
+      "norm_label": "listregistercatalog()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "listregistercatalog_listregistercatalogavailability",
+      "label": "listRegisterCatalogAvailability()",
+      "norm_label": "listregistercatalogavailability()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "listregistercatalog_mapskutoregistercatalogrow",
+      "label": "mapSkuToRegisterCatalogRow()",
+      "norm_label": "mapskutoregistercatalogrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "listregistercatalog_readcategoryname",
+      "label": "readCategoryName()",
+      "norm_label": "readcategoryname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "listregistercatalog_readcolorname",
+      "label": "readColorName()",
+      "norm_label": "readcolorname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L49"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
+      "label": "listRegisterCatalog.ts",
+      "norm_label": "listregistercatalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L1"
     },
     {
@@ -58614,56 +58770,56 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "vendors_createvendorcommandwithctx",
-      "label": "createVendorCommandWithCtx()",
-      "norm_label": "createvendorcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "vendors_createvendorwithctx",
-      "label": "createVendorWithCtx()",
-      "norm_label": "createvendorwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "vendors_mapcreatevendorerror",
-      "label": "mapCreateVendorError()",
-      "norm_label": "mapcreatevendorerror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L32"
     },
     {
       "community": 1360,
@@ -58758,56 +58914,56 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "vendors_createvendorcommandwithctx",
+      "label": "createVendorCommandWithCtx()",
+      "norm_label": "createvendorcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "vendors_createvendorwithctx",
+      "label": "createVendorWithCtx()",
+      "norm_label": "createvendorwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "vendors_mapcreatevendorerror",
+      "label": "mapCreateVendorError()",
+      "norm_label": "mapcreatevendorerror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L32"
     },
     {
       "community": 1370,
@@ -58902,55 +59058,55 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -59046,55 +59202,55 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -59190,245 +59346,254 @@
     {
       "community": 14,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
-      "label": "sessionCommands.ts",
-      "norm_label": "sessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L1"
+      "id": "harness_review_buildgitprocessenv",
+      "label": "buildGitProcessEnv()",
+      "norm_label": "buildgitprocessenv()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L419"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L765"
+      "id": "harness_review_collectcommandsforchangedfiles",
+      "label": "collectCommandsForChangedFiles()",
+      "norm_label": "collectcommandsforchangedfiles()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L302"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_createdefaultsessioncommandservice",
-      "label": "createDefaultSessionCommandService()",
-      "norm_label": "createdefaultsessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L720"
+      "id": "harness_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L93"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_createpossessioncommandservice",
-      "label": "createPosSessionCommandService()",
-      "norm_label": "createpossessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L139"
+      "id": "harness_review_formatmissingpathprefixerror",
+      "label": "formatMissingPathPrefixError()",
+      "norm_label": "formatmissingpathprefixerror()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L83"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_failure",
-      "label": "failure()",
-      "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L958"
+      "id": "harness_review_getchangedfilesforharnessreview",
+      "label": "getChangedFilesForHarnessReview()",
+      "norm_label": "getchangedfilesforharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L425"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_isactiveregistersession",
-      "label": "isActiveRegisterSession()",
-      "norm_label": "isactiveregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L776"
+      "id": "harness_review_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L102"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_issessionexpired",
-      "label": "isSessionExpired()",
-      "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L867"
+      "id": "harness_review_loadreviewtarget",
+      "label": "loadReviewTarget()",
+      "norm_label": "loadreviewtarget()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L132"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L29"
+      "id": "harness_review_loadreviewtargets",
+      "label": "loadReviewTargets()",
+      "norm_label": "loadreviewtargets()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L269"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "sessioncommands_recordsessionlifecyclebesteffort",
-      "label": "recordSessionLifecycleBestEffort()",
-      "norm_label": "recordsessionlifecyclebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L732"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L782"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_resolveregistersessionbinding",
-      "label": "resolveRegisterSessionBinding()",
-      "norm_label": "resolveregistersessionbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L811"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_runbindsessiontoregistersessioncommand",
-      "label": "runBindSessionToRegisterSessionCommand()",
-      "norm_label": "runbindsessiontoregistersessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L697"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_runholdsessioncommand",
-      "label": "runHoldSessionCommand()",
-      "norm_label": "runholdsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L686"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_runremovesessionitemcommand",
-      "label": "runRemoveSessionItemCommand()",
-      "norm_label": "runremovesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L713"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_runresumesessioncommand",
-      "label": "runResumeSessionCommand()",
-      "norm_label": "runresumesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L690"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_runstartsessioncommand",
-      "label": "runStartSessionCommand()",
-      "norm_label": "runstartsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L669"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_runupsertsessionitemcommand",
-      "label": "runUpsertSessionItemCommand()",
-      "norm_label": "runupsertsessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L706"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L951"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesession",
-      "label": "validateActiveSession()",
-      "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L874"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesessionregisterbinding",
-      "label": "validateActiveSessionRegisterBinding()",
-      "norm_label": "validateactivesessionregisterbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L847"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "sessioncommands_validatemodifiablesession",
-      "label": "validateModifiableSession()",
-      "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L918"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "harness_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L57"
     },
     {
-      "community": 140,
+      "community": 14,
       "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
+      "id": "harness_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_parseharnessreviewargs",
+      "label": "parseHarnessReviewArgs()",
+      "norm_label": "parseharnessreviewargs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L666"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_resolveharnessreviewshell",
+      "label": "resolveHarnessReviewShell()",
+      "norm_label": "resolveharnessreviewshell()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L533"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_rungitcommand",
+      "label": "runGitCommand()",
+      "norm_label": "rungitcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L398"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L568"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_runharnessreview",
+      "label": "runHarnessReview()",
+      "norm_label": "runharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L582"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_runpackagescript",
+      "label": "runPackageScript()",
+      "norm_label": "runpackagescript()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L519"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_runrawcommand",
+      "label": "runRawCommand()",
+      "norm_label": "runrawcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L554"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "scripts_harness_review_ts",
+      "label": "harness-review.ts",
+      "norm_label": "harness-review.ts",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L1"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L1"
     },
     {
       "community": 1400,
@@ -59523,56 +59688,56 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1410,
@@ -59667,55 +59832,55 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "analyticsview_activecheckoutsessions",
-      "label": "ActiveCheckoutSessions()",
-      "norm_label": "activecheckoutsessions()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L89"
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "analyticsview_formatmetric",
-      "label": "formatMetric()",
-      "norm_label": "formatmetric()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L22"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "analyticsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L154"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "analyticsview_storefrontsignalcard",
-      "label": "StorefrontSignalCard()",
-      "norm_label": "storefrontsignalcard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L26"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "analyticsview_storevisitors",
-      "label": "StoreVisitors()",
-      "norm_label": "storevisitors()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L59"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "label": "AnalyticsView.tsx",
-      "norm_label": "analyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -59811,56 +59976,56 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "analyticsview_activecheckoutsessions",
+      "label": "ActiveCheckoutSessions()",
+      "norm_label": "activecheckoutsessions()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "analyticsview_formatmetric",
+      "label": "formatMetric()",
+      "norm_label": "formatmetric()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "analyticsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L154"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "analyticsview_storefrontsignalcard",
+      "label": "StorefrontSignalCard()",
+      "norm_label": "storefrontsignalcard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "analyticsview_storevisitors",
+      "label": "StoreVisitors()",
+      "norm_label": "storevisitors()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
+      "label": "AnalyticsView.tsx",
+      "norm_label": "analyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1430,
@@ -59955,56 +60120,56 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1440,
@@ -60099,55 +60264,55 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
-      "label": "CashControlsHeaderSkeleton()",
-      "norm_label": "cashcontrolsheaderskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L83"
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L373"
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L544"
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_metriccardskeleton",
-      "label": "MetricCardSkeleton()",
-      "norm_label": "metriccardskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L97"
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L266"
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
     },
     {
       "community": 145,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
     },
     {
@@ -60243,55 +60408,55 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
+      "id": "cashcontrolsdashboard_cashcontrolsheaderskeleton",
+      "label": "CashControlsHeaderSkeleton()",
+      "norm_label": "cashcontrolsheaderskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L83"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
+      "id": "cashcontrolsdashboard_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L373"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
+      "id": "cashcontrolsdashboard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L544"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
+      "id": "cashcontrolsdashboard_metriccardskeleton",
+      "label": "MetricCardSkeleton()",
+      "norm_label": "metriccardskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L97"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
+      "id": "cashcontrolsdashboard_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L266"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
       "source_location": "L1"
     },
     {
@@ -60387,56 +60552,56 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
-      "label": "ReceivingView.tsx",
-      "norm_label": "receivingview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "receivingview_builddefaultreceivedquantities",
-      "label": "buildDefaultReceivedQuantities()",
-      "norm_label": "builddefaultreceivedquantities()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "receivingview_buildreceivedquantitiesaftersubmission",
-      "label": "buildReceivedQuantitiesAfterSubmission()",
-      "norm_label": "buildreceivedquantitiesaftersubmission()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "receivingview_buildsubmissionkey",
-      "label": "buildSubmissionKey()",
-      "norm_label": "buildsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "receivingview_parselineitemdescription",
-      "label": "parseLineItemDescription()",
-      "norm_label": "parselineitemdescription()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "receivingview_receivingview",
-      "label": "ReceivingView()",
-      "norm_label": "receivingview()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L85"
     },
     {
       "community": 1470,
@@ -60531,56 +60696,56 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
+      "label": "ReceivingView.tsx",
+      "norm_label": "receivingview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
       "source_location": "L1"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
+      "id": "receivingview_builddefaultreceivedquantities",
+      "label": "buildDefaultReceivedQuantities()",
+      "norm_label": "builddefaultreceivedquantities()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L50"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
+      "id": "receivingview_buildreceivedquantitiesaftersubmission",
+      "label": "buildReceivedQuantitiesAfterSubmission()",
+      "norm_label": "buildreceivedquantitiesaftersubmission()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L59"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
+      "id": "receivingview_buildsubmissionkey",
+      "label": "buildSubmissionKey()",
+      "norm_label": "buildsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L32"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
+      "id": "receivingview_parselineitemdescription",
+      "label": "parseLineItemDescription()",
+      "norm_label": "parselineitemdescription()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L36"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
+      "id": "receivingview_receivingview",
+      "label": "ReceivingView()",
+      "norm_label": "receivingview()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L85"
     },
     {
       "community": 1480,
@@ -60675,56 +60840,56 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
     },
     {
       "community": 1490,
@@ -60819,191 +60984,191 @@
     {
       "community": 15,
       "file_type": "code",
-      "id": "compound_solution_check_assertcompoundsolutioncheck",
-      "label": "assertCompoundSolutionCheck()",
-      "norm_label": "assertcompoundsolutioncheck()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L297"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_collectchangedfiles",
-      "label": "collectChangedFiles()",
-      "norm_label": "collectchangedfiles()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_collectcompoundsolutionfindings",
-      "label": "collectCompoundSolutionFindings()",
-      "norm_label": "collectcompoundsolutionfindings()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_collectexistingfiles",
-      "label": "collectExistingFiles()",
-      "norm_label": "collectexistingfiles()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_collectmarkdowncontents",
-      "label": "collectMarkdownContents()",
-      "norm_label": "collectmarkdowncontents()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_collectsourcelinechanges",
-      "label": "collectSourceLineChanges()",
-      "norm_label": "collectsourcelinechanges()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_countfilelines",
-      "label": "countFileLines()",
-      "norm_label": "countfilelines()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_extractsolutionreferences",
-      "label": "extractSolutionReferences()",
-      "norm_label": "extractsolutionreferences()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_isconsiderablesourcepath",
-      "label": "isConsiderableSourcePath()",
-      "norm_label": "isconsiderablesourcepath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_ismarkdowndocpath",
-      "label": "isMarkdownDocPath()",
-      "norm_label": "ismarkdowndocpath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_issolutiondocpath",
-      "label": "isSolutionDocPath()",
-      "norm_label": "issolutiondocpath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_mergelinechanges",
-      "label": "mergeLineChanges()",
-      "norm_label": "mergelinechanges()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L180"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_parseargs",
-      "label": "parseArgs()",
-      "norm_label": "parseargs()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L264"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_parsechangedfiles",
-      "label": "parseChangedFiles()",
-      "norm_label": "parsechangedfiles()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_parsenumstat",
-      "label": "parseNumstat()",
-      "norm_label": "parsenumstat()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L159"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "compound_solution_check_totalconsiderablesourcelinechanges",
-      "label": "totalConsiderableSourceLineChanges()",
-      "norm_label": "totalconsiderablesourcelinechanges()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_ts",
-      "label": "compound-solution-check.ts",
-      "norm_label": "compound-solution-check.ts",
-      "source_file": "scripts/compound-solution-check.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "label": "sessionCommands.ts",
+      "norm_label": "sessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_createdefaultsessioncommandservice",
+      "label": "createDefaultSessionCommandService()",
+      "norm_label": "createdefaultsessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L720"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_createpossessioncommandservice",
+      "label": "createPosSessionCommandService()",
+      "norm_label": "createpossessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_failure",
+      "label": "failure()",
+      "norm_label": "failure()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L958"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_isactiveregistersession",
+      "label": "isActiveRegisterSession()",
+      "norm_label": "isactiveregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L776"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_issessionexpired",
+      "label": "isSessionExpired()",
+      "norm_label": "issessionexpired()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L867"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_recordsessionlifecyclebesteffort",
+      "label": "recordSessionLifecycleBestEffort()",
+      "norm_label": "recordsessionlifecyclebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L732"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L782"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_resolveregistersessionbinding",
+      "label": "resolveRegisterSessionBinding()",
+      "norm_label": "resolveregistersessionbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L811"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_runbindsessiontoregistersessioncommand",
+      "label": "runBindSessionToRegisterSessionCommand()",
+      "norm_label": "runbindsessiontoregistersessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L697"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_runholdsessioncommand",
+      "label": "runHoldSessionCommand()",
+      "norm_label": "runholdsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L686"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_runremovesessionitemcommand",
+      "label": "runRemoveSessionItemCommand()",
+      "norm_label": "runremovesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L713"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_runresumesessioncommand",
+      "label": "runResumeSessionCommand()",
+      "norm_label": "runresumesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L690"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_runstartsessioncommand",
+      "label": "runStartSessionCommand()",
+      "norm_label": "runstartsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L669"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_runupsertsessionitemcommand",
+      "label": "runUpsertSessionItemCommand()",
+      "norm_label": "runupsertsessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L706"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L951"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_validateactivesession",
+      "label": "validateActiveSession()",
+      "norm_label": "validateactivesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L874"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_validateactivesessionregisterbinding",
+      "label": "validateActiveSessionRegisterBinding()",
+      "norm_label": "validateactivesessionregisterbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L847"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "sessioncommands_validatemodifiablesession",
+      "label": "validateModifiableSession()",
+      "norm_label": "validatemodifiablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L918"
     },
     {
       "community": 150,
@@ -62304,6 +62469,60 @@
     {
       "community": 167,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
       "norm_label": "getremainingforfreedelivery()",
@@ -62311,7 +62530,7 @@
       "source_location": "L138"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -62320,7 +62539,7 @@
       "source_location": "L100"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -62329,7 +62548,7 @@
       "source_location": "L74"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -62338,7 +62557,7 @@
       "source_location": "L34"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -62347,7 +62566,7 @@
       "source_location": "L17"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -62356,7 +62575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -62365,7 +62584,7 @@
       "source_location": "L149"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -62374,7 +62593,7 @@
       "source_location": "L156"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -62383,7 +62602,7 @@
       "source_location": "L201"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -62392,7 +62611,7 @@
       "source_location": "L93"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -62401,66 +62620,12 @@
       "source_location": "L282"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
       "norm_label": "auth.verify.tsx",
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "compound_solution_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "compound_solution_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "compound_solution_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "compound_solution_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "compound_solution_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_test_ts",
-      "label": "compound-solution-check.test.ts",
-      "norm_label": "compound-solution-check.test.ts",
-      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -63924,366 +64089,6 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "operationsqueueview_getapprovalrequestcopy",
-      "label": "getApprovalRequestCopy()",
-      "norm_label": "getapprovalrequestcopy()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L60"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "operationsqueueview_getdefaultworkflow",
-      "label": "getDefaultWorkflow()",
-      "norm_label": "getdefaultworkflow()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "operationsqueueview_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L496"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "operationsqueueview_setdecisioningapprovalrequestid",
-      "label": "setDecisioningApprovalRequestId()",
-      "norm_label": "setdecisioningapprovalrequestid()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L559"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -64291,7 +64096,7 @@
       "source_location": "L30"
     },
     {
-      "community": 198,
+      "community": 190,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -64300,7 +64105,7 @@
       "source_location": "L43"
     },
     {
-      "community": 198,
+      "community": 190,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -64309,7 +64114,7 @@
       "source_location": "L106"
     },
     {
-      "community": 198,
+      "community": 190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -64318,12 +64123,372 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "operationsqueueview_getapprovalrequestcopy",
+      "label": "getApprovalRequestCopy()",
+      "norm_label": "getapprovalrequestcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "operationsqueueview_getdefaultworkflow",
+      "label": "getDefaultWorkflow()",
+      "norm_label": "getdefaultworkflow()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "operationsqueueview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L496"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "operationsqueueview_setdecisioningapprovalrequestid",
+      "label": "setDecisioningApprovalRequestId()",
+      "norm_label": "setdecisioningapprovalrequestid()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L559"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -66885,42 +67050,6 @@
     {
       "community": 235,
       "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 236,
-      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -66928,7 +67057,7 @@
       "source_location": "L26"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -66937,7 +67066,7 @@
       "source_location": "L79"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -66946,7 +67075,7 @@
       "source_location": "L33"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -66955,7 +67084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -66964,7 +67093,7 @@
       "source_location": "L10"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -66973,7 +67102,7 @@
       "source_location": "L18"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -66982,7 +67111,7 @@
       "source_location": "L52"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -66991,7 +67120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -67000,7 +67129,7 @@
       "source_location": "L98"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -67009,7 +67138,7 @@
       "source_location": "L56"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -67018,7 +67147,7 @@
       "source_location": "L49"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -67027,7 +67156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -67036,7 +67165,7 @@
       "source_location": "L28"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -67045,7 +67174,7 @@
       "source_location": "L42"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -67054,12 +67183,48 @@
       "source_location": "L73"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
       "norm_label": "operationalevents.ts",
       "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "operationalworkitems_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "operationalworkitems_createoperationalworkitemwithctx",
+      "label": "createOperationalWorkItemWithCtx()",
+      "norm_label": "createoperationalworkitemwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
+      "label": "updateOperationalWorkItemStatusWithCtx()",
+      "norm_label": "updateoperationalworkitemstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
+      "label": "operationalWorkItems.ts",
+      "norm_label": "operationalworkitems.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
     },
     {
@@ -67236,42 +67401,6 @@
     {
       "community": 240,
       "file_type": "code",
-      "id": "operationalworkitems_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "operationalworkitems_createoperationalworkitemwithctx",
-      "label": "createOperationalWorkItemWithCtx()",
-      "norm_label": "createoperationalworkitemwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
-      "label": "updateOperationalWorkItemStatusWithCtx()",
-      "norm_label": "updateoperationalworkitemstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
-      "label": "operationalWorkItems.ts",
-      "norm_label": "operationalworkitems.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -67279,7 +67408,7 @@
       "source_location": "L18"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -67288,7 +67417,7 @@
       "source_location": "L25"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -67297,7 +67426,7 @@
       "source_location": "L11"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -67306,7 +67435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -67315,7 +67444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -67324,7 +67453,7 @@
       "source_location": "L33"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -67333,7 +67462,7 @@
       "source_location": "L19"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -67342,7 +67471,7 @@
       "source_location": "L42"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -67351,7 +67480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -67360,7 +67489,7 @@
       "source_location": "L31"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -67369,7 +67498,7 @@
       "source_location": "L48"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -67378,7 +67507,7 @@
       "source_location": "L131"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -67387,7 +67516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -67396,7 +67525,7 @@
       "source_location": "L37"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -67405,7 +67534,7 @@
       "source_location": "L24"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -67414,7 +67543,7 @@
       "source_location": "L19"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -67423,7 +67552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -67432,7 +67561,7 @@
       "source_location": "L31"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -67441,7 +67570,7 @@
       "source_location": "L26"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -67450,7 +67579,7 @@
       "source_location": "L53"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -67459,7 +67588,7 @@
       "source_location": "L36"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -67468,7 +67597,7 @@
       "source_location": "L96"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -67477,7 +67606,7 @@
       "source_location": "L71"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -67486,7 +67615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -67495,7 +67624,7 @@
       "source_location": "L21"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -67504,7 +67633,7 @@
       "source_location": "L42"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -67513,7 +67642,7 @@
       "source_location": "L80"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -67522,7 +67651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -67531,7 +67660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -67540,7 +67669,7 @@
       "source_location": "L126"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -67549,7 +67678,7 @@
       "source_location": "L34"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -67558,7 +67687,7 @@
       "source_location": "L76"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -67567,7 +67696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -67576,7 +67705,7 @@
       "source_location": "L159"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -67585,13 +67714,49 @@
       "source_location": "L56"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L177"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
+      "label": "replenishment.test.ts",
+      "norm_label": "replenishment.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "replenishment_test_createreplenishmentqueryctx",
+      "label": "createReplenishmentQueryCtx()",
+      "norm_label": "createreplenishmentqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "replenishment_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "replenishment_test_toasynciterable",
+      "label": "toAsyncIterable()",
+      "norm_label": "toasynciterable()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L11"
     },
     {
       "community": 25,
@@ -67758,42 +67923,6 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
-      "label": "replenishment.test.ts",
-      "norm_label": "replenishment.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "replenishment_test_createreplenishmentqueryctx",
-      "label": "createReplenishmentQueryCtx()",
-      "norm_label": "createreplenishmentqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "replenishment_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "replenishment_test_toasynciterable",
-      "label": "toAsyncIterable()",
-      "norm_label": "toasynciterable()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -67801,7 +67930,7 @@
       "source_location": "L19"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -67810,7 +67939,7 @@
       "source_location": "L26"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -67819,7 +67948,7 @@
       "source_location": "L12"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -67828,7 +67957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -67837,7 +67966,7 @@
       "source_location": "L21"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -67846,7 +67975,7 @@
       "source_location": "L63"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -67855,7 +67984,7 @@
       "source_location": "L71"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -67864,7 +67993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -67873,7 +68002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -67882,7 +68011,7 @@
       "source_location": "L13"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -67891,7 +68020,7 @@
       "source_location": "L31"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -67900,7 +68029,7 @@
       "source_location": "L9"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -67909,7 +68038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -67918,7 +68047,7 @@
       "source_location": "L12"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -67927,7 +68056,7 @@
       "source_location": "L46"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -67936,7 +68065,7 @@
       "source_location": "L7"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -67945,7 +68074,7 @@
       "source_location": "L227"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -67954,7 +68083,7 @@
       "source_location": "L46"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -67963,7 +68092,7 @@
       "source_location": "L27"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -67972,7 +68101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -67981,7 +68110,7 @@
       "source_location": "L55"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -67990,7 +68119,7 @@
       "source_location": "L32"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -67999,7 +68128,7 @@
       "source_location": "L211"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -68008,7 +68137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -68017,7 +68146,7 @@
       "source_location": "L52"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -68026,7 +68155,7 @@
       "source_location": "L27"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -68035,7 +68164,7 @@
       "source_location": "L288"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -68044,7 +68173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -68053,7 +68182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -68062,7 +68191,7 @@
       "source_location": "L15"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -68071,7 +68200,7 @@
       "source_location": "L32"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -68080,7 +68209,7 @@
       "source_location": "L19"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -68089,7 +68218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -68098,7 +68227,7 @@
       "source_location": "L52"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -68107,13 +68236,49 @@
       "source_location": "L3"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
       "norm_label": "groupproductviewsbyday()",
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
+      "label": "MaintenanceMessageEditor.tsx",
+      "norm_label": "maintenancemessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L1"
     },
     {
       "community": 26,
@@ -68280,42 +68445,6 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "maintenancemessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "label": "MaintenanceMessageEditor.tsx",
-      "norm_label": "maintenancemessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
       "norm_label": "shoplook.tsx",
@@ -68323,7 +68452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -68332,7 +68461,7 @@
       "source_location": "L67"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -68341,7 +68470,7 @@
       "source_location": "L90"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -68350,7 +68479,7 @@
       "source_location": "L73"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -68359,7 +68488,7 @@
       "source_location": "L78"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -68368,7 +68497,7 @@
       "source_location": "L67"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -68377,7 +68506,7 @@
       "source_location": "L85"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -68386,7 +68515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -68395,7 +68524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -68404,7 +68533,7 @@
       "source_location": "L67"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -68413,7 +68542,7 @@
       "source_location": "L61"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -68422,7 +68551,7 @@
       "source_location": "L73"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -68431,7 +68560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -68440,7 +68569,7 @@
       "source_location": "L105"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -68449,7 +68578,7 @@
       "source_location": "L97"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -68458,7 +68587,7 @@
       "source_location": "L83"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -68467,7 +68596,7 @@
       "source_location": "L91"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -68476,7 +68605,7 @@
       "source_location": "L68"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -68485,7 +68614,7 @@
       "source_location": "L22"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -68494,7 +68623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -68503,7 +68632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -68512,7 +68641,7 @@
       "source_location": "L162"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -68521,7 +68650,7 @@
       "source_location": "L384"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -68530,7 +68659,7 @@
       "source_location": "L345"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -68539,7 +68668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -68548,7 +68677,7 @@
       "source_location": "L22"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -68557,7 +68686,7 @@
       "source_location": "L27"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -68566,7 +68695,7 @@
       "source_location": "L40"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -68575,7 +68704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -68584,7 +68713,7 @@
       "source_location": "L63"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -68593,7 +68722,7 @@
       "source_location": "L54"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -68602,7 +68731,7 @@
       "source_location": "L11"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -68611,7 +68740,7 @@
       "source_location": "L16"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -68620,7 +68749,7 @@
       "source_location": "L35"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -68629,13 +68758,49 @@
       "source_location": "L6"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
       "norm_label": "complimentaryproductsview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
+      "label": "promoCodeMoney.ts",
+      "norm_label": "promocodemoney.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "promocodemoney_parsepromodiscountinput",
+      "label": "parsePromoDiscountInput()",
+      "norm_label": "parsepromodiscountinput()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountdisplaytext",
+      "label": "promoDiscountDisplayText()",
+      "norm_label": "promodiscountdisplaytext()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountinputvalue",
+      "label": "promoDiscountInputValue()",
+      "norm_label": "promodiscountinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L21"
     },
     {
       "community": 27,
@@ -68802,42 +68967,6 @@
     {
       "community": 270,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
-      "label": "promoCodeMoney.ts",
-      "norm_label": "promocodemoney.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "promocodemoney_parsepromodiscountinput",
-      "label": "parsePromoDiscountInput()",
-      "norm_label": "parsepromodiscountinput()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountdisplaytext",
-      "label": "promoDiscountDisplayText()",
-      "norm_label": "promodiscountdisplaytext()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountinputvalue",
-      "label": "promoDiscountInputValue()",
-      "norm_label": "promodiscountinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
       "norm_label": "servicecasesview.tsx",
@@ -68845,7 +68974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -68854,7 +68983,7 @@
       "source_location": "L178"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -68863,7 +68992,7 @@
       "source_location": "L205"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -68872,7 +69001,7 @@
       "source_location": "L806"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -68881,7 +69010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -68890,7 +69019,7 @@
       "source_location": "L41"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -68899,7 +69028,7 @@
       "source_location": "L45"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -68908,7 +69037,7 @@
       "source_location": "L65"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -68917,7 +69046,7 @@
       "source_location": "L75"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -68926,7 +69055,7 @@
       "source_location": "L82"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -68935,7 +69064,7 @@
       "source_location": "L93"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -68944,7 +69073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -68953,7 +69082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -68962,7 +69091,7 @@
       "source_location": "L15"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -68971,7 +69100,7 @@
       "source_location": "L28"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -68980,7 +69109,7 @@
       "source_location": "L54"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -68989,7 +69118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "usegetproducts_usegetarchivedproducts",
       "label": "useGetArchivedProducts()",
@@ -68998,7 +69127,7 @@
       "source_location": "L36"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -69007,7 +69136,7 @@
       "source_location": "L7"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -69016,7 +69145,7 @@
       "source_location": "L40"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -69025,7 +69154,7 @@
       "source_location": "L66"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -69034,7 +69163,7 @@
       "source_location": "L121"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -69043,7 +69172,7 @@
       "source_location": "L74"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -69052,7 +69181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -69061,7 +69190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -69070,7 +69199,7 @@
       "source_location": "L34"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -69079,7 +69208,7 @@
       "source_location": "L28"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -69088,7 +69217,7 @@
       "source_location": "L48"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -69097,7 +69226,7 @@
       "source_location": "L51"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -69106,7 +69235,7 @@
       "source_location": "L92"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -69115,7 +69244,7 @@
       "source_location": "L16"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -69124,7 +69253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -69133,7 +69262,7 @@
       "source_location": "L22"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -69142,7 +69271,7 @@
       "source_location": "L10"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -69151,13 +69280,49 @@
       "source_location": "L57"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
       "norm_label": "customergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
     },
     {
       "community": 28,
@@ -69324,42 +69489,6 @@
     {
       "community": 280,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
       "norm_label": "sessiongateway.ts",
@@ -69367,7 +69496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -69376,7 +69505,7 @@
       "source_location": "L38"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -69385,7 +69514,7 @@
       "source_location": "L65"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -69394,7 +69523,7 @@
       "source_location": "L91"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -69403,7 +69532,7 @@
       "source_location": "L4"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -69412,7 +69541,7 @@
       "source_location": "L20"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -69421,7 +69550,7 @@
       "source_location": "L42"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -69430,7 +69559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -69439,7 +69568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -69448,7 +69577,7 @@
       "source_location": "L37"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -69457,7 +69586,7 @@
       "source_location": "L49"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -69466,7 +69595,7 @@
       "source_location": "L65"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -69475,7 +69604,7 @@
       "source_location": "L13"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -69484,7 +69613,7 @@
       "source_location": "L46"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -69493,7 +69622,7 @@
       "source_location": "L21"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -69502,7 +69631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -69511,7 +69640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -69520,7 +69649,7 @@
       "source_location": "L8"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -69529,7 +69658,7 @@
       "source_location": "L5"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -69538,7 +69667,7 @@
       "source_location": "L20"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -69547,7 +69676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -69556,7 +69685,7 @@
       "source_location": "L11"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -69565,7 +69694,7 @@
       "source_location": "L9"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -69574,7 +69703,7 @@
       "source_location": "L25"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -69583,7 +69712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -69592,7 +69721,7 @@
       "source_location": "L50"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -69601,7 +69730,7 @@
       "source_location": "L92"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -69610,7 +69739,7 @@
       "source_location": "L74"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -69619,7 +69748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -69628,7 +69757,7 @@
       "source_location": "L62"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -69637,7 +69766,7 @@
       "source_location": "L109"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -69646,7 +69775,7 @@
       "source_location": "L177"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -69655,7 +69784,7 @@
       "source_location": "L18"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -69664,7 +69793,7 @@
       "source_location": "L52"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -69673,12 +69802,48 @@
       "source_location": "L68"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
       "norm_label": "billingdetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -69846,42 +70011,6 @@
     {
       "community": 290,
       "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 291,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
       "norm_label": "productattribute.tsx",
@@ -69889,7 +70018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -69898,7 +70027,7 @@
       "source_location": "L81"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -69907,7 +70036,7 @@
       "source_location": "L85"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -69916,7 +70045,7 @@
       "source_location": "L27"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -69925,7 +70054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -69934,7 +70063,7 @@
       "source_location": "L43"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -69943,7 +70072,7 @@
       "source_location": "L13"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -69952,7 +70081,7 @@
       "source_location": "L88"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -69961,7 +70090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -69970,7 +70099,7 @@
       "source_location": "L111"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -69979,7 +70108,7 @@
       "source_location": "L66"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -69988,7 +70117,7 @@
       "source_location": "L127"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -69997,7 +70126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -70006,7 +70135,7 @@
       "source_location": "L25"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -70015,13 +70144,49 @@
       "source_location": "L90"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
       "norm_label": "usestorecontext()",
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 295,
@@ -82059,101 +82224,101 @@
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L116"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L283"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L318"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L74"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L55"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L46"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L16"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 600,
@@ -82338,100 +82503,100 @@
     {
       "community": 61,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -82617,101 +82782,101 @@
     {
       "community": 62,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 620,
@@ -82896,101 +83061,101 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
     },
     {
       "community": 630,
@@ -83175,101 +83340,101 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 640,
@@ -89979,226 +90144,226 @@
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_appendlistsection",
-      "label": "appendListSection()",
-      "norm_label": "appendlistsection()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L609"
+      "id": "compound_solution_check_assertcompoundsolutioncheck",
+      "label": "assertCompoundSolutionCheck()",
+      "norm_label": "assertcompoundsolutioncheck()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L391"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_buildmarkdownbundle",
-      "label": "buildMarkdownBundle()",
-      "norm_label": "buildmarkdownbundle()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L628"
+      "id": "compound_solution_check_collectchangedfiles",
+      "label": "collectChangedFiles()",
+      "norm_label": "collectchangedfiles()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L288"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_collectcoverage",
-      "label": "collectCoverage()",
-      "norm_label": "collectcoverage()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L398"
+      "id": "compound_solution_check_collectcompoundsolutionfindings",
+      "label": "collectCompoundSolutionFindings()",
+      "norm_label": "collectcompoundsolutionfindings()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L150"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_evaluategraphifyfreshness",
-      "label": "evaluateGraphifyFreshness()",
-      "norm_label": "evaluategraphifyfreshness()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L532"
+      "id": "compound_solution_check_collectexistingfiles",
+      "label": "collectExistingFiles()",
+      "norm_label": "collectexistingfiles()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L350"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L144"
+      "id": "compound_solution_check_collectmarkdowncontents",
+      "label": "collectMarkdownContents()",
+      "norm_label": "collectmarkdowncontents()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L333"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_formatvalidationcommand",
-      "label": "formatValidationCommand()",
-      "norm_label": "formatvalidationcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L132"
+      "id": "compound_solution_check_collectsourcelinechanges",
+      "label": "collectSourceLineChanges()",
+      "norm_label": "collectsourcelinechanges()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L297"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_getchangedfilesfromgit",
-      "label": "getChangedFilesFromGit()",
-      "norm_label": "getchangedfilesfromgit()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L177"
+      "id": "compound_solution_check_countfilelines",
+      "label": "countFileLines()",
+      "norm_label": "countfilelines()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L284"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_islikelycodeorconfig",
-      "label": "isLikelyCodeOrConfig()",
-      "norm_label": "islikelycodeorconfig()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L493"
+      "id": "compound_solution_check_extractfrontmatter",
+      "label": "extractFrontmatter()",
+      "norm_label": "extractfrontmatter()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L107"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_islocalgeneratedartifactpath",
-      "label": "isLocalGeneratedArtifactPath()",
-      "norm_label": "islocalgeneratedartifactpath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L523"
+      "id": "compound_solution_check_extractsolutionreferences",
+      "label": "extractSolutionReferences()",
+      "norm_label": "extractsolutionreferences()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L101"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_isworktreemetadatapath",
-      "label": "isWorktreeMetadataPath()",
-      "norm_label": "isworktreemetadatapath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L514"
+      "id": "compound_solution_check_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L238"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_loadselfreviewtarget",
-      "label": "loadSelfReviewTarget()",
-      "norm_label": "loadselfreviewtarget()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L247"
+      "id": "compound_solution_check_iscompoundsensitiveworkflowpath",
+      "label": "isCompoundSensitiveWorkflowPath()",
+      "norm_label": "iscompoundsensitiveworkflowpath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L86"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_loadselfreviewtargets",
-      "label": "loadSelfReviewTargets()",
-      "norm_label": "loadselfreviewtargets()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L379"
+      "id": "compound_solution_check_isconsiderablesourcepath",
+      "label": "isConsiderableSourcePath()",
+      "norm_label": "isconsiderablesourcepath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L71"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L106"
+      "id": "compound_solution_check_ismarkdowndocpath",
+      "label": "isMarkdownDocPath()",
+      "norm_label": "ismarkdowndocpath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L67"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L128"
+      "id": "compound_solution_check_issolutiondocpath",
+      "label": "isSolutionDocPath()",
+      "norm_label": "issolutiondocpath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L63"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L96"
+      "id": "compound_solution_check_mergelinechanges",
+      "label": "mergeLineChanges()",
+      "norm_label": "mergelinechanges()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L274"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-self-review.ts",
+      "id": "compound_solution_check_missingsolutionfrontmatterfields",
+      "label": "missingSolutionFrontmatterFields()",
+      "norm_label": "missingsolutionfrontmatterfields()",
+      "source_file": "scripts/compound-solution-check.ts",
       "source_location": "L120"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_parsecliarguments",
-      "label": "parseCliArguments()",
-      "norm_label": "parsecliarguments()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L801"
+      "id": "compound_solution_check_missingsolutionsections",
+      "label": "missingSolutionSections()",
+      "norm_label": "missingsolutionsections()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L128"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_parseruntimescenarios",
-      "label": "parseRuntimeScenarios()",
-      "norm_label": "parseruntimescenarios()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L241"
+      "id": "compound_solution_check_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L53"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_quotecode",
-      "label": "quoteCode()",
-      "norm_label": "quotecode()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L140"
+      "id": "compound_solution_check_parseargs",
+      "label": "parseArgs()",
+      "norm_label": "parseargs()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L358"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L153"
+      "id": "compound_solution_check_parsechangedfiles",
+      "label": "parseChangedFiles()",
+      "norm_label": "parsechangedfiles()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L246"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L157"
+      "id": "compound_solution_check_parsenumstat",
+      "label": "parseNumstat()",
+      "norm_label": "parsenumstat()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L253"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_runharnessselfreview",
-      "label": "runHarnessSelfReview()",
-      "norm_label": "runharnessselfreview()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L850"
+      "id": "compound_solution_check_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L221"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "harness_self_review_runquietharnesscheck",
-      "label": "runQuietHarnessCheck()",
-      "norm_label": "runquietharnesscheck()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L600"
-    },
-    {
-      "community": 9,
-      "file_type": "code",
-      "id": "harness_self_review_sortuniquepaths",
+      "id": "compound_solution_check_sortuniquepaths",
       "label": "sortUniquePaths()",
       "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L100"
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L57"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "scripts_harness_self_review_ts",
-      "label": "harness-self-review.ts",
-      "norm_label": "harness-self-review.ts",
-      "source_file": "scripts/harness-self-review.ts",
+      "id": "compound_solution_check_totalconsiderablesourcelinechanges",
+      "label": "totalConsiderableSourceLineChanges()",
+      "norm_label": "totalconsiderablesourcelinechanges()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 9,
+      "file_type": "code",
+      "id": "scripts_compound_solution_check_ts",
+      "label": "compound-solution-check.ts",
+      "norm_label": "compound-solution-check.ts",
+      "source_file": "scripts/compound-solution-check.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1594
-- Graph nodes: 4487
-- Graph edges: 4286
+- Graph nodes: 4492
+- Graph edges: 4296
 - Communities: 1522
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `ProcurementView.tsx` (35 edges, Community 2) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `RegisterSessionView.tsx` (27 edges, Community 7) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storeConfigV2.ts` (27 edges, Community 6) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `posSessions.ts` (23 edges, Community 10) - [`packages/athena-webapp/convex/inventory/posSessions.ts`](../../../packages/athena-webapp/convex/inventory/posSessions.ts)
-- `cycleCountDrafts.ts` (21 edges, Community 11) - [`packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts`](../../../packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts)
+- `posSessions.ts` (23 edges, Community 11) - [`packages/athena-webapp/convex/inventory/posSessions.ts`](../../../packages/athena-webapp/convex/inventory/posSessions.ts)
+- `cycleCountDrafts.ts` (21 edges, Community 12) - [`packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts`](../../../packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 12) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 13) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 37) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 12) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 13) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/scripts/compound-solution-check.test.ts
+++ b/scripts/compound-solution-check.test.ts
@@ -72,6 +72,36 @@ function lineChanges(entries: Array<[string, number, number]>) {
   );
 }
 
+function solutionNote(title = "Procurement") {
+  return `---
+title: ${title}
+date: 2026-05-06
+category: harness
+module: repo
+problem_type: missing_guardrail
+component: compound-check
+resolution_type: guardrail
+severity: medium
+tags:
+  - compound
+---
+
+# ${title}
+
+## Problem
+
+Substantial work needs durable delivery context.
+
+## Solution
+
+Require a concrete solution note before merge.
+
+## Prevention
+
+Run the compound check before handoff.
+`;
+}
+
 describe("extractSolutionReferences", () => {
   it("finds repo-relative solution doc references in markdown", () => {
     expect(
@@ -185,7 +215,7 @@ describe("collectCompoundSolutionFindings", () => {
         "packages/athena-webapp/src/components/ProcurementView.tsx",
       ]),
       markdownContents: new Map([
-        ["docs/solutions/logic-errors/procurement.md", "# Procurement\n"],
+        ["docs/solutions/logic-errors/procurement.md", solutionNote()],
       ]),
       sourceLineChanges: lineChanges([
         ["packages/athena-webapp/src/components/ProcurementView.tsx", 151, 0],
@@ -197,13 +227,76 @@ describe("collectCompoundSolutionFindings", () => {
 
   it("passes small source changes below the threshold", () => {
     const findings = collectCompoundSolutionFindings({
-      changedFiles: ["scripts/harness-review.ts"],
-      existingFiles: new Set(["scripts/harness-review.ts"]),
+      changedFiles: ["packages/athena-webapp/src/components/ProcurementView.tsx"],
+      existingFiles: new Set([
+        "packages/athena-webapp/src/components/ProcurementView.tsx",
+      ]),
       markdownContents: new Map(),
-      sourceLineChanges: lineChanges([["scripts/harness-review.ts", 75, 20]]),
+      sourceLineChanges: lineChanges([
+        ["packages/athena-webapp/src/components/ProcurementView.tsx", 75, 20],
+      ]),
     });
 
     expect(findings).toEqual([]);
+  });
+
+  it("passes workflow test-only changes without a solution doc", () => {
+    const findings = collectCompoundSolutionFindings({
+      changedFiles: ["scripts/compound-solution-check.test.ts"],
+      existingFiles: new Set(["scripts/compound-solution-check.test.ts"]),
+      markdownContents: new Map(),
+      sourceLineChanges: lineChanges([
+        ["scripts/compound-solution-check.test.ts", 30, 2],
+      ]),
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("fails sensitive workflow changes below the line threshold without a solution doc", () => {
+    const findings = collectCompoundSolutionFindings({
+      changedFiles: ["scripts/compound-solution-check.ts"],
+      existingFiles: new Set(["scripts/compound-solution-check.ts"]),
+      markdownContents: new Map(),
+      sourceLineChanges: lineChanges([["scripts/compound-solution-check.ts", 5, 1]]),
+    });
+
+    expect(findings).toEqual([
+      {
+        message:
+          "Compound-sensitive workflow changes detected in scripts/compound-solution-check.ts without a docs/solutions/**/*.md update.",
+      },
+    ]);
+  });
+
+  it("fails changed solution notes that are placeholders", () => {
+    const findings = collectCompoundSolutionFindings({
+      changedFiles: [
+        "docs/solutions/harness/placeholder.md",
+        "packages/athena-webapp/src/components/ProcurementView.tsx",
+      ],
+      existingFiles: new Set([
+        "docs/solutions/harness/placeholder.md",
+        "packages/athena-webapp/src/components/ProcurementView.tsx",
+      ]),
+      markdownContents: new Map([
+        ["docs/solutions/harness/placeholder.md", "# Placeholder\n"],
+      ]),
+      sourceLineChanges: lineChanges([
+        ["packages/athena-webapp/src/components/ProcurementView.tsx", 151, 0],
+      ]),
+    });
+
+    expect(findings).toEqual([
+      {
+        message:
+          "Changed solution note docs/solutions/harness/placeholder.md is missing required frontmatter fields: title, date, category, module, problem_type, component, resolution_type, severity, tags.",
+      },
+      {
+        message:
+          "Changed solution note docs/solutions/harness/placeholder.md is missing required sections: Problem, Solution, Prevention.",
+      },
+    ]);
   });
 });
 
@@ -257,7 +350,7 @@ describe("assertCompoundSolutionCheck", () => {
     await write(
       rootDir,
       "docs/solutions/harness/compound-solution-gate.md",
-      "# Compound Solution Gate\n"
+      solutionNote("Compound Solution Gate")
     );
 
     expect(() =>

--- a/scripts/compound-solution-check.ts
+++ b/scripts/compound-solution-check.ts
@@ -19,6 +19,18 @@ type CompoundSolutionFinding = {
 };
 
 const DEFAULT_SOURCE_LINE_THRESHOLD = 150;
+const REQUIRED_SOLUTION_FRONTMATTER_FIELDS = [
+  "title",
+  "date",
+  "category",
+  "module",
+  "problem_type",
+  "component",
+  "resolution_type",
+  "severity",
+  "tags",
+] as const;
+const REQUIRED_SOLUTION_SECTIONS = ["Problem", "Solution", "Prevention"] as const;
 
 const SOURCE_PATTERNS = [
   /^packages\/[^/]+\/src\/.*\.(ts|tsx|js|jsx)$/,
@@ -28,6 +40,13 @@ const SOURCE_PATTERNS = [
 ] as const;
 
 const TEST_FILE_PATTERN = /(^|\/)[^/]+\.(test|spec)\.(ts|tsx|js|jsx)$/;
+const COMPOUND_SENSITIVE_PATTERNS = [
+  /^scripts\/(?:compound-solution-check|pre-push-review|pre-commit-generated-artifacts|harness-|coverage-|architecture-boundary-check|github-pr-merge).*\.(ts|tsx|js|mjs|cjs)$/,
+  /^\.agents\/skills\/(?:execute|deliver-work|compound-delivery-kernel|track|ce-work|ce-commit-push-pr)\/SKILL\.md$/,
+  /^\.github\/workflows\/.+\.ya?ml$/,
+  /^\.husky\/.+$/,
+  /^package\.json$/,
+] as const;
 const SOLUTION_REFERENCE_PATTERN =
   /(?:^|[\s('"`])((?:\.\/)?docs\/solutions\/[A-Za-z0-9._/-]+\.md)(?=$|[\s)'"`,.])/g;
 
@@ -64,9 +83,51 @@ export function isConsiderableSourcePath(repoPath: string) {
   return SOURCE_PATTERNS.some((pattern) => pattern.test(normalizedPath));
 }
 
+export function isCompoundSensitiveWorkflowPath(repoPath: string) {
+  const normalizedPath = normalizeRepoPath(repoPath);
+
+  if (
+    isSolutionDocPath(normalizedPath) ||
+    normalizedPath.startsWith("graphify-out/") ||
+    normalizedPath.includes("/_generated/") ||
+    TEST_FILE_PATTERN.test(normalizedPath)
+  ) {
+    return false;
+  }
+
+  return COMPOUND_SENSITIVE_PATTERNS.some((pattern) => pattern.test(normalizedPath));
+}
+
 export function extractSolutionReferences(markdown: string) {
   return sortUniquePaths(
     [...markdown.matchAll(SOLUTION_REFERENCE_PATTERN)].map((match) => match[1])
+  );
+}
+
+function extractFrontmatter(markdown: string) {
+  if (!markdown.startsWith("---\n")) {
+    return "";
+  }
+
+  const closingIndex = markdown.indexOf("\n---", 4);
+  if (closingIndex === -1) {
+    return "";
+  }
+
+  return markdown.slice(4, closingIndex);
+}
+
+function missingSolutionFrontmatterFields(markdown: string) {
+  const frontmatter = extractFrontmatter(markdown);
+
+  return REQUIRED_SOLUTION_FRONTMATTER_FIELDS.filter(
+    (field) => !new RegExp(`^${field}:`, "m").test(frontmatter)
+  );
+}
+
+function missingSolutionSections(markdown: string) {
+  return REQUIRED_SOLUTION_SECTIONS.filter(
+    (section) => !new RegExp(`^## ${section}\\s*$`, "m").test(markdown)
   );
 }
 
@@ -98,6 +159,9 @@ export function collectCompoundSolutionFindings({
   const changedSolutionDocs = normalizedChangedFiles.filter((filePath) =>
     isSolutionDocPath(filePath)
   );
+  const changedSensitiveWorkflowFiles = normalizedChangedFiles.filter((filePath) =>
+    isCompoundSensitiveWorkflowPath(filePath)
+  );
 
   for (const [filePath, markdown] of markdownContents) {
     const references = extractSolutionReferences(markdown);
@@ -113,11 +177,41 @@ export function collectCompoundSolutionFindings({
     }
   }
 
+  for (const filePath of changedSolutionDocs) {
+    const markdown = markdownContents.get(filePath) ?? "";
+    const missingFrontmatterFields = missingSolutionFrontmatterFields(markdown);
+    const missingSections = missingSolutionSections(markdown);
+
+    if (missingFrontmatterFields.length > 0) {
+      findings.push({
+        message: `Changed solution note ${filePath} is missing required frontmatter fields: ${missingFrontmatterFields.join(
+          ", "
+        )}.`,
+      });
+    }
+
+    if (missingSections.length > 0) {
+      findings.push({
+        message: `Changed solution note ${filePath} is missing required sections: ${missingSections.join(
+          ", "
+        )}.`,
+      });
+    }
+  }
+
   const sourceLineTotal = totalConsiderableSourceLineChanges(sourceLineChanges);
 
   if (sourceLineTotal >= threshold && changedSolutionDocs.length === 0) {
     findings.push({
       message: `Substantial source change detected (${sourceLineTotal} changed source lines, threshold ${threshold}) without a docs/solutions/**/*.md update.`,
+    });
+  }
+
+  if (changedSensitiveWorkflowFiles.length > 0 && changedSolutionDocs.length === 0) {
+    findings.push({
+      message: `Compound-sensitive workflow changes detected in ${changedSensitiveWorkflowFiles.join(
+        ", "
+      )} without a docs/solutions/**/*.md update.`,
     });
   }
 
@@ -313,7 +407,7 @@ export function assertCompoundSolutionCheck(
     throw new Error(
       `Compound solution check failed:\n${findings
         .map((finding) => `- ${finding.message}`)
-        .join("\n")}\n\nAdd or update a docs/solutions note for reusable work, or remove stale solution references from the changed docs.`
+        .join("\n")}\n\nThis is the final integration gate for the whole branch, including parallel subagent work. Add or update a complete docs/solutions note for reusable work, remove stale solution references from changed docs, or tighten this sensor with a focused regression if the branch is a proven false positive.`
     );
   }
 }


### PR DESCRIPTION
## Summary
- require changed solution notes to include reusable-learning frontmatter plus Problem/Solution/Prevention sections
- require solution notes for compound-sensitive workflow files even below the aggregate source-line threshold
- update harness docs and the existing compound solution note; regenerate graphify artifacts

## Why
Parallel subagent delivery can produce a large final branch where no single worker owns the final compounding artifact. The final integration gate now catches that aggregate gap while rejecting placeholder notes.

## Validation
- bun test scripts/compound-solution-check.test.ts
- bun run compound:check
- bun run harness:test
- bun run graphify:rebuild
- git diff --check
- bun run pr:athena
- git push pre-push hook
